### PR TITLE
Allow openAPI 3 to have correct requestBody schema

### DIFF
--- a/lib/src/__snapshots__/parser.spec.ts.snap
+++ b/lib/src/__snapshots__/parser.spec.ts.snap
@@ -25,6 +25,7 @@ Object {
           "kind": "static",
         },
       ],
+      "requestContentType": "application/json",
       "requestType": Object {
         "kind": "type-reference",
         "typeName": "CreateUserRequest",
@@ -70,6 +71,7 @@ Object {
           "kind": "static",
         },
       ],
+      "requestContentType": "application/json",
       "requestType": Object {
         "kind": "void",
       },
@@ -112,6 +114,7 @@ Object {
           },
         },
       ],
+      "requestContentType": "application/json",
       "requestType": Object {
         "kind": "void",
       },
@@ -186,6 +189,7 @@ Object {
           "kind": "static",
         },
       ],
+      "requestContentType": "application/json",
       "requestType": Object {
         "kind": "type-reference",
         "typeName": "CreateUserRequest",
@@ -231,6 +235,7 @@ Object {
           "kind": "static",
         },
       ],
+      "requestContentType": "application/json",
       "requestType": Object {
         "kind": "void",
       },
@@ -273,6 +278,7 @@ Object {
           },
         },
       ],
+      "requestContentType": "application/json",
       "requestType": Object {
         "kind": "void",
       },

--- a/lib/src/generators/contract/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/openapi3.spec.ts.snap
@@ -25,7 +25,13 @@ exports[`OpenAPI 3 generator produces valid code multi-file: json 1`] = `
         ],
         \\"parameters\\": [],
         \\"requestBody\\": {
-          \\"$ref\\": \\"#/components/schemas/CreateUserRequest\\"
+          \\"content\\": {
+            \\"application/json\\": {
+              \\"schema\\": {
+                \\"$ref\\": \\"#/components/schemas/CreateUserRequest\\"
+              }
+            }
+          }
         },
         \\"responses\\": {
           \\"200\\": {
@@ -221,7 +227,10 @@ paths:
         - TODO
       parameters: []
       requestBody:
-        $ref: '#/components/schemas/CreateUserRequest'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateUserRequest'
       responses:
         '200':
           content:
@@ -356,7 +365,13 @@ exports[`OpenAPI 3 generator produces valid code single-file: json 1`] = `
         ],
         \\"parameters\\": [],
         \\"requestBody\\": {
-          \\"$ref\\": \\"#/components/schemas/CreateUserRequest\\"
+          \\"content\\": {
+            \\"application/json\\": {
+              \\"schema\\": {
+                \\"$ref\\": \\"#/components/schemas/CreateUserRequest\\"
+              }
+            }
+          }
         },
         \\"responses\\": {
           \\"200\\": {
@@ -584,7 +599,10 @@ paths:
         - TODO
       parameters: []
       requestBody:
-        $ref: '#/components/schemas/CreateUserRequest'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateUserRequest'
       responses:
         '200':
           content:

--- a/lib/src/generators/contract/openapi3-schema.spec.ts
+++ b/lib/src/generators/contract/openapi3-schema.spec.ts
@@ -13,9 +13,52 @@ import {
   unionType,
   VOID
 } from "../../models";
-import { openApi3TypeSchema } from "./openapi3-schema";
+import {
+  openApi3TypeSchema,
+  openApiV3ContentTypeSchema
+} from "./openapi3-schema";
 
 describe("JSON Schema generator", () => {
+  describe("generates content type validator", () => {
+    test("application/json", () => {
+      expect(
+        openApiV3ContentTypeSchema(
+          "application/json",
+          typeReference("OtherType")
+        )
+      ).toMatchInlineSnapshot(`
+Object {
+  "content": Object {
+    "application/json": Object {
+      "schema": Object {
+        "$ref": "#/components/schemas/OtherType",
+      },
+    },
+  },
+}
+`);
+    });
+
+    test("text/html", () => {
+      expect(
+        openApiV3ContentTypeSchema(
+          "text/html",
+          typeReference("OtherType")
+        )
+      ).toMatchInlineSnapshot(`
+Object {
+  "content": Object {
+    "text/html": Object {
+      "schema": Object {
+        "$ref": "#/components/schemas/OtherType",
+      },
+    },
+  },
+}
+`);
+    });
+  });
+
   describe("generates type validator", () => {
     test("void", () => {
       expect(openApi3TypeSchema(VOID)).toMatchInlineSnapshot(`null`);

--- a/lib/src/generators/contract/openapi3-schema.ts
+++ b/lib/src/generators/contract/openapi3-schema.ts
@@ -28,7 +28,9 @@ export function openApiV3ContentTypeSchema(contentType: HttpContentType, type: T
       return {
         content: {
           "text/html": {
-            schema: openApi3TypeSchema(type)
+            schema: {
+              type: "string"
+            }
           }
         }
       };
@@ -157,7 +159,7 @@ export interface OpenAPI3SchemaApplicationJsonContentType extends OpenAPI3BaseSc
 export interface OpenAPI3SchemaTextHtmlContentType extends OpenAPI3BaseSchemaType {
   content: {
     'text/html': {
-      schema: OpenAPI3SchemaType | null
+      schema: OpenAPI3SchemaTypeString
     }
   }
 }

--- a/lib/src/generators/contract/openapi3-schema.ts
+++ b/lib/src/generators/contract/openapi3-schema.ts
@@ -1,6 +1,7 @@
 import assertNever from "../../assert-never";
 import { Type } from "../../models";
 import compact = require("lodash/compact");
+import {HttpContentType} from "@zenclabs/api";
 
 export function rejectVoidOpenApi3SchemaType(
   type: Type,
@@ -11,6 +12,29 @@ export function rejectVoidOpenApi3SchemaType(
     throw new Error(errorMessage);
   }
   return schemaType;
+}
+
+export function openApiV3ContentTypeSchema(contentType: HttpContentType, type: Type): OpenAPI3SchemaContentType {
+  switch (contentType) {
+    case "application/json":
+      return {
+        content: {
+          "application/json": {
+            schema: openApi3TypeSchema(type)
+          }
+        }
+      };
+    case "text/html":
+      return {
+        content: {
+          "text/html": {
+            schema: openApi3TypeSchema(type)
+          }
+        }
+      };
+    default:
+      throw assertNever(contentType);
+  }
 }
 
 export function openApi3TypeSchema(type: Type): OpenAPI3SchemaType | null {
@@ -118,6 +142,26 @@ export interface OpenAPI3BaseSchemaType {
   };
 }
 
+export type OpenAPI3SchemaContentType =
+  | OpenAPI3SchemaApplicationJsonContentType
+  | OpenAPI3SchemaTextHtmlContentType
+
+export interface OpenAPI3SchemaApplicationJsonContentType extends OpenAPI3BaseSchemaType {
+  content: {
+    'application/json': {
+      schema: OpenAPI3SchemaType | null
+    }
+  }
+}
+
+export interface OpenAPI3SchemaTextHtmlContentType extends OpenAPI3BaseSchemaType {
+  content: {
+    'text/html': {
+      schema: OpenAPI3SchemaType | null
+    }
+  }
+}
+
 export interface OpenAPI3SchemaTypeObject extends OpenAPI3BaseSchemaType {
   type: "object";
   properties: {
@@ -135,7 +179,8 @@ export interface OpenAPI3SchemaTypeOneOf extends OpenAPI3BaseSchemaType {
   oneOf: OpenAPI3SchemaType[];
 }
 
-export interface OpenAPI3SchemaTypeNull extends OpenAPI3BaseSchemaType {}
+export interface OpenAPI3SchemaTypeNull extends OpenAPI3BaseSchemaType {
+}
 
 export interface OpenAPI3SchemaTypeString extends OpenAPI3BaseSchemaType {
   type: "string";

--- a/lib/src/generators/contract/openapi3.ts
+++ b/lib/src/generators/contract/openapi3.ts
@@ -5,6 +5,7 @@ import { isVoid } from "../../validator";
 import {
   OpenAPI3SchemaType,
   openApi3TypeSchema,
+  openApiV3ContentTypeSchema,
   rejectVoidOpenApi3SchemaType
 } from "./openapi3-schema";
 import identity = require("lodash/identity");
@@ -77,7 +78,10 @@ export function openApiV3(api: Api): OpenApiV3 {
             {
               requestBody: isVoid(api, endpoint.requestType)
                 ? undefined
-                : defaultTo(openApi3TypeSchema(endpoint.requestType), undefined)
+                : defaultTo(openApiV3ContentTypeSchema(
+                    defaultTo(endpoint.requestContentType, "application/json"),
+                    endpoint.requestType),
+                  undefined)
             },
             identity
           ),

--- a/lib/src/lib.ts
+++ b/lib/src/lib.ts
@@ -57,7 +57,7 @@ export function isHttpMethod(method: string): method is HttpMethod {
   }
 }
 
-export function isHttpContentType(contentType: String): contentType is HttpContentType {
+export function isHttpContentType(contentType: string): contentType is HttpContentType {
   switch (contentType) {
     case "application/json":
     case "text/html":

--- a/lib/src/lib.ts
+++ b/lib/src/lib.ts
@@ -15,6 +15,7 @@ export function endpoint(description: EndpointDescription) {
 export interface EndpointDescription {
   method: HttpMethod;
   path: string;
+  requestContentType?: HttpContentType;
   successStatusCode?: number;
 }
 
@@ -55,6 +56,20 @@ export function isHttpMethod(method: string): method is HttpMethod {
       return false;
   }
 }
+
+export function isHttpContentType(contentType: String): contentType is HttpContentType {
+  switch (contentType) {
+    case "application/json":
+    case "text/html":
+      return true;
+    default:
+      return false;
+  }
+}
+
+export type HttpContentType =
+  | "application/json"
+  | "text/html"
 
 export type HttpMethod =
   | "GET"

--- a/lib/src/models.ts
+++ b/lib/src/models.ts
@@ -1,6 +1,6 @@
 import compact = require("lodash/compact");
 import uniq = require("lodash/uniq");
-import { HttpMethod } from "./lib";
+import {HttpContentType, HttpMethod} from "./lib";
 
 export interface Api {
   endpoints: {
@@ -15,6 +15,7 @@ export interface Endpoint {
   method: HttpMethod;
   path: PathComponent[];
   headers: Headers;
+  requestContentType?: HttpContentType;
   requestType: Type;
   responseType: Type;
   successStatusCode?: number;

--- a/lib/src/parser.ts
+++ b/lib/src/parser.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs-extra";
 import * as path from "path";
 import * as ts from "typescript";
-import { isHttpMethod } from "./lib";
+import { isHttpMethod, isHttpContentType } from "./lib";
 import {
   Api,
   arrayType,
@@ -168,8 +168,10 @@ function extractEndpoint(
   }
   const methodLiteral = endpointDescription.properties["method"];
   const pathLiteral = endpointDescription.properties["path"];
+  const requestContentTypeLiteral = endpointDescription.properties["requestContentType"];
   const successStatusCodeLiteral =
     endpointDescription.properties["successStatusCode"];
+
   if (!isStringLiteral(methodLiteral)) {
     throw panic(
       `Invalid method in endpoint description: ${endpointDescriptionExpression.getText(
@@ -188,6 +190,23 @@ function extractEndpoint(
       )}`
     );
   }
+
+  let requestContentType = "application/json";
+  if (requestContentTypeLiteral) {
+    if (!isStringLiteral(requestContentTypeLiteral)) {
+      throw panic(
+        `Invalid method in endpoint description: ${endpointDescriptionExpression.getText(
+          sourceFile
+        )}`
+      );
+    }
+    requestContentType = requestContentTypeLiteral.text;
+
+  }
+  if (!isHttpContentType(requestContentType)) {
+    throw panic(`${method} is not a valid HTTP content type`);
+  }
+  
   let successStatusCode;
   if (successStatusCodeLiteral) {
     if (!isNumericLiteral(successStatusCodeLiteral)) {
@@ -439,6 +458,7 @@ function extractEndpoint(
   return {
     method,
     path: pathComponents,
+    requestContentType,
     headers,
     requestType,
     responseType,

--- a/lib/src/parser.ts
+++ b/lib/src/parser.ts
@@ -195,18 +195,17 @@ function extractEndpoint(
   if (requestContentTypeLiteral) {
     if (!isStringLiteral(requestContentTypeLiteral)) {
       throw panic(
-        `Invalid method in endpoint description: ${endpointDescriptionExpression.getText(
+        `Invalid request content type in endpoint description: ${endpointDescriptionExpression.getText(
           sourceFile
         )}`
       );
     }
     requestContentType = requestContentTypeLiteral.text;
-
   }
   if (!isHttpContentType(requestContentType)) {
     throw panic(`${method} is not a valid HTTP content type`);
   }
-  
+
   let successStatusCode;
   if (successStatusCodeLiteral) {
     if (!isNumericLiteral(successStatusCodeLiteral)) {


### PR DESCRIPTION
Changes:
- add `HttpContentType` that currently only supports `application/json` and `text/html`
- add optional `requestContentType` into endpoint that will get defaulted to `application/json`
- openAPI 3 now have generated `content` for the `requestBody`

Before the change:
```yaml
      requestBody:
        $ref: '#/components/schemas/CreateUserRequest'
```

After the change:
```yaml
      requestBody:
        content:
          application/json: 
            schema:
              $ref: '#/components/schemas/CreateUserRequest'
```

Thing to discuss:
- is it a good idea to default the content type as `application/json`?