### PR TITLE
Fix OpenAPI 2 generator to produces vallid OpenAPI 2

### DIFF
--- a/examples/src/single-file/api.ts
+++ b/examples/src/single-file/api.ts
@@ -67,15 +67,9 @@ export interface CreateUserRequest {
   name: string;
 }
 
-export type CreateUserResponse =
-  | {
-      success: false;
-      errors: string[];
-    }
-  | {
-      success: true;
-      confirmation: string;
-    };
+export interface CreateUserResponse {
+  success: boolean;
+}
 
 export interface GetUserResponse {
   name: string;

--- a/lib/src/__snapshots__/parser.spec.ts.snap
+++ b/lib/src/__snapshots__/parser.spec.ts.snap
@@ -309,36 +309,12 @@ Object {
       },
     },
     "CreateUserResponse": Object {
-      "kind": "union",
-      "types": Array [
-        Object {
-          "kind": "object",
-          "properties": Object {
-            "errors": Object {
-              "elements": Object {
-                "kind": "string",
-              },
-              "kind": "array",
-            },
-            "success": Object {
-              "kind": "boolean-constant",
-              "value": false,
-            },
-          },
+      "kind": "object",
+      "properties": Object {
+        "success": Object {
+          "kind": "boolean",
         },
-        Object {
-          "kind": "object",
-          "properties": Object {
-            "confirmation": Object {
-              "kind": "string",
-            },
-            "success": Object {
-              "kind": "boolean-constant",
-              "value": true,
-            },
-          },
-        },
-      ],
+      },
     },
     "GetUserResponse": Object {
       "kind": "object",

--- a/lib/src/generators/contract/__snapshots__/json-schema.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/json-schema.spec.ts.snap
@@ -84,42 +84,14 @@ exports[`JSON Schema generator produces valid code single-file: json 1`] = `
       ]
     },
     \\"CreateUserResponse\\": {
-      \\"oneOf\\": [
-        {
-          \\"type\\": \\"object\\",
-          \\"properties\\": {
-            \\"success\\": {
-              \\"type\\": \\"boolean\\",
-              \\"const\\": false
-            },
-            \\"errors\\": {
-              \\"type\\": \\"array\\",
-              \\"items\\": {
-                \\"type\\": \\"string\\"
-              }
-            }
-          },
-          \\"required\\": [
-            \\"success\\",
-            \\"errors\\"
-          ]
-        },
-        {
-          \\"type\\": \\"object\\",
-          \\"properties\\": {
-            \\"success\\": {
-              \\"type\\": \\"boolean\\",
-              \\"const\\": true
-            },
-            \\"confirmation\\": {
-              \\"type\\": \\"string\\"
-            }
-          },
-          \\"required\\": [
-            \\"success\\",
-            \\"confirmation\\"
-          ]
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"success\\": {
+          \\"type\\": \\"boolean\\"
         }
+      },
+      \\"required\\": [
+        \\"success\\"
       ]
     },
     \\"GetUserResponse\\": {
@@ -148,29 +120,12 @@ definitions:
     required:
       - name
   CreateUserResponse:
-    oneOf:
-      - type: object
-        properties:
-          success:
-            type: boolean
-            const: false
-          errors:
-            type: array
-            items:
-              type: string
-        required:
-          - success
-          - errors
-      - type: object
-        properties:
-          success:
-            type: boolean
-            const: true
-          confirmation:
-            type: string
-        required:
-          - success
-          - confirmation
+    type: object
+    properties:
+      success:
+        type: boolean
+    required:
+      - success
   GetUserResponse:
     type: object
     properties:

--- a/lib/src/generators/contract/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/openapi2.spec.ts.snap
@@ -468,46 +468,14 @@ exports[`OpenAPI 2 generator produces valid code single-file: json 1`] = `
       ]
     },
     \\"CreateUserResponse\\": {
-      \\"allOf\\": [
-        {
-          \\"type\\": \\"object\\",
-          \\"properties\\": {
-            \\"success\\": {
-              \\"type\\": \\"boolean\\",
-              \\"enum\\": [
-                false
-              ]
-            },
-            \\"errors\\": {
-              \\"type\\": \\"array\\",
-              \\"items\\": {
-                \\"type\\": \\"string\\"
-              }
-            }
-          },
-          \\"required\\": [
-            \\"success\\",
-            \\"errors\\"
-          ]
-        },
-        {
-          \\"type\\": \\"object\\",
-          \\"properties\\": {
-            \\"success\\": {
-              \\"type\\": \\"boolean\\",
-              \\"enum\\": [
-                true
-              ]
-            },
-            \\"confirmation\\": {
-              \\"type\\": \\"string\\"
-            }
-          },
-          \\"required\\": [
-            \\"success\\",
-            \\"confirmation\\"
-          ]
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"success\\": {
+          \\"type\\": \\"boolean\\"
         }
+      },
+      \\"required\\": [
+        \\"success\\"
       ]
     },
     \\"GetUserResponse\\": {
@@ -630,31 +598,12 @@ definitions:
     required:
       - name
   CreateUserResponse:
-    allOf:
-      - type: object
-        properties:
-          success:
-            type: boolean
-            enum:
-              - false
-          errors:
-            type: array
-            items:
-              type: string
-        required:
-          - success
-          - errors
-      - type: object
-        properties:
-          success:
-            type: boolean
-            enum:
-              - true
-          confirmation:
-            type: string
-        required:
-          - success
-          - confirmation
+    type: object
+    properties:
+      success:
+        type: boolean
+    required:
+      - success
   GetUserResponse:
     type: object
     properties:

--- a/lib/src/generators/contract/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/openapi2.spec.ts.snap
@@ -23,14 +23,21 @@ exports[`OpenAPI 2 generator produces valid code multi-file: json 1`] = `
         \\"tags\\": [
           \\"TODO\\"
         ],
-        \\"parameters\\": [],
-        \\"requestBody\\": {
-          \\"$ref\\": \\"#/components/schemas/CreateUserRequest\\"
-        },
+        \\"parameters\\": [
+          {
+            \\"in\\": \\"body\\",
+            \\"name\\": \\"body\\",
+            \\"description\\": \\"TODO\\",
+            \\"required\\": true,
+            \\"schema\\": {
+              \\"$ref\\": \\"#/definitions/CreateUserRequest\\"
+            }
+          }
+        ],
         \\"responses\\": {
           \\"200\\": {
             \\"schema\\": {
-              \\"$ref\\": \\"#/components/schemas/CreateUserResponse\\"
+              \\"$ref\\": \\"#/definitions/CreateUserResponse\\"
             },
             \\"description\\": \\"\\"
           },
@@ -58,9 +65,6 @@ exports[`OpenAPI 2 generator produces valid code multi-file: json 1`] = `
         ],
         \\"responses\\": {
           \\"200\\": {
-            \\"schema\\": {
-              \\"nullable\\": true
-            },
             \\"description\\": \\"\\"
           },
           \\"403\\": {
@@ -193,13 +197,17 @@ paths:
       description: TODO
       tags:
         - TODO
-      parameters: []
-      requestBody:
-        $ref: '#/components/schemas/CreateUserRequest'
+      parameters:
+        - in: body
+          name: body
+          description: TODO
+          required: true
+          schema:
+            $ref: '#/definitions/CreateUserRequest'
       responses:
         '200':
           schema:
-            $ref: '#/components/schemas/CreateUserResponse'
+            $ref: '#/definitions/CreateUserResponse'
           description: ''
         default:
           description: ''
@@ -217,8 +225,6 @@ paths:
           required: true
       responses:
         '200':
-          schema:
-            nullable: true
           description: ''
         '403':
           schema:
@@ -315,14 +321,21 @@ exports[`OpenAPI 2 generator produces valid code single-file: json 1`] = `
         \\"tags\\": [
           \\"TODO\\"
         ],
-        \\"parameters\\": [],
-        \\"requestBody\\": {
-          \\"$ref\\": \\"#/components/schemas/CreateUserRequest\\"
-        },
+        \\"parameters\\": [
+          {
+            \\"in\\": \\"body\\",
+            \\"name\\": \\"body\\",
+            \\"description\\": \\"TODO\\",
+            \\"required\\": true,
+            \\"schema\\": {
+              \\"$ref\\": \\"#/definitions/CreateUserRequest\\"
+            }
+          }
+        ],
         \\"responses\\": {
           \\"200\\": {
             \\"schema\\": {
-              \\"$ref\\": \\"#/components/schemas/CreateUserResponse\\"
+              \\"$ref\\": \\"#/definitions/CreateUserResponse\\"
             },
             \\"description\\": \\"\\"
           },
@@ -390,9 +403,6 @@ exports[`OpenAPI 2 generator produces valid code single-file: json 1`] = `
         ],
         \\"responses\\": {
           \\"200\\": {
-            \\"schema\\": {
-              \\"nullable\\": true
-            },
             \\"description\\": \\"\\"
           },
           \\"403\\": {
@@ -444,7 +454,7 @@ exports[`OpenAPI 2 generator produces valid code single-file: json 1`] = `
       ]
     },
     \\"CreateUserResponse\\": {
-      \\"oneOf\\": [
+      \\"allOf\\": [
         {
           \\"type\\": \\"object\\",
           \\"properties\\": {
@@ -517,13 +527,17 @@ paths:
       description: TODO
       tags:
         - TODO
-      parameters: []
-      requestBody:
-        $ref: '#/components/schemas/CreateUserRequest'
+      parameters:
+        - in: body
+          name: body
+          description: TODO
+          required: true
+          schema:
+            $ref: '#/definitions/CreateUserRequest'
       responses:
         '200':
           schema:
-            $ref: '#/components/schemas/CreateUserResponse'
+            $ref: '#/definitions/CreateUserResponse'
           description: ''
         default:
           description: ''
@@ -567,8 +581,6 @@ paths:
           required: true
       responses:
         '200':
-          schema:
-            nullable: true
           description: ''
         '403':
           schema:
@@ -600,7 +612,7 @@ definitions:
     required:
       - name
   CreateUserResponse:
-    oneOf:
+    allOf:
       - type: object
         properties:
           success:

--- a/lib/src/generators/contract/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/openapi2.spec.ts.snap
@@ -20,6 +20,9 @@ exports[`OpenAPI 2 generator produces valid code multi-file: json 1`] = `
       \\"post\\": {
         \\"operationId\\": \\"createUser\\",
         \\"description\\": \\"TODO\\",
+        \\"consumes\\": [
+          \\"application/json\\"
+        ],
         \\"tags\\": [
           \\"TODO\\"
         ],
@@ -51,6 +54,7 @@ exports[`OpenAPI 2 generator produces valid code multi-file: json 1`] = `
       \\"delete\\": {
         \\"operationId\\": \\"deleteUser\\",
         \\"description\\": \\"TODO\\",
+        \\"consumes\\": [],
         \\"tags\\": [
           \\"TODO\\"
         ],
@@ -106,6 +110,7 @@ exports[`OpenAPI 2 generator produces valid code multi-file: json 1`] = `
       \\"get\\": {
         \\"operationId\\": \\"getUser\\",
         \\"description\\": \\"TODO\\",
+        \\"consumes\\": [],
         \\"tags\\": [
           \\"TODO\\"
         ],
@@ -195,6 +200,8 @@ paths:
     post:
       operationId: createUser
       description: TODO
+      consumes:
+        - application/json
       tags:
         - TODO
       parameters:
@@ -215,6 +222,7 @@ paths:
     delete:
       operationId: deleteUser
       description: TODO
+      consumes: []
       tags:
         - TODO
       parameters:
@@ -251,6 +259,7 @@ paths:
     get:
       operationId: getUser
       description: TODO
+      consumes: []
       tags:
         - TODO
       parameters:
@@ -318,6 +327,9 @@ exports[`OpenAPI 2 generator produces valid code single-file: json 1`] = `
       \\"post\\": {
         \\"operationId\\": \\"createUser\\",
         \\"description\\": \\"TODO\\",
+        \\"consumes\\": [
+          \\"application/json\\"
+        ],
         \\"tags\\": [
           \\"TODO\\"
         ],
@@ -349,6 +361,7 @@ exports[`OpenAPI 2 generator produces valid code single-file: json 1`] = `
       \\"get\\": {
         \\"operationId\\": \\"getUser\\",
         \\"description\\": \\"TODO\\",
+        \\"consumes\\": [],
         \\"tags\\": [
           \\"TODO\\"
         ],
@@ -389,6 +402,7 @@ exports[`OpenAPI 2 generator produces valid code single-file: json 1`] = `
       \\"delete\\": {
         \\"operationId\\": \\"deleteUser\\",
         \\"description\\": \\"TODO\\",
+        \\"consumes\\": [],
         \\"tags\\": [
           \\"TODO\\"
         ],
@@ -525,6 +539,8 @@ paths:
     post:
       operationId: createUser
       description: TODO
+      consumes:
+        - application/json
       tags:
         - TODO
       parameters:
@@ -545,6 +561,7 @@ paths:
     get:
       operationId: getUser
       description: TODO
+      consumes: []
       tags:
         - TODO
       parameters:
@@ -571,6 +588,7 @@ paths:
     delete:
       operationId: deleteUser
       description: TODO
+      consumes: []
       tags:
         - TODO
       parameters:

--- a/lib/src/generators/contract/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/openapi3.spec.ts.snap
@@ -523,46 +523,14 @@ exports[`OpenAPI 3 generator produces valid code single-file: json 1`] = `
         ]
       },
       \\"CreateUserResponse\\": {
-        \\"oneOf\\": [
-          {
-            \\"type\\": \\"object\\",
-            \\"properties\\": {
-              \\"success\\": {
-                \\"type\\": \\"boolean\\",
-                \\"enum\\": [
-                  false
-                ]
-              },
-              \\"errors\\": {
-                \\"type\\": \\"array\\",
-                \\"items\\": {
-                  \\"type\\": \\"string\\"
-                }
-              }
-            },
-            \\"required\\": [
-              \\"success\\",
-              \\"errors\\"
-            ]
-          },
-          {
-            \\"type\\": \\"object\\",
-            \\"properties\\": {
-              \\"success\\": {
-                \\"type\\": \\"boolean\\",
-                \\"enum\\": [
-                  true
-                ]
-              },
-              \\"confirmation\\": {
-                \\"type\\": \\"string\\"
-              }
-            },
-            \\"required\\": [
-              \\"success\\",
-              \\"confirmation\\"
-            ]
+        \\"type\\": \\"object\\",
+        \\"properties\\": {
+          \\"success\\": {
+            \\"type\\": \\"boolean\\"
           }
+        },
+        \\"required\\": [
+          \\"success\\"
         ]
       },
       \\"GetUserResponse\\": {
@@ -696,31 +664,12 @@ components:
       required:
         - name
     CreateUserResponse:
-      oneOf:
-        - type: object
-          properties:
-            success:
-              type: boolean
-              enum:
-                - false
-            errors:
-              type: array
-              items:
-                type: string
-          required:
-            - success
-            - errors
-        - type: object
-          properties:
-            success:
-              type: boolean
-              enum:
-                - true
-            confirmation:
-              type: string
-          required:
-            - success
-            - confirmation
+      type: object
+      properties:
+        success:
+          type: boolean
+      required:
+        - success
     GetUserResponse:
       type: object
       properties:

--- a/lib/src/generators/contract/openapi2-schema.spec.ts
+++ b/lib/src/generators/contract/openapi2-schema.spec.ts
@@ -182,22 +182,10 @@ Object {
     });
 
     test("union", () => {
-      expect(openApi2TypeSchema(unionType(STRING, NUMBER, BOOLEAN)))
-        .toMatchInlineSnapshot(`
-Object {
-  "allOf": Array [
-    Object {
-      "type": "string",
-    },
-    Object {
-      "type": "number",
-    },
-    Object {
-      "type": "boolean",
-    },
-  ],
-}
-`);
+      expect(() => openApi2TypeSchema(unionType(STRING, NUMBER, BOOLEAN)))
+        .toThrowError(
+          "Unions are not supported in OpenAPI 2"
+        );
     });
 
     test("type reference", () => {

--- a/lib/src/generators/contract/openapi2-schema.spec.ts
+++ b/lib/src/generators/contract/openapi2-schema.spec.ts
@@ -22,11 +22,7 @@ describe("JSON Schema generator", () => {
     });
 
     test("null", () => {
-      expect(openApi2TypeSchema(NULL)).toMatchInlineSnapshot(`
-Object {
-  "nullable": true,
-}
-`);
+      expect(openApi2TypeSchema(NULL)).toMatchInlineSnapshot(`null`);
     });
 
     test("boolean", () => {
@@ -189,7 +185,7 @@ Object {
       expect(openApi2TypeSchema(unionType(STRING, NUMBER, BOOLEAN)))
         .toMatchInlineSnapshot(`
 Object {
-  "oneOf": Array [
+  "allOf": Array [
     Object {
       "type": "string",
     },
@@ -208,7 +204,7 @@ Object {
       expect(openApi2TypeSchema(typeReference("OtherType")))
         .toMatchInlineSnapshot(`
 Object {
-  "$ref": "#/components/schemas/OtherType",
+  "$ref": "#/definitions/OtherType",
 }
 `);
     });

--- a/lib/src/generators/contract/openapi2-schema.ts
+++ b/lib/src/generators/contract/openapi2-schema.ts
@@ -78,14 +78,8 @@ export function openApi2TypeSchema(type: Type): OpenAPI2SchemaType | null {
     case "optional":
       throw new Error(`Unsupported top-level optional type`);
     case "union":
-      const types = type.types.map(t => openApi2TypeSchema(t));
-      const withoutNullTypes = compact(types);
-      if (withoutNullTypes.length !== types.length) {
-        throw new Error(`Unsupported void type in union`);
-      }
-      return {
-        allOf: withoutNullTypes
-      };
+      // Please have a look at https://github.com/OAI/OpenAPI-Specification/issues/333
+      throw new Error(`Unions are not supported in OpenAPI 2`);
     case "type-reference":
       return {
         $ref: `#/definitions/${type.typeName}`

--- a/lib/src/generators/contract/openapi2-schema.ts
+++ b/lib/src/generators/contract/openapi2-schema.ts
@@ -18,9 +18,7 @@ export function openApi2TypeSchema(type: Type): OpenAPI2SchemaType | null {
     case "void":
       return null;
     case "null":
-      return {
-        nullable: true
-      };
+      return null;
     case "boolean":
       return {
         type: "boolean"
@@ -86,11 +84,11 @@ export function openApi2TypeSchema(type: Type): OpenAPI2SchemaType | null {
         throw new Error(`Unsupported void type in union`);
       }
       return {
-        oneOf: withoutNullTypes
+        allOf: withoutNullTypes
       };
     case "type-reference":
       return {
-        $ref: `#/components/schemas/${type.typeName}`
+        $ref: `#/definitions/${type.typeName}`
       };
     default:
       throw assertNever(type);
@@ -100,7 +98,7 @@ export function openApi2TypeSchema(type: Type): OpenAPI2SchemaType | null {
 export type OpenAPI2SchemaType =
   | OpenAPI2SchemaTypeObject
   | OpenAPI2SchemaTypeArray
-  | OpenAPI2SchemaTypeOneOf
+  | OpenAPI2SchemaTypeAllOf
   | OpenAPI2SchemaTypeNull
   | OpenAPI2SchemaTypeString
   | OpenAPI2SchemaTypeNumber
@@ -109,7 +107,6 @@ export type OpenAPI2SchemaType =
   | OpenAPI2SchemaTypeReference;
 
 export interface OpenAPI2BaseSchemaType {
-  nullable?: boolean;
   discriminator?: {
     propertyName: string;
     mapping: {
@@ -131,8 +128,8 @@ export interface OpenAPI2SchemaTypeArray extends OpenAPI2BaseSchemaType {
   items: OpenAPI2SchemaType;
 }
 
-export interface OpenAPI2SchemaTypeOneOf extends OpenAPI2BaseSchemaType {
-  oneOf: OpenAPI2SchemaType[];
+export interface OpenAPI2SchemaTypeAllOf extends OpenAPI2BaseSchemaType {
+  allOf: OpenAPI2SchemaType[];
 }
 
 export interface OpenAPI2SchemaTypeNull extends OpenAPI2BaseSchemaType {}

--- a/lib/src/generators/contract/openapi2.ts
+++ b/lib/src/generators/contract/openapi2.ts
@@ -200,9 +200,9 @@ export type OpenAPIV2NonBodyParameter = {
 
 export type OpenAPIV2BodyParameter = {
   in: "body";
-  name: string;
+  name: "body";
   description?: string;
-  required: boolean;
+  required: true;
   schema: OpenAPI2SchemaType | undefined
 };
 

--- a/lib/src/generators/contract/openapi2.ts
+++ b/lib/src/generators/contract/openapi2.ts
@@ -2,11 +2,8 @@ import * as YAML from "js-yaml";
 import assertNever from "../../assert-never";
 import {Api, Endpoint, Type} from "../../models";
 import {isVoid} from "../../validator";
-import {
-  OpenAPI2SchemaType,
-  openApi2TypeSchema,
-  rejectVoidOpenApi2SchemaType
-} from "./openapi2-schema";
+import {OpenAPI2SchemaType, openApi2TypeSchema, rejectVoidOpenApi2SchemaType} from "./openapi2-schema";
+import {HttpContentType} from "@zenclabs/api";
 import compact = require("lodash/compact");
 import defaultTo = require("lodash/defaultTo");
 
@@ -23,27 +20,6 @@ export function generateOpenApiV2(api: Api, format: "json" | "yaml") {
 }
 
 export function openApiV2(api: Api): OpenApiV2 {
-  function getParameters(endpoint: Endpoint): OpenAPIV2Parameter[] {
-    const parameters = endpoint.path.map(
-      (pathComponent): OpenAPIV2Parameter | null =>
-        pathComponent.kind === "dynamic"
-          ? {
-            in: "path",
-            name: pathComponent.name,
-            description: "TODO",
-            ...rejectVoidOpenApi2SchemaType(
-              pathComponent.type,
-              `Unsupported void type for path component ${
-                pathComponent.name
-                }`
-            ),
-            required: true
-          }
-          : null
-    ).concat([requestBody(api, endpoint.requestType)])
-    return compact(parameters);
-  }
-
   return {
     swagger: "2.0",
     tags: [
@@ -72,8 +48,9 @@ export function openApiV2(api: Api): OpenApiV2 {
         acc[openApiPath][endpoint.method.toLowerCase()] = {
           operationId: endpointName,
           description: "TODO",
+          consumes: consumes(api, endpoint),
           tags: ["TODO"],
-          parameters: getParameters(endpoint),
+          parameters: getParameters(api, endpoint),
           responses: {
             default: response(api, endpoint.genericErrorType),
             [(endpoint.successStatusCode || 200).toString(10)]: response(
@@ -111,6 +88,32 @@ export function openApiV2(api: Api): OpenApiV2 {
       {} as { [typeName: string]: OpenAPI2SchemaType }
     )
   };
+}
+
+function getParameters(api: Api, endpoint: Endpoint): OpenAPIV2Parameter[] {
+  const parameters = endpoint.path.map(
+    (pathComponent): OpenAPIV2Parameter | null =>
+      pathComponent.kind === "dynamic"
+        ? {
+          in: "path",
+          name: pathComponent.name,
+          description: "TODO",
+          ...rejectVoidOpenApi2SchemaType(
+            pathComponent.type,
+            `Unsupported void type for path component ${
+              pathComponent.name
+              }`
+          ),
+          required: true
+        }
+        : null
+  ).concat([requestBody(api, endpoint.requestType)])
+  return compact(parameters);
+}
+
+function consumes(api: Api, endpoint: Endpoint): HttpContentType[] {
+  const contentType = isVoid(api, endpoint.requestType) ? null : endpoint.requestContentType;
+  return compact([contentType]);
 }
 
 function requestBody(api: Api, type: Type): OpenAPIV2Parameter | null {
@@ -173,6 +176,7 @@ export interface OpenAPIV2TagObject {
 export interface OpenAPIV2Operation {
   operationId: string;
   description?: string;
+  consumes?: HttpContentType[];
   tags?: string[];
   parameters: OpenAPIV2Parameter[];
   requestBody?: OpenAPI2SchemaType;

--- a/lib/src/generators/typescript/__snapshots__/types.spec.ts.snap
+++ b/lib/src/generators/typescript/__snapshots__/types.spec.ts.snap
@@ -20,11 +20,7 @@ exports[`TypeScript types generator produces valid code single-file 1`] = `
 };
 
 export type CreateUserResponse = {
-    success: false;
-    errors: string[];
-} | {
-    success: true;
-    confirmation: string;
+    success: boolean;
 };
 
 export type GetUserResponse = {

--- a/lib/src/generators/typescript/__snapshots__/validators.spec.ts.snap
+++ b/lib/src/generators/typescript/__snapshots__/validators.spec.ts.snap
@@ -152,7 +152,7 @@ export function validateCreateUserRequest(value: any): value is CreateUserReques
 }
 
 export function validateCreateUserResponse(value: any): value is CreateUserResponse {
-    return !(value === null) && typeof value === \\"object\\" && value[\\"success\\"] === false && (value[\\"errors\\"] instanceof Array && value[\\"errors\\"].reduce((acc, curr) => acc && typeof curr === \\"string\\", true)) || !(value === null) && typeof value === \\"object\\" && value[\\"success\\"] === true && typeof value[\\"confirmation\\"] === \\"string\\";
+    return !(value === null) && typeof value === \\"object\\" && typeof value[\\"success\\"] === \\"boolean\\";
 }
 
 export function validateGetUserResponse(value: any): value is GetUserResponse {


### PR DESCRIPTION
Changes:
- rename `#/components/schemas/...` into `#/definitions/...`
- remove `requestBody` and replace it with body parameters
- append `requestContentType` as `consumes` attribute

Before change:
```yaml
      parameters: []
      requestBody:
        $ref: '#/components/schemas/CreateUserRequest'
      responses:
        '200':
          schema:
            $ref: '#/components/schemas/CreateUserResponse'
          description: ''
        default:
          description: ''
```

After the change:
```yaml
      consumes:
        - application/json
      parameters:
        - in: body
          name: body
          description: TODO
          required: true
          schema:
            $ref: '#/definitions/CreateUserRequest'
      responses:
        '200':
          schema:
            $ref: '#/definitions/CreateUserResponse'
          description: ''
        default:
          description: ''
```