### PR TITLE
[TOOL-128] Render header name with hyphen correctly for axios client generator

### DIFF
--- a/lib/src/generators/typescript/__snapshots__/axios-client.spec.ts.snap
+++ b/lib/src/generators/typescript/__snapshots__/axios-client.spec.ts.snap
@@ -24,7 +24,7 @@ export async function createUser(request: CreateUserRequest, authToken: string |
         url: \\"/users/create\\",
         method: \\"POST\\",
         responseType: \\"json\\",
-        headers: { Authorization: authToken },
+        headers: { \\"Authorization\\": authToken },
         data: request,
         validateStatus: () => true
     });
@@ -75,7 +75,7 @@ export async function deleteUser(userId: number, authToken: string): Promise<{
         url: \\"/users/\\" + userId + \\"-confirmed\\",
         method: \\"DELETE\\",
         responseType: \\"json\\",
-        headers: { Authorization: authToken },
+        headers: { \\"Authorization\\": authToken },
         validateStatus: () => true
     });
     switch (response.status) {
@@ -214,7 +214,7 @@ export async function createUser(request: CreateUserRequest, authToken: string |
         url: \\"/users/create\\",
         method: \\"POST\\",
         responseType: \\"json\\",
-        headers: { Authorization: authToken },
+        headers: { \\"Authorization\\": authToken },
         data: request,
         validateStatus: () => true
     });
@@ -346,7 +346,7 @@ export async function deleteUser(userId: number, authToken: string): Promise<{
         url: \\"/users/\\" + userId + \\"-confirmed\\",
         method: \\"DELETE\\",
         responseType: \\"json\\",
-        headers: { Authorization: authToken },
+        headers: { \\"Authorization\\": authToken },
         validateStatus: () => true
     });
     switch (response.status) {

--- a/lib/src/generators/typescript/axios-client.ts
+++ b/lib/src/generators/typescript/axios-client.ts
@@ -269,7 +269,7 @@ function generateAxiosCall(
                         Object.entries(endpoint.headers).map(
                           ([headerName, header]) =>
                             ts.createPropertyAssignment(
-                              header.headerFieldName,
+                              ts.createStringLiteral(header.headerFieldName),
                               ts.createIdentifier(headerName)
                             )
                         )


### PR DESCRIPTION
This will fix https://github.com/airtasker/spot/issues/42