### PR TITLE
Explicitly push the NPM package as "public"

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf build; tsc -b --force && rm -rf build/examples && oclif-dev manifest && oclif-dev readme",
     "test": "jest",
-    "release": "yarn version && oclif-dev readme && git add README.md && git commit README.md -m \"Update README\" && git push && npm publish"
+    "release": "yarn version && oclif-dev readme && git add README.md && git commit README.md -m \"Update README\" && git push && npm publish --access=public"
   }
 }


### PR DESCRIPTION
This addresses a warning on the first push of the NPM package otherwise.