### PR TITLE
[TOOL-114] Parse types and literals when extracting decorators

### DIFF
--- a/lib/src/parsing/components/endpoint-method.ts
+++ b/lib/src/parsing/components/endpoint-method.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
 import { Api, Endpoint } from "../../models";
 import { extractSingleDecorator } from "../decorators";
-import { extractLiteral, isObjectLiteral } from "../literal-parser";
+import { isObjectLiteral } from "../literal-parser";
 import { panic } from "../panic";
 import { extractGenericErrorType } from "./generic-error-type";
 import { extractHeaders } from "./headers";
@@ -57,37 +57,24 @@ export function parseEndpointMethod(
     );
   }
   // @endpoint() expects to be passed an object literal to define its method, path, etc.
-  const endpointDescriptionExpression = endpointDecorator.arguments[0];
-  const endpointDescription = extractLiteral(
-    sourceFile,
-    endpointDescriptionExpression
-  );
+  const endpointDescription = endpointDecorator.arguments[0];
   if (!isObjectLiteral(endpointDescription)) {
     throw panic(
-      `@endpoint() expects an object literal, got this instead: ${endpointDescriptionExpression.getText(
+      `@endpoint() expects an object literal, got this instead: ${methodDeclaration.getText(
         sourceFile
       )}`
     );
   }
   const endpoint: Endpoint = {
-    method: extractMethod(
-      sourceFile,
-      endpointDescriptionExpression,
-      endpointDescription
-    ),
-    path: extractPath(
-      sourceFile,
-      methodDeclaration,
-      endpointDescriptionExpression,
-      endpointDescription
-    ),
+    method: extractMethod(sourceFile, methodDeclaration, endpointDescription),
+    path: extractPath(sourceFile, methodDeclaration, endpointDescription),
     requestContentType: extractRequestContentType(
       sourceFile,
-      endpointDescriptionExpression,
+      methodDeclaration,
       endpointDescription
     ),
-    headers: extractHeaders(sourceFile, methodDeclaration.parameters),
-    queryParams: extractQueryParams(sourceFile, methodDeclaration.parameters),
+    headers: extractHeaders(sourceFile, methodDeclaration),
+    queryParams: extractQueryParams(sourceFile, methodDeclaration),
     requestType: extractRequestType(sourceFile, methodDeclaration.parameters),
     responseType: extractResponseType(sourceFile, methodDeclaration),
     genericErrorType: extractGenericErrorType(sourceFile, methodDeclaration),
@@ -97,7 +84,7 @@ export function parseEndpointMethod(
     ),
     ...extractSuccessStatusCode(
       sourceFile,
-      endpointDescriptionExpression,
+      methodDeclaration,
       endpointDescription
     )
   };

--- a/lib/src/parsing/components/generic-error-type.ts
+++ b/lib/src/parsing/components/generic-error-type.ts
@@ -2,7 +2,6 @@ import * as ts from "typescript";
 import { Type, VOID } from "../../models";
 import { extractSingleDecorator } from "../decorators";
 import { panic } from "../panic";
-import { extractType } from "../type-parser";
 
 /**
  * Returns the generic error type attached to an endpoint, or void otherwise.
@@ -34,7 +33,7 @@ export function extractGenericErrorType(
         }`
       );
     }
-    return extractType(sourceFile, genericErrorDecorator.typeParameters[0]);
+    return genericErrorDecorator.typeParameters[0];
   }
   return VOID;
 }

--- a/lib/src/parsing/components/headers.ts
+++ b/lib/src/parsing/components/headers.ts
@@ -1,11 +1,7 @@
 import * as ts from "typescript";
 import { Headers } from "../../models";
 import { extractSingleDecorator } from "../decorators";
-import {
-  extractLiteral,
-  isObjectLiteral,
-  isStringLiteral
-} from "../literal-parser";
+import { isObjectLiteral, isStringLiteral } from "../literal-parser";
 import { panic } from "../panic";
 import { extractParameterType } from "./parameter-type";
 
@@ -27,17 +23,18 @@ import { extractParameterType } from "./parameter-type";
  */
 export function extractHeaders(
   sourceFile: ts.SourceFile,
-  parameters: ts.NodeArray<ts.ParameterDeclaration>
+  methodDeclaration: ts.MethodDeclaration
 ): Headers {
   const headers: Headers = {};
-  for (const parameter of parameters) {
-    processHeaderParameter(sourceFile, parameter, headers);
+  for (const parameter of methodDeclaration.parameters) {
+    processHeaderParameter(sourceFile, methodDeclaration, parameter, headers);
   }
   return headers;
 }
 
 function processHeaderParameter(
   sourceFile: ts.SourceFile,
+  methodDeclaration: ts.MethodDeclaration,
   parameter: ts.ParameterDeclaration,
   headers: Headers
 ) {
@@ -60,13 +57,10 @@ function processHeaderParameter(
       }`
     );
   }
-  const headerDescription = extractLiteral(
-    sourceFile,
-    headerDecorator.arguments[0]
-  );
+  const headerDescription = headerDecorator.arguments[0];
   if (!isObjectLiteral(headerDescription)) {
     throw panic(
-      `@header() expects an object literal, got this instead: ${headerDecorator.arguments[0].getText(
+      `@header() expects an object literal, got this instead: ${methodDeclaration.getText(
         sourceFile
       )}`
     );
@@ -74,7 +68,7 @@ function processHeaderParameter(
   const nameProperty = headerDescription.properties["name"];
   if (!nameProperty || !isStringLiteral(nameProperty)) {
     throw panic(
-      `@header() expects a string name, got this instead: ${headerDecorator.arguments[0].getText(
+      `@header() expects a string name, got this instead: ${methodDeclaration.getText(
         sourceFile
       )}`
     );
@@ -84,7 +78,7 @@ function processHeaderParameter(
   if (descriptionProperty) {
     if (!isStringLiteral(descriptionProperty)) {
       throw panic(
-        `@header() expects a string description, got this instead: ${headerDecorator.arguments[0].getText(
+        `@header() expects a string description, got this instead: ${methodDeclaration.getText(
           sourceFile
         )}`
       );

--- a/lib/src/parsing/components/method.ts
+++ b/lib/src/parsing/components/method.ts
@@ -21,13 +21,13 @@ import { panic } from "../panic";
  */
 export function extractMethod(
   sourceFile: ts.SourceFile,
-  endpointDescriptionExpression: ts.Expression,
+  methodDeclaration: ts.MethodDeclaration,
   endpointDescription: ObjectLiteral
 ): HttpMethod {
   const methodLiteral = endpointDescription.properties["method"];
   if (!isStringLiteral(methodLiteral)) {
     throw panic(
-      `Invalid method in endpoint description: ${endpointDescriptionExpression.getText(
+      `Invalid method in endpoint description: ${methodDeclaration.getText(
         sourceFile
       )}`
     );

--- a/lib/src/parsing/components/request-content-type.ts
+++ b/lib/src/parsing/components/request-content-type.ts
@@ -22,7 +22,7 @@ import { panic } from "../panic";
  */
 export function extractRequestContentType(
   sourceFile: ts.SourceFile,
-  endpointDescriptionExpression: ts.Expression,
+  methodDeclaration: ts.MethodDeclaration,
   endpointDescription: ObjectLiteral
 ): HttpContentType {
   const requestContentTypeLiteral =
@@ -31,7 +31,7 @@ export function extractRequestContentType(
   if (requestContentTypeLiteral) {
     if (!isStringLiteral(requestContentTypeLiteral)) {
       throw panic(
-        `Invalid request content type in endpoint description: ${endpointDescriptionExpression.getText(
+        `Invalid request content type in endpoint description: ${methodDeclaration.getText(
           sourceFile
         )}`
       );

--- a/lib/src/parsing/components/success-status-code.ts
+++ b/lib/src/parsing/components/success-status-code.ts
@@ -23,7 +23,7 @@ import { panic } from "../panic";
  */
 export function extractSuccessStatusCode(
   sourceFile: ts.SourceFile,
-  endpointDescriptionExpression: ts.Expression,
+  methodDeclaration: ts.MethodDeclaration,
   endpointDescription: ObjectLiteral
 ): {
   successStatusCode?: number;
@@ -35,7 +35,7 @@ export function extractSuccessStatusCode(
   }
   if (!isNumericLiteral(successStatusCodeLiteral)) {
     throw panic(
-      `Invalid success status code in endpoint description: ${endpointDescriptionExpression.getText(
+      `Invalid success status code in endpoint description: ${methodDeclaration.getText(
         sourceFile
       )}`
     );

--- a/lib/src/parsing/decorators.ts
+++ b/lib/src/parsing/decorators.ts
@@ -1,5 +1,8 @@
 import * as ts from "typescript";
+import { Type } from "../models";
+import { extractLiteral, Literal } from "./literal-parser";
 import { panic } from "./panic";
+import { extractType } from "./type-parser";
 
 /**
  * Extracts the arguments from a single decorator associated with a TypeScript node.
@@ -84,8 +87,12 @@ export function extractMultipleDecorators(
           decorator.expression.expression.getText(sourceFile) === decoratorName
         ) {
           decorators.push({
-            typeParameters: [...(decorator.expression.typeArguments || [])],
-            arguments: [...decorator.expression.arguments]
+            typeParameters: [...(decorator.expression.typeArguments || [])].map(
+              t => extractType(sourceFile, t)
+            ),
+            arguments: [...decorator.expression.arguments].map(e =>
+              extractLiteral(sourceFile, e)
+            )
           });
         }
       }
@@ -95,6 +102,6 @@ export function extractMultipleDecorators(
 }
 
 export interface Decorator {
-  typeParameters: ts.TypeNode[];
-  arguments: ts.Expression[];
+  typeParameters: Type[];
+  arguments: Literal[];
 }


### PR DESCRIPTION
This removes parsing logic from the upper layers and should make code a bit easier to follow.

It does mean that we lose the ability to output only the part of the code that failed to parse, and instead have to output the whole endpoint code. That's probably fine, as they should still be rather small. Arguably, it will also give useful context.