### PR TITLE
Use more conventional tagging pattern for triggering releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,17 +105,17 @@ workflows:
       - build-and-test:
           filters:
             tags:
-              only: /^release.*$/
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - prettier-check:
           filters:
             tags:
-              only: /^release.*$/
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - publish:
           requires:
             - build-and-test
             - prettier-check
           filters:
             tags:
-              only: /^release.*$/
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
             branches:
               ignore: /.*/


### PR DESCRIPTION
Instead of release/v0.1.27, we'll just push a tag to v0.1.27.