### PR TITLE
Allow usage of interface inheritance

### DIFF
--- a/examples/src/multi-file/endpoints/delete-user.ts
+++ b/examples/src/multi-file/endpoints/delete-user.ts
@@ -2,11 +2,12 @@ import {
   endpoint,
   genericError,
   header,
+  Int64,
   pathParam,
-  specificError,
   response,
-  Int64
+  specificError
 } from "@airtasker/spot";
+import { BaseError, ForbiddenError } from "../errors";
 
 export class DeleteUser {
   @endpoint({
@@ -14,13 +15,8 @@ export class DeleteUser {
     path: "/users/:userId-confirmed",
     tags: ["users"]
   })
-  @genericError<{
-    message: string;
-  }>()
-  @specificError<{
-    message: string;
-    signedInAs: string;
-  }>({
+  @genericError<BaseError>()
+  @specificError<ForbiddenError>({
     name: "forbidden",
     statusCode: 403
   })

--- a/examples/src/multi-file/errors.ts
+++ b/examples/src/multi-file/errors.ts
@@ -1,0 +1,7 @@
+export interface BaseError {
+  message: string;
+}
+
+export interface ForbiddenError extends BaseError {
+  signedInAs: string;
+}

--- a/examples/src/single-file/single-file-api.ts
+++ b/examples/src/single-file/single-file-api.ts
@@ -1,5 +1,6 @@
 import {
   api,
+  DateTime,
   endpoint,
   Float,
   genericError,
@@ -10,9 +11,8 @@ import {
   pathParam,
   queryParam,
   request,
-  specificError,
   response,
-  DateTime
+  specificError
 } from "@airtasker/spot";
 
 @api({
@@ -73,13 +73,8 @@ export class Api {
     path: "/users/:userId-confirmed",
     tags: ["users"]
   })
-  @genericError<{
-    message: string;
-  }>()
-  @specificError<{
-    message: string;
-    signedInAs: string;
-  }>({
+  @genericError<BaseError>()
+  @specificError<ForbiddenError>({
     name: "forbidden",
     statusCode: 403
   })
@@ -94,6 +89,8 @@ export class Api {
   }
 }
 
+// Requests and responses.
+
 export interface CreateUserRequest {
   name: string;
   roles: "admin" | "member";
@@ -102,4 +99,14 @@ export interface CreateUserRequest {
 export interface CreateUserResponse {
   success: boolean;
   created_at: DateTime;
+}
+
+// Errors.
+
+export interface BaseError {
+  message: string;
+}
+
+export interface ForbiddenError extends BaseError {
+  signedInAs: string;
 }

--- a/lib/src/__snapshots__/parser.spec.ts.snap
+++ b/lib/src/__snapshots__/parser.spec.ts.snap
@@ -48,12 +48,8 @@ Object {
     "deleteUser": Object {
       "description": "",
       "genericErrorType": Object {
-        "kind": "object",
-        "properties": Object {
-          "message": Object {
-            "kind": "string",
-          },
-        },
+        "kind": "type-reference",
+        "typeName": "BaseError",
       },
       "headers": Object {
         "authToken": Object {
@@ -95,15 +91,8 @@ Object {
         "forbidden": Object {
           "statusCode": 403,
           "type": Object {
-            "kind": "object",
-            "properties": Object {
-              "message": Object {
-                "kind": "string",
-              },
-              "signedInAs": Object {
-                "kind": "string",
-              },
-            },
+            "kind": "type-reference",
+            "typeName": "ForbiddenError",
           },
         },
       },
@@ -149,6 +138,7 @@ Object {
       },
       "responseType": Object {
         "elements": Object {
+          "extends": Array [],
           "kind": "object",
           "properties": Object {
             "age": Object {
@@ -196,6 +186,7 @@ Object {
         "kind": "void",
       },
       "responseType": Object {
+        "extends": Array [],
         "kind": "object",
         "properties": Object {
           "age": Object {
@@ -216,7 +207,17 @@ Object {
     },
   },
   "types": Object {
+    "BaseError": Object {
+      "extends": Array [],
+      "kind": "object",
+      "properties": Object {
+        "message": Object {
+          "kind": "string",
+        },
+      },
+    },
     "CreateUserRequest": Object {
+      "extends": Array [],
       "kind": "object",
       "properties": Object {
         "name": Object {
@@ -238,6 +239,7 @@ Object {
       },
     },
     "CreateUserResponse": Object {
+      "extends": Array [],
       "kind": "object",
       "properties": Object {
         "created_at": Object {
@@ -245,6 +247,20 @@ Object {
         },
         "success": Object {
           "kind": "boolean",
+        },
+      },
+    },
+    "ForbiddenError": Object {
+      "extends": Array [
+        Object {
+          "kind": "type-reference",
+          "typeName": "BaseError",
+        },
+      ],
+      "kind": "object",
+      "properties": Object {
+        "signedInAs": Object {
+          "kind": "string",
         },
       },
     },
@@ -300,12 +316,8 @@ Object {
     "deleteUser": Object {
       "description": "",
       "genericErrorType": Object {
-        "kind": "object",
-        "properties": Object {
-          "message": Object {
-            "kind": "string",
-          },
-        },
+        "kind": "type-reference",
+        "typeName": "BaseError",
       },
       "headers": Object {
         "authToken": Object {
@@ -347,15 +359,8 @@ Object {
         "forbidden": Object {
           "statusCode": 403,
           "type": Object {
-            "kind": "object",
-            "properties": Object {
-              "message": Object {
-                "kind": "string",
-              },
-              "signedInAs": Object {
-                "kind": "string",
-              },
-            },
+            "kind": "type-reference",
+            "typeName": "ForbiddenError",
           },
         },
       },
@@ -401,6 +406,7 @@ Object {
       },
       "responseType": Object {
         "elements": Object {
+          "extends": Array [],
           "kind": "object",
           "properties": Object {
             "age": Object {
@@ -448,6 +454,7 @@ Object {
         "kind": "void",
       },
       "responseType": Object {
+        "extends": Array [],
         "kind": "object",
         "properties": Object {
           "age": Object {
@@ -468,7 +475,17 @@ Object {
     },
   },
   "types": Object {
+    "BaseError": Object {
+      "extends": Array [],
+      "kind": "object",
+      "properties": Object {
+        "message": Object {
+          "kind": "string",
+        },
+      },
+    },
     "CreateUserRequest": Object {
+      "extends": Array [],
       "kind": "object",
       "properties": Object {
         "name": Object {
@@ -490,6 +507,7 @@ Object {
       },
     },
     "CreateUserResponse": Object {
+      "extends": Array [],
       "kind": "object",
       "properties": Object {
         "created_at": Object {
@@ -497,6 +515,20 @@ Object {
         },
         "success": Object {
           "kind": "boolean",
+        },
+      },
+    },
+    "ForbiddenError": Object {
+      "extends": Array [
+        Object {
+          "kind": "type-reference",
+          "typeName": "BaseError",
+        },
+      ],
+      "kind": "object",
+      "properties": Object {
+        "signedInAs": Object {
+          "kind": "string",
         },
       },
     },

--- a/lib/src/generators/contract/__snapshots__/json-schema.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/json-schema.spec.ts.snap
@@ -42,6 +42,32 @@ exports[`JSON Schema generator produces valid code multi-file: json 1`] = `
         \\"success\\",
         \\"created_at\\"
       ]
+    },
+    \\"BaseError\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"message\\": {
+          \\"type\\": \\"string\\"
+        }
+      },
+      \\"required\\": [
+        \\"message\\"
+      ]
+    },
+    \\"ForbiddenError\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"message\\": {
+          \\"type\\": \\"string\\"
+        },
+        \\"signedInAs\\": {
+          \\"type\\": \\"string\\"
+        }
+      },
+      \\"required\\": [
+        \\"message\\",
+        \\"signedInAs\\"
+      ]
     }
   }
 }"
@@ -74,6 +100,23 @@ definitions:
     required:
       - success
       - created_at
+  BaseError:
+    type: object
+    properties:
+      message:
+        type: string
+    required:
+      - message
+  ForbiddenError:
+    type: object
+    properties:
+      message:
+        type: string
+      signedInAs:
+        type: string
+    required:
+      - message
+      - signedInAs
 "
 `;
 
@@ -119,6 +162,32 @@ exports[`JSON Schema generator produces valid code single-file: json 1`] = `
         \\"success\\",
         \\"created_at\\"
       ]
+    },
+    \\"BaseError\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"message\\": {
+          \\"type\\": \\"string\\"
+        }
+      },
+      \\"required\\": [
+        \\"message\\"
+      ]
+    },
+    \\"ForbiddenError\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"message\\": {
+          \\"type\\": \\"string\\"
+        },
+        \\"signedInAs\\": {
+          \\"type\\": \\"string\\"
+        }
+      },
+      \\"required\\": [
+        \\"message\\",
+        \\"signedInAs\\"
+      ]
     }
   }
 }"
@@ -151,5 +220,22 @@ definitions:
     required:
       - success
       - created_at
+  BaseError:
+    type: object
+    properties:
+      message:
+        type: string
+    required:
+      - message
+  ForbiddenError:
+    type: object
+    properties:
+      message:
+        type: string
+      signedInAs:
+        type: string
+    required:
+      - message
+      - signedInAs
 "
 `;

--- a/lib/src/generators/contract/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/openapi2.spec.ts.snap
@@ -88,33 +88,13 @@ exports[`OpenAPI 2 generator produces valid code multi-file: json 1`] = `
           },
           \\"403\\": {
             \\"schema\\": {
-              \\"type\\": \\"object\\",
-              \\"properties\\": {
-                \\"message\\": {
-                  \\"type\\": \\"string\\"
-                },
-                \\"signedInAs\\": {
-                  \\"type\\": \\"string\\"
-                }
-              },
-              \\"required\\": [
-                \\"message\\",
-                \\"signedInAs\\"
-              ]
+              \\"$ref\\": \\"#/definitions/ForbiddenError\\"
             },
             \\"description\\": \\"\\"
           },
           \\"default\\": {
             \\"schema\\": {
-              \\"type\\": \\"object\\",
-              \\"properties\\": {
-                \\"message\\": {
-                  \\"type\\": \\"string\\"
-                }
-              },
-              \\"required\\": [
-                \\"message\\"
-              ]
+              \\"$ref\\": \\"#/definitions/BaseError\\"
             },
             \\"description\\": \\"\\"
           }
@@ -253,6 +233,32 @@ exports[`OpenAPI 2 generator produces valid code multi-file: json 1`] = `
         \\"success\\",
         \\"created_at\\"
       ]
+    },
+    \\"BaseError\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"message\\": {
+          \\"type\\": \\"string\\"
+        }
+      },
+      \\"required\\": [
+        \\"message\\"
+      ]
+    },
+    \\"ForbiddenError\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"message\\": {
+          \\"type\\": \\"string\\"
+        },
+        \\"signedInAs\\": {
+          \\"type\\": \\"string\\"
+        }
+      },
+      \\"required\\": [
+        \\"message\\",
+        \\"signedInAs\\"
+      ]
     }
   }
 }"
@@ -319,24 +325,11 @@ paths:
           description: ''
         '403':
           schema:
-            type: object
-            properties:
-              message:
-                type: string
-              signedInAs:
-                type: string
-            required:
-              - message
-              - signedInAs
+            $ref: '#/definitions/ForbiddenError'
           description: ''
         default:
           schema:
-            type: object
-            properties:
-              message:
-                type: string
-            required:
-              - message
+            $ref: '#/definitions/BaseError'
           description: ''
   /users:
     get:
@@ -428,6 +421,23 @@ definitions:
     required:
       - success
       - created_at
+  BaseError:
+    type: object
+    properties:
+      message:
+        type: string
+    required:
+      - message
+  ForbiddenError:
+    type: object
+    properties:
+      message:
+        type: string
+      signedInAs:
+        type: string
+    required:
+      - message
+      - signedInAs
 "
 `;
 
@@ -615,33 +625,13 @@ exports[`OpenAPI 2 generator produces valid code single-file: json 1`] = `
           },
           \\"403\\": {
             \\"schema\\": {
-              \\"type\\": \\"object\\",
-              \\"properties\\": {
-                \\"message\\": {
-                  \\"type\\": \\"string\\"
-                },
-                \\"signedInAs\\": {
-                  \\"type\\": \\"string\\"
-                }
-              },
-              \\"required\\": [
-                \\"message\\",
-                \\"signedInAs\\"
-              ]
+              \\"$ref\\": \\"#/definitions/ForbiddenError\\"
             },
             \\"description\\": \\"\\"
           },
           \\"default\\": {
             \\"schema\\": {
-              \\"type\\": \\"object\\",
-              \\"properties\\": {
-                \\"message\\": {
-                  \\"type\\": \\"string\\"
-                }
-              },
-              \\"required\\": [
-                \\"message\\"
-              ]
+              \\"$ref\\": \\"#/definitions/BaseError\\"
             },
             \\"description\\": \\"\\"
           }
@@ -683,6 +673,32 @@ exports[`OpenAPI 2 generator produces valid code single-file: json 1`] = `
       \\"required\\": [
         \\"success\\",
         \\"created_at\\"
+      ]
+    },
+    \\"BaseError\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"message\\": {
+          \\"type\\": \\"string\\"
+        }
+      },
+      \\"required\\": [
+        \\"message\\"
+      ]
+    },
+    \\"ForbiddenError\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"message\\": {
+          \\"type\\": \\"string\\"
+        },
+        \\"signedInAs\\": {
+          \\"type\\": \\"string\\"
+        }
+      },
+      \\"required\\": [
+        \\"message\\",
+        \\"signedInAs\\"
       ]
     }
   }
@@ -815,24 +831,11 @@ paths:
           description: ''
         '403':
           schema:
-            type: object
-            properties:
-              message:
-                type: string
-              signedInAs:
-                type: string
-            required:
-              - message
-              - signedInAs
+            $ref: '#/definitions/ForbiddenError'
           description: ''
         default:
           schema:
-            type: object
-            properties:
-              message:
-                type: string
-            required:
-              - message
+            $ref: '#/definitions/BaseError'
           description: ''
 definitions:
   CreateUserRequest:
@@ -859,5 +862,22 @@ definitions:
     required:
       - success
       - created_at
+  BaseError:
+    type: object
+    properties:
+      message:
+        type: string
+    required:
+      - message
+  ForbiddenError:
+    type: object
+    properties:
+      message:
+        type: string
+      signedInAs:
+        type: string
+    required:
+      - message
+      - signedInAs
 "
 `;

--- a/lib/src/generators/contract/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/openapi3.spec.ts.snap
@@ -103,19 +103,7 @@ exports[`OpenAPI 3 generator produces valid code multi-file: json 1`] = `
             \\"content\\": {
               \\"application/json\\": {
                 \\"schema\\": {
-                  \\"type\\": \\"object\\",
-                  \\"properties\\": {
-                    \\"message\\": {
-                      \\"type\\": \\"string\\"
-                    },
-                    \\"signedInAs\\": {
-                      \\"type\\": \\"string\\"
-                    }
-                  },
-                  \\"required\\": [
-                    \\"message\\",
-                    \\"signedInAs\\"
-                  ]
+                  \\"$ref\\": \\"#/components/schemas/ForbiddenError\\"
                 }
               }
             },
@@ -125,15 +113,7 @@ exports[`OpenAPI 3 generator produces valid code multi-file: json 1`] = `
             \\"content\\": {
               \\"application/json\\": {
                 \\"schema\\": {
-                  \\"type\\": \\"object\\",
-                  \\"properties\\": {
-                    \\"message\\": {
-                      \\"type\\": \\"string\\"
-                    }
-                  },
-                  \\"required\\": [
-                    \\"message\\"
-                  ]
+                  \\"$ref\\": \\"#/components/schemas/BaseError\\"
                 }
               }
             },
@@ -287,6 +267,32 @@ exports[`OpenAPI 3 generator produces valid code multi-file: json 1`] = `
           \\"success\\",
           \\"created_at\\"
         ]
+      },
+      \\"BaseError\\": {
+        \\"type\\": \\"object\\",
+        \\"properties\\": {
+          \\"message\\": {
+            \\"type\\": \\"string\\"
+          }
+        },
+        \\"required\\": [
+          \\"message\\"
+        ]
+      },
+      \\"ForbiddenError\\": {
+        \\"type\\": \\"object\\",
+        \\"properties\\": {
+          \\"message\\": {
+            \\"type\\": \\"string\\"
+          },
+          \\"signedInAs\\": {
+            \\"type\\": \\"string\\"
+          }
+        },
+        \\"required\\": [
+          \\"message\\",
+          \\"signedInAs\\"
+        ]
       }
     }
   }
@@ -361,26 +367,13 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                  signedInAs:
-                    type: string
-                required:
-                  - message
-                  - signedInAs
+                $ref: '#/components/schemas/ForbiddenError'
           description: ''
         default:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                required:
-                  - message
+                $ref: '#/components/schemas/BaseError'
           description: ''
   /users:
     get:
@@ -478,6 +471,23 @@ components:
       required:
         - success
         - created_at
+    BaseError:
+      type: object
+      properties:
+        message:
+          type: string
+      required:
+        - message
+    ForbiddenError:
+      type: object
+      properties:
+        message:
+          type: string
+        signedInAs:
+          type: string
+      required:
+        - message
+        - signedInAs
 "
 `;
 
@@ -692,19 +702,7 @@ exports[`OpenAPI 3 generator produces valid code single-file: json 1`] = `
             \\"content\\": {
               \\"application/json\\": {
                 \\"schema\\": {
-                  \\"type\\": \\"object\\",
-                  \\"properties\\": {
-                    \\"message\\": {
-                      \\"type\\": \\"string\\"
-                    },
-                    \\"signedInAs\\": {
-                      \\"type\\": \\"string\\"
-                    }
-                  },
-                  \\"required\\": [
-                    \\"message\\",
-                    \\"signedInAs\\"
-                  ]
+                  \\"$ref\\": \\"#/components/schemas/ForbiddenError\\"
                 }
               }
             },
@@ -714,15 +712,7 @@ exports[`OpenAPI 3 generator produces valid code single-file: json 1`] = `
             \\"content\\": {
               \\"application/json\\": {
                 \\"schema\\": {
-                  \\"type\\": \\"object\\",
-                  \\"properties\\": {
-                    \\"message\\": {
-                      \\"type\\": \\"string\\"
-                    }
-                  },
-                  \\"required\\": [
-                    \\"message\\"
-                  ]
+                  \\"$ref\\": \\"#/components/schemas/BaseError\\"
                 }
               }
             },
@@ -767,6 +757,32 @@ exports[`OpenAPI 3 generator produces valid code single-file: json 1`] = `
         \\"required\\": [
           \\"success\\",
           \\"created_at\\"
+        ]
+      },
+      \\"BaseError\\": {
+        \\"type\\": \\"object\\",
+        \\"properties\\": {
+          \\"message\\": {
+            \\"type\\": \\"string\\"
+          }
+        },
+        \\"required\\": [
+          \\"message\\"
+        ]
+      },
+      \\"ForbiddenError\\": {
+        \\"type\\": \\"object\\",
+        \\"properties\\": {
+          \\"message\\": {
+            \\"type\\": \\"string\\"
+          },
+          \\"signedInAs\\": {
+            \\"type\\": \\"string\\"
+          }
+        },
+        \\"required\\": [
+          \\"message\\",
+          \\"signedInAs\\"
         ]
       }
     }
@@ -912,26 +928,13 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                  signedInAs:
-                    type: string
-                required:
-                  - message
-                  - signedInAs
+                $ref: '#/components/schemas/ForbiddenError'
           description: ''
         default:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                required:
-                  - message
+                $ref: '#/components/schemas/BaseError'
           description: ''
 components:
   schemas:
@@ -959,5 +962,22 @@ components:
       required:
         - success
         - created_at
+    BaseError:
+      type: object
+      properties:
+        message:
+          type: string
+      required:
+        - message
+    ForbiddenError:
+      type: object
+      properties:
+        message:
+          type: string
+        signedInAs:
+          type: string
+      required:
+        - message
+        - signedInAs
 "
 `;

--- a/lib/src/generators/contract/json-schema.spec.ts
+++ b/lib/src/generators/contract/json-schema.spec.ts
@@ -50,7 +50,7 @@ describe("JSON Schema generator", () => {
 
   describe("generates type validator", () => {
     test("void", () => {
-      expect(jsonTypeSchema(VOID)).toMatchInlineSnapshot(`
+      expect(jsonTypeSchema({}, VOID)).toMatchInlineSnapshot(`
 Object {
   "type": "null",
 }
@@ -58,7 +58,7 @@ Object {
     });
 
     test("null", () => {
-      expect(jsonTypeSchema(NULL)).toMatchInlineSnapshot(`
+      expect(jsonTypeSchema({}, NULL)).toMatchInlineSnapshot(`
 Object {
   "type": "null",
 }
@@ -66,7 +66,7 @@ Object {
     });
 
     test("boolean", () => {
-      expect(jsonTypeSchema(BOOLEAN)).toMatchInlineSnapshot(`
+      expect(jsonTypeSchema({}, BOOLEAN)).toMatchInlineSnapshot(`
 Object {
   "type": "boolean",
 }
@@ -74,13 +74,13 @@ Object {
     });
 
     test("boolean constant", () => {
-      expect(jsonTypeSchema(booleanConstant(true))).toMatchInlineSnapshot(`
+      expect(jsonTypeSchema({}, booleanConstant(true))).toMatchInlineSnapshot(`
 Object {
   "const": true,
   "type": "boolean",
 }
 `);
-      expect(jsonTypeSchema(booleanConstant(false))).toMatchInlineSnapshot(`
+      expect(jsonTypeSchema({}, booleanConstant(false))).toMatchInlineSnapshot(`
 Object {
   "const": false,
   "type": "boolean",
@@ -89,7 +89,7 @@ Object {
     });
 
     test("string", () => {
-      expect(jsonTypeSchema(STRING)).toMatchInlineSnapshot(`
+      expect(jsonTypeSchema({}, STRING)).toMatchInlineSnapshot(`
 Object {
   "type": "string",
 }
@@ -97,7 +97,7 @@ Object {
     });
 
     test("string constant", () => {
-      expect(jsonTypeSchema(stringConstant("some constant")))
+      expect(jsonTypeSchema({}, stringConstant("some constant")))
         .toMatchInlineSnapshot(`
 Object {
   "const": "some constant",
@@ -107,7 +107,7 @@ Object {
     });
 
     test("number", () => {
-      expect(jsonTypeSchema(NUMBER)).toMatchInlineSnapshot(`
+      expect(jsonTypeSchema({}, NUMBER)).toMatchInlineSnapshot(`
 Object {
   "type": "number",
 }
@@ -115,7 +115,7 @@ Object {
     });
 
     test("int32", () => {
-      expect(jsonTypeSchema(INT32)).toMatchInlineSnapshot(`
+      expect(jsonTypeSchema({}, INT32)).toMatchInlineSnapshot(`
 Object {
   "type": "number",
 }
@@ -123,7 +123,7 @@ Object {
     });
 
     test("int64", () => {
-      expect(jsonTypeSchema(INT64)).toMatchInlineSnapshot(`
+      expect(jsonTypeSchema({}, INT64)).toMatchInlineSnapshot(`
 Object {
   "type": "number",
 }
@@ -131,7 +131,7 @@ Object {
     });
 
     test("float", () => {
-      expect(jsonTypeSchema(FLOAT)).toMatchInlineSnapshot(`
+      expect(jsonTypeSchema({}, FLOAT)).toMatchInlineSnapshot(`
 Object {
   "type": "number",
 }
@@ -139,7 +139,7 @@ Object {
     });
 
     test("double", () => {
-      expect(jsonTypeSchema(DOUBLE)).toMatchInlineSnapshot(`
+      expect(jsonTypeSchema({}, DOUBLE)).toMatchInlineSnapshot(`
 Object {
   "type": "number",
 }
@@ -147,19 +147,19 @@ Object {
     });
 
     test("integer constant", () => {
-      expect(jsonTypeSchema(integerConstant(0))).toMatchInlineSnapshot(`
+      expect(jsonTypeSchema({}, integerConstant(0))).toMatchInlineSnapshot(`
 Object {
   "const": 0,
   "type": "integer",
 }
 `);
-      expect(jsonTypeSchema(integerConstant(123))).toMatchInlineSnapshot(`
+      expect(jsonTypeSchema({}, integerConstant(123))).toMatchInlineSnapshot(`
 Object {
   "const": 123,
   "type": "integer",
 }
 `);
-      expect(jsonTypeSchema(integerConstant(-1000))).toMatchInlineSnapshot(`
+      expect(jsonTypeSchema({}, integerConstant(-1000))).toMatchInlineSnapshot(`
 Object {
   "const": -1000,
   "type": "integer",
@@ -168,7 +168,7 @@ Object {
     });
 
     test("object", () => {
-      expect(jsonTypeSchema(objectType({}))).toMatchInlineSnapshot(`
+      expect(jsonTypeSchema({}, objectType({}))).toMatchInlineSnapshot(`
 Object {
   "properties": Object {},
   "required": Array [],
@@ -177,6 +177,7 @@ Object {
 `);
       expect(
         jsonTypeSchema(
+          {},
           objectType({
             singleField: NUMBER
           })
@@ -196,6 +197,7 @@ Object {
 `);
       expect(
         jsonTypeSchema(
+          {},
           objectType({
             field1: NUMBER,
             field2: STRING,
@@ -225,7 +227,7 @@ Object {
     });
 
     test("array", () => {
-      expect(jsonTypeSchema(arrayType(STRING))).toMatchInlineSnapshot(`
+      expect(jsonTypeSchema({}, arrayType(STRING))).toMatchInlineSnapshot(`
 Object {
   "items": Object {
     "type": "string",
@@ -236,13 +238,13 @@ Object {
     });
 
     test("optional", () => {
-      expect(() => jsonTypeSchema(optionalType(STRING))).toThrowError(
+      expect(() => jsonTypeSchema({}, optionalType(STRING))).toThrowError(
         "Unsupported top-level optional type"
       );
     });
 
     test("union", () => {
-      expect(jsonTypeSchema(unionType(STRING, NUMBER, BOOLEAN)))
+      expect(jsonTypeSchema({}, unionType(STRING, NUMBER, BOOLEAN)))
         .toMatchInlineSnapshot(`
 Object {
   "oneOf": Array [
@@ -261,7 +263,8 @@ Object {
     });
 
     test("type reference", () => {
-      expect(jsonTypeSchema(typeReference("OtherType"))).toMatchInlineSnapshot(`
+      expect(jsonTypeSchema({}, typeReference("OtherType")))
+        .toMatchInlineSnapshot(`
 Object {
   "$ref": "#/definitions/OtherType",
 }

--- a/lib/src/generators/contract/json-schema.spec.ts
+++ b/lib/src/generators/contract/json-schema.spec.ts
@@ -224,6 +224,52 @@ Object {
   "type": "object",
 }
 `);
+      expect(
+        jsonTypeSchema(
+          {
+            extended1: objectType(
+              {
+                field2: optionalType(BOOLEAN),
+                field3: NUMBER
+              },
+              ["extended2"]
+            ),
+            extended2: objectType({
+              field1: NUMBER,
+              field2: STRING
+            })
+          },
+          objectType(
+            {
+              field4: STRING
+            },
+            ["extended1"]
+          )
+        )
+      ).toMatchInlineSnapshot(`
+Object {
+  "properties": Object {
+    "field1": Object {
+      "type": "number",
+    },
+    "field2": Object {
+      "type": "boolean",
+    },
+    "field3": Object {
+      "type": "number",
+    },
+    "field4": Object {
+      "type": "string",
+    },
+  },
+  "required": Array [
+    "field1",
+    "field3",
+    "field4",
+  ],
+  "type": "object",
+}
+`);
     });
 
     test("array", () => {

--- a/lib/src/generators/contract/openapi2-schema.spec.ts
+++ b/lib/src/generators/contract/openapi2-schema.spec.ts
@@ -18,20 +18,19 @@ import {
   VOID
 } from "../../models";
 import { openApi2TypeSchema } from "./openapi2-schema";
-import { jsonTypeSchema } from "./json-schema";
 
 describe("JSON Schema generator", () => {
   describe("generates type validator", () => {
     test("void", () => {
-      expect(openApi2TypeSchema(VOID)).toMatchInlineSnapshot(`null`);
+      expect(openApi2TypeSchema({}, VOID)).toMatchInlineSnapshot(`null`);
     });
 
     test("null", () => {
-      expect(openApi2TypeSchema(NULL)).toMatchInlineSnapshot(`null`);
+      expect(openApi2TypeSchema({}, NULL)).toMatchInlineSnapshot(`null`);
     });
 
     test("boolean", () => {
-      expect(openApi2TypeSchema(BOOLEAN)).toMatchInlineSnapshot(`
+      expect(openApi2TypeSchema({}, BOOLEAN)).toMatchInlineSnapshot(`
 Object {
   "type": "boolean",
 }
@@ -39,7 +38,8 @@ Object {
     });
 
     test("boolean constant", () => {
-      expect(openApi2TypeSchema(booleanConstant(true))).toMatchInlineSnapshot(`
+      expect(openApi2TypeSchema({}, booleanConstant(true)))
+        .toMatchInlineSnapshot(`
 Object {
   "enum": Array [
     true,
@@ -47,7 +47,8 @@ Object {
   "type": "boolean",
 }
 `);
-      expect(openApi2TypeSchema(booleanConstant(false))).toMatchInlineSnapshot(`
+      expect(openApi2TypeSchema({}, booleanConstant(false)))
+        .toMatchInlineSnapshot(`
 Object {
   "enum": Array [
     false,
@@ -58,7 +59,7 @@ Object {
     });
 
     test("string", () => {
-      expect(openApi2TypeSchema(STRING)).toMatchInlineSnapshot(`
+      expect(openApi2TypeSchema({}, STRING)).toMatchInlineSnapshot(`
 Object {
   "type": "string",
 }
@@ -66,7 +67,7 @@ Object {
     });
 
     test("string constant", () => {
-      expect(openApi2TypeSchema(stringConstant("some constant")))
+      expect(openApi2TypeSchema({}, stringConstant("some constant")))
         .toMatchInlineSnapshot(`
 Object {
   "enum": Array [
@@ -78,7 +79,7 @@ Object {
     });
 
     test("number", () => {
-      expect(openApi2TypeSchema(NUMBER)).toMatchInlineSnapshot(`
+      expect(openApi2TypeSchema({}, NUMBER)).toMatchInlineSnapshot(`
 Object {
   "type": "number",
 }
@@ -86,7 +87,7 @@ Object {
     });
 
     test("int32", () => {
-      expect(openApi2TypeSchema(INT32)).toMatchInlineSnapshot(`
+      expect(openApi2TypeSchema({}, INT32)).toMatchInlineSnapshot(`
 Object {
   "format": "int32",
   "type": "integer",
@@ -95,7 +96,7 @@ Object {
     });
 
     test("int64", () => {
-      expect(openApi2TypeSchema(INT64)).toMatchInlineSnapshot(`
+      expect(openApi2TypeSchema({}, INT64)).toMatchInlineSnapshot(`
 Object {
   "format": "int64",
   "type": "integer",
@@ -104,7 +105,7 @@ Object {
     });
 
     test("float", () => {
-      expect(openApi2TypeSchema(FLOAT)).toMatchInlineSnapshot(`
+      expect(openApi2TypeSchema({}, FLOAT)).toMatchInlineSnapshot(`
 Object {
   "format": "float",
   "type": "number",
@@ -113,7 +114,7 @@ Object {
     });
 
     test("double", () => {
-      expect(openApi2TypeSchema(DOUBLE)).toMatchInlineSnapshot(`
+      expect(openApi2TypeSchema({}, DOUBLE)).toMatchInlineSnapshot(`
 Object {
   "format": "double",
   "type": "number",
@@ -122,7 +123,7 @@ Object {
     });
 
     test("integer constant", () => {
-      expect(openApi2TypeSchema(integerConstant(0))).toMatchInlineSnapshot(`
+      expect(openApi2TypeSchema({}, integerConstant(0))).toMatchInlineSnapshot(`
 Object {
   "enum": Array [
     0,
@@ -130,7 +131,8 @@ Object {
   "type": "integer",
 }
 `);
-      expect(openApi2TypeSchema(integerConstant(122))).toMatchInlineSnapshot(`
+      expect(openApi2TypeSchema({}, integerConstant(122)))
+        .toMatchInlineSnapshot(`
 Object {
   "enum": Array [
     122,
@@ -138,7 +140,8 @@ Object {
   "type": "integer",
 }
 `);
-      expect(openApi2TypeSchema(integerConstant(-1000))).toMatchInlineSnapshot(`
+      expect(openApi2TypeSchema({}, integerConstant(-1000)))
+        .toMatchInlineSnapshot(`
 Object {
   "enum": Array [
     -1000,
@@ -149,7 +152,7 @@ Object {
     });
 
     test("object", () => {
-      expect(openApi2TypeSchema(objectType({}))).toMatchInlineSnapshot(`
+      expect(openApi2TypeSchema({}, objectType({}))).toMatchInlineSnapshot(`
 Object {
   "properties": Object {},
   "required": Array [],
@@ -158,6 +161,7 @@ Object {
 `);
       expect(
         openApi2TypeSchema(
+          {},
           objectType({
             singleField: NUMBER
           })
@@ -177,6 +181,7 @@ Object {
 `);
       expect(
         openApi2TypeSchema(
+          {},
           objectType({
             field1: NUMBER,
             field2: STRING,
@@ -206,7 +211,7 @@ Object {
     });
 
     test("array", () => {
-      expect(openApi2TypeSchema(arrayType(STRING))).toMatchInlineSnapshot(`
+      expect(openApi2TypeSchema({}, arrayType(STRING))).toMatchInlineSnapshot(`
 Object {
   "items": Object {
     "type": "string",
@@ -217,19 +222,19 @@ Object {
     });
 
     test("optional", () => {
-      expect(() => openApi2TypeSchema(optionalType(STRING))).toThrowError(
+      expect(() => openApi2TypeSchema({}, optionalType(STRING))).toThrowError(
         "Unsupported top-level optional type"
       );
     });
 
     test("union", () => {
       expect(() =>
-        openApi2TypeSchema(unionType(STRING, NUMBER, BOOLEAN))
+        openApi2TypeSchema({}, unionType(STRING, NUMBER, BOOLEAN))
       ).toThrowError("Unions are not supported in OpenAPI 2");
     });
 
     test("type reference", () => {
-      expect(openApi2TypeSchema(typeReference("OtherType")))
+      expect(openApi2TypeSchema({}, typeReference("OtherType")))
         .toMatchInlineSnapshot(`
 Object {
   "$ref": "#/definitions/OtherType",

--- a/lib/src/generators/contract/openapi2-schema.spec.ts
+++ b/lib/src/generators/contract/openapi2-schema.spec.ts
@@ -208,6 +208,52 @@ Object {
   "type": "object",
 }
 `);
+      expect(
+        openApi2TypeSchema(
+          {
+            extended1: objectType(
+              {
+                field2: optionalType(BOOLEAN),
+                field3: NUMBER
+              },
+              ["extended2"]
+            ),
+            extended2: objectType({
+              field1: NUMBER,
+              field2: STRING
+            })
+          },
+          objectType(
+            {
+              field4: STRING
+            },
+            ["extended1"]
+          )
+        )
+      ).toMatchInlineSnapshot(`
+Object {
+  "properties": Object {
+    "field1": Object {
+      "type": "number",
+    },
+    "field2": Object {
+      "type": "boolean",
+    },
+    "field3": Object {
+      "type": "number",
+    },
+    "field4": Object {
+      "type": "string",
+    },
+  },
+  "required": Array [
+    "field1",
+    "field3",
+    "field4",
+  ],
+  "type": "object",
+}
+`);
     });
 
     test("array", () => {

--- a/lib/src/generators/contract/openapi3-schema.spec.ts
+++ b/lib/src/generators/contract/openapi3-schema.spec.ts
@@ -253,6 +253,52 @@ Object {
   "type": "object",
 }
 `);
+      expect(
+        openApi3TypeSchema(
+          {
+            extended1: objectType(
+              {
+                field2: optionalType(BOOLEAN),
+                field3: NUMBER
+              },
+              ["extended2"]
+            ),
+            extended2: objectType({
+              field1: NUMBER,
+              field2: STRING
+            })
+          },
+          objectType(
+            {
+              field4: STRING
+            },
+            ["extended1"]
+          )
+        )
+      ).toMatchInlineSnapshot(`
+Object {
+  "properties": Object {
+    "field1": Object {
+      "type": "number",
+    },
+    "field2": Object {
+      "type": "boolean",
+    },
+    "field3": Object {
+      "type": "number",
+    },
+    "field4": Object {
+      "type": "string",
+    },
+  },
+  "required": Array [
+    "field1",
+    "field3",
+    "field4",
+  ],
+  "type": "object",
+}
+`);
     });
 
     test("array", () => {

--- a/lib/src/generators/contract/openapi3-schema.spec.ts
+++ b/lib/src/generators/contract/openapi3-schema.spec.ts
@@ -27,6 +27,7 @@ describe("JSON Schema generator", () => {
     test("application/json", () => {
       expect(
         openApiV3ContentTypeSchema(
+          {},
           "application/json",
           typeReference("OtherType")
         )
@@ -45,7 +46,7 @@ Object {
 
     test("text/html", () => {
       expect(
-        openApiV3ContentTypeSchema("text/html", typeReference("OtherType"))
+        openApiV3ContentTypeSchema({}, "text/html", typeReference("OtherType"))
       ).toMatchInlineSnapshot(`
 Object {
   "content": Object {
@@ -62,11 +63,11 @@ Object {
 
   describe("generates type validator", () => {
     test("void", () => {
-      expect(openApi3TypeSchema(VOID)).toMatchInlineSnapshot(`null`);
+      expect(openApi3TypeSchema({}, VOID)).toMatchInlineSnapshot(`null`);
     });
 
     test("null", () => {
-      expect(openApi3TypeSchema(NULL)).toMatchInlineSnapshot(`
+      expect(openApi3TypeSchema({}, NULL)).toMatchInlineSnapshot(`
 Object {
   "nullable": true,
 }
@@ -74,7 +75,7 @@ Object {
     });
 
     test("boolean", () => {
-      expect(openApi3TypeSchema(BOOLEAN)).toMatchInlineSnapshot(`
+      expect(openApi3TypeSchema({}, BOOLEAN)).toMatchInlineSnapshot(`
 Object {
   "type": "boolean",
 }
@@ -82,7 +83,8 @@ Object {
     });
 
     test("boolean constant", () => {
-      expect(openApi3TypeSchema(booleanConstant(true))).toMatchInlineSnapshot(`
+      expect(openApi3TypeSchema({}, booleanConstant(true)))
+        .toMatchInlineSnapshot(`
 Object {
   "enum": Array [
     true,
@@ -90,7 +92,8 @@ Object {
   "type": "boolean",
 }
 `);
-      expect(openApi3TypeSchema(booleanConstant(false))).toMatchInlineSnapshot(`
+      expect(openApi3TypeSchema({}, booleanConstant(false)))
+        .toMatchInlineSnapshot(`
 Object {
   "enum": Array [
     false,
@@ -101,7 +104,7 @@ Object {
     });
 
     test("string", () => {
-      expect(openApi3TypeSchema(STRING)).toMatchInlineSnapshot(`
+      expect(openApi3TypeSchema({}, STRING)).toMatchInlineSnapshot(`
 Object {
   "type": "string",
 }
@@ -109,7 +112,7 @@ Object {
     });
 
     test("string constant", () => {
-      expect(openApi3TypeSchema(stringConstant("some constant")))
+      expect(openApi3TypeSchema({}, stringConstant("some constant")))
         .toMatchInlineSnapshot(`
 Object {
   "enum": Array [
@@ -121,7 +124,7 @@ Object {
     });
 
     test("number", () => {
-      expect(openApi3TypeSchema(NUMBER)).toMatchInlineSnapshot(`
+      expect(openApi3TypeSchema({}, NUMBER)).toMatchInlineSnapshot(`
 Object {
   "type": "number",
 }
@@ -129,7 +132,7 @@ Object {
     });
 
     test("int32", () => {
-      expect(openApi3TypeSchema(INT32)).toMatchInlineSnapshot(`
+      expect(openApi3TypeSchema({}, INT32)).toMatchInlineSnapshot(`
 Object {
   "format": "int32",
   "type": "integer",
@@ -138,7 +141,7 @@ Object {
     });
 
     test("int64", () => {
-      expect(openApi3TypeSchema(INT64)).toMatchInlineSnapshot(`
+      expect(openApi3TypeSchema({}, INT64)).toMatchInlineSnapshot(`
 Object {
   "format": "int64",
   "type": "integer",
@@ -147,7 +150,7 @@ Object {
     });
 
     test("float", () => {
-      expect(openApi3TypeSchema(FLOAT)).toMatchInlineSnapshot(`
+      expect(openApi3TypeSchema({}, FLOAT)).toMatchInlineSnapshot(`
 Object {
   "format": "float",
   "type": "number",
@@ -156,7 +159,7 @@ Object {
     });
 
     test("double", () => {
-      expect(openApi3TypeSchema(DOUBLE)).toMatchInlineSnapshot(`
+      expect(openApi3TypeSchema({}, DOUBLE)).toMatchInlineSnapshot(`
 Object {
   "format": "double",
   "type": "number",
@@ -165,7 +168,7 @@ Object {
     });
 
     test("integer constant", () => {
-      expect(openApi3TypeSchema(integerConstant(0))).toMatchInlineSnapshot(`
+      expect(openApi3TypeSchema({}, integerConstant(0))).toMatchInlineSnapshot(`
 Object {
   "enum": Array [
     0,
@@ -173,7 +176,8 @@ Object {
   "type": "integer",
 }
 `);
-      expect(openApi3TypeSchema(integerConstant(123))).toMatchInlineSnapshot(`
+      expect(openApi3TypeSchema({}, integerConstant(123)))
+        .toMatchInlineSnapshot(`
 Object {
   "enum": Array [
     123,
@@ -181,7 +185,8 @@ Object {
   "type": "integer",
 }
 `);
-      expect(openApi3TypeSchema(integerConstant(-1000))).toMatchInlineSnapshot(`
+      expect(openApi3TypeSchema({}, integerConstant(-1000)))
+        .toMatchInlineSnapshot(`
 Object {
   "enum": Array [
     -1000,
@@ -192,7 +197,7 @@ Object {
     });
 
     test("object", () => {
-      expect(openApi3TypeSchema(objectType({}))).toMatchInlineSnapshot(`
+      expect(openApi3TypeSchema({}, objectType({}))).toMatchInlineSnapshot(`
 Object {
   "properties": Object {},
   "required": Array [],
@@ -201,6 +206,7 @@ Object {
 `);
       expect(
         openApi3TypeSchema(
+          {},
           objectType({
             singleField: NUMBER
           })
@@ -220,6 +226,7 @@ Object {
 `);
       expect(
         openApi3TypeSchema(
+          {},
           objectType({
             field1: NUMBER,
             field2: STRING,
@@ -249,7 +256,7 @@ Object {
     });
 
     test("array", () => {
-      expect(openApi3TypeSchema(arrayType(STRING))).toMatchInlineSnapshot(`
+      expect(openApi3TypeSchema({}, arrayType(STRING))).toMatchInlineSnapshot(`
 Object {
   "items": Object {
     "type": "string",
@@ -260,13 +267,13 @@ Object {
     });
 
     test("optional", () => {
-      expect(() => openApi3TypeSchema(optionalType(STRING))).toThrowError(
+      expect(() => openApi3TypeSchema({}, optionalType(STRING))).toThrowError(
         "Unsupported top-level optional type"
       );
     });
 
     test("union", () => {
-      expect(openApi3TypeSchema(unionType(STRING, NUMBER, BOOLEAN)))
+      expect(openApi3TypeSchema({}, unionType(STRING, NUMBER, BOOLEAN)))
         .toMatchInlineSnapshot(`
 Object {
   "oneOf": Array [
@@ -285,7 +292,7 @@ Object {
     });
 
     test("type reference", () => {
-      expect(openApi3TypeSchema(typeReference("OtherType")))
+      expect(openApi3TypeSchema({}, typeReference("OtherType")))
         .toMatchInlineSnapshot(`
 Object {
   "$ref": "#/components/schemas/OtherType",

--- a/lib/src/generators/contract/openapi3.ts
+++ b/lib/src/generators/contract/openapi3.ts
@@ -58,6 +58,7 @@ export function openApiV3(api: Api): OpenApiV3 {
               ? undefined
               : defaultTo(
                   openApiV3ContentTypeSchema(
+                    api.types,
                     defaultTo(endpoint.requestContentType, "application/json"),
                     endpoint.requestType
                   ),
@@ -94,6 +95,7 @@ export function openApiV3(api: Api): OpenApiV3 {
       schemas: Object.entries(api.types).reduce(
         (acc, [typeName, type]) => {
           acc[typeName] = rejectVoidOpenApi3SchemaType(
+            api.types,
             type,
             `Unsupported void type ${typeName}`
           );
@@ -135,6 +137,7 @@ function getParameters(api: Api, endpoint: Endpoint): OpenAPIV3Parameter[] {
               description: pathComponent.description,
               required: true,
               schema: rejectVoidOpenApi3SchemaType(
+                api.types,
                 pathComponent.type,
                 `Unsupported void type for path component ${pathComponent.name}`
               )
@@ -150,6 +153,7 @@ function getParameters(api: Api, endpoint: Endpoint): OpenAPIV3Parameter[] {
             description: queryComponent.description,
             required: queryComponent.type.kind !== "optional",
             schema: rejectVoidOpenApi3SchemaType(
+              api.types,
               queryComponent.type.kind === "optional"
                 ? queryComponent.type.optional
                 : queryComponent.type,
@@ -168,6 +172,7 @@ function getParameters(api: Api, endpoint: Endpoint): OpenAPIV3Parameter[] {
             description: header.description,
             required: header.type.kind !== "optional",
             schema: rejectVoidOpenApi3SchemaType(
+              api.types,
               header.type.kind === "optional"
                 ? header.type.optional
                 : header.type,
@@ -181,7 +186,7 @@ function getParameters(api: Api, endpoint: Endpoint): OpenAPIV3Parameter[] {
 }
 
 function response(api: Api, type: Type): OpenAPIV3Response {
-  const schemaType = openApi3TypeSchema(type);
+  const schemaType = openApi3TypeSchema(api.types, type);
   return {
     ...(schemaType
       ? {

--- a/lib/src/generators/typescript/__snapshots__/axios-client.spec.ts.snap
+++ b/lib/src/generators/typescript/__snapshots__/axios-client.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`TypeScript axios client generator produces valid code multi-file 1`] = `
 "import axios from \\"axios\\";
 
-import { CreateUserRequest, CreateUserResponse } from \\"./types\\";
+import { CreateUserRequest, CreateUserResponse, BaseError, ForbiddenError } from \\"./types\\";
 
 import * as validators from \\"./validators\\";
 
@@ -62,15 +62,10 @@ export class SpotApi {
         data: null;
     } | {
         kind: \\"unknown-error\\";
-        data: {
-            message: string;
-        };
+        data: BaseError;
     } | {
         kind: \\"forbidden\\";
-        data: {
-            message: string;
-            signedInAs: string;
-        };
+        data: ForbiddenError;
     }> {
         if (!validators.validateDeleteUser_paramUserId(userId)) {
             throw new Error(\`Invalid parameter userId: \${JSON.stringify(userId, null, 2)}\`);
@@ -211,7 +206,7 @@ export class SpotApi {
 exports[`TypeScript axios client generator produces valid code single-file 1`] = `
 "import axios from \\"axios\\";
 
-import { CreateUserRequest, CreateUserResponse } from \\"./types\\";
+import { CreateUserRequest, CreateUserResponse, BaseError, ForbiddenError } from \\"./types\\";
 
 import * as validators from \\"./validators\\";
 
@@ -359,15 +354,10 @@ export class SpotApi {
         data: null;
     } | {
         kind: \\"unknown-error\\";
-        data: {
-            message: string;
-        };
+        data: BaseError;
     } | {
         kind: \\"forbidden\\";
-        data: {
-            message: string;
-            signedInAs: string;
-        };
+        data: ForbiddenError;
     }> {
         if (!validators.validateDeleteUser_paramUserId(userId)) {
             throw new Error(\`Invalid parameter userId: \${JSON.stringify(userId, null, 2)}\`);

--- a/lib/src/generators/typescript/__snapshots__/express-server.spec.ts.snap
+++ b/lib/src/generators/typescript/__snapshots__/express-server.spec.ts.snap
@@ -17,23 +17,20 @@ export async function createUser(request: CreateUserRequest, authToken: string |
 `;
 
 exports[`TypeScript Express server generator produces valid code multi-file: endpoint:deleteUser 1`] = `
-"export async function deleteUser(userId: number, authToken: string): Promise<{
+"import { BaseError, ForbiddenError } from \\"../types\\";
+
+export async function deleteUser(userId: number, authToken: string): Promise<{
     error?: void;
     status: number;
     data: null;
 } | {
     error: \\"forbidden\\";
     status?: void;
-    data: {
-        message: string;
-        signedInAs: string;
-    };
+    data: ForbiddenError;
 } | {
     error: string;
     status?: number;
-    data: {
-        message: string;
-    };
+    data: BaseError;
 }> {
     throw new Error(\\"Endpoint deleteUser is not yet implemented!\\");
 }"
@@ -237,23 +234,20 @@ export async function createUser(request: CreateUserRequest, authToken: string |
 `;
 
 exports[`TypeScript Express server generator produces valid code single-file: endpoint:deleteUser 1`] = `
-"export async function deleteUser(userId: number, authToken: string): Promise<{
+"import { BaseError, ForbiddenError } from \\"../types\\";
+
+export async function deleteUser(userId: number, authToken: string): Promise<{
     error?: void;
     status: number;
     data: null;
 } | {
     error: \\"forbidden\\";
     status?: void;
-    data: {
-        message: string;
-        signedInAs: string;
-    };
+    data: ForbiddenError;
 } | {
     error: string;
     status?: number;
-    data: {
-        message: string;
-    };
+    data: BaseError;
 }> {
     throw new Error(\\"Endpoint deleteUser is not yet implemented!\\");
 }"

--- a/lib/src/generators/typescript/__snapshots__/types.spec.ts.snap
+++ b/lib/src/generators/typescript/__snapshots__/types.spec.ts.snap
@@ -9,6 +9,15 @@ exports[`TypeScript types generator produces valid code multi-file 1`] = `
 export type CreateUserResponse = {
     success: boolean;
     created_at: string;
+};
+
+export type BaseError = {
+    message: string;
+};
+
+export type ForbiddenError = {
+    message: string;
+    signedInAs: string;
 };"
 `;
 
@@ -21,5 +30,14 @@ exports[`TypeScript types generator produces valid code single-file 1`] = `
 export type CreateUserResponse = {
     success: boolean;
     created_at: string;
+};
+
+export type BaseError = {
+    message: string;
+};
+
+export type ForbiddenError = {
+    message: string;
+    signedInAs: string;
 };"
 `;

--- a/lib/src/generators/typescript/__snapshots__/validators.spec.ts.snap
+++ b/lib/src/generators/typescript/__snapshots__/validators.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TypeScript validators generator produces valid code multi-file 1`] = `
-"import { CreateUserRequest, CreateUserResponse } from \\"./types\\";
+"import { CreateUserRequest, CreateUserResponse, BaseError, ForbiddenError } from \\"./types\\";
 
 export function validateCreateUser_request(value: any): value is CreateUserRequest {
     return validateCreateUserRequest(value);
@@ -35,17 +35,12 @@ export function validateDeleteUser_response(value: any): value is null {
     return value === null;
 }
 
-export function validateDeleteUser_genericError(value: any): value is {
-    message: string;
-} {
-    return !(value === null) && typeof value === \\"object\\" && typeof value[\\"message\\"] === \\"string\\";
+export function validateDeleteUser_genericError(value: any): value is BaseError {
+    return validateBaseError(value);
 }
 
-export function validateDeleteUser_specificErrorForbidden(value: any): value is {
-    message: string;
-    signedInAs: string;
-} {
-    return !(value === null) && typeof value === \\"object\\" && typeof value[\\"message\\"] === \\"string\\" && typeof value[\\"signedInAs\\"] === \\"string\\";
+export function validateDeleteUser_specificErrorForbidden(value: any): value is ForbiddenError {
+    return validateForbiddenError(value);
 }
 
 export function validateFindUsers_request(value: any): value is void {
@@ -96,11 +91,19 @@ export function validateCreateUserRequest(value: any): value is CreateUserReques
 
 export function validateCreateUserResponse(value: any): value is CreateUserResponse {
     return !(value === null) && typeof value === \\"object\\" && typeof value[\\"success\\"] === \\"boolean\\" && typeof value[\\"created_at\\"] === \\"string\\";
+}
+
+export function validateBaseError(value: any): value is BaseError {
+    return !(value === null) && typeof value === \\"object\\" && typeof value[\\"message\\"] === \\"string\\";
+}
+
+export function validateForbiddenError(value: any): value is ForbiddenError {
+    return !(value === null) && typeof value === \\"object\\" && typeof value[\\"message\\"] === \\"string\\" && typeof value[\\"signedInAs\\"] === \\"string\\";
 }"
 `;
 
 exports[`TypeScript validators generator produces valid code single-file 1`] = `
-"import { CreateUserRequest, CreateUserResponse } from \\"./types\\";
+"import { CreateUserRequest, CreateUserResponse, BaseError, ForbiddenError } from \\"./types\\";
 
 export function validateCreateUser_request(value: any): value is CreateUserRequest {
     return validateCreateUserRequest(value);
@@ -176,17 +179,12 @@ export function validateDeleteUser_response(value: any): value is null {
     return value === null;
 }
 
-export function validateDeleteUser_genericError(value: any): value is {
-    message: string;
-} {
-    return !(value === null) && typeof value === \\"object\\" && typeof value[\\"message\\"] === \\"string\\";
+export function validateDeleteUser_genericError(value: any): value is BaseError {
+    return validateBaseError(value);
 }
 
-export function validateDeleteUser_specificErrorForbidden(value: any): value is {
-    message: string;
-    signedInAs: string;
-} {
-    return !(value === null) && typeof value === \\"object\\" && typeof value[\\"message\\"] === \\"string\\" && typeof value[\\"signedInAs\\"] === \\"string\\";
+export function validateDeleteUser_specificErrorForbidden(value: any): value is ForbiddenError {
+    return validateForbiddenError(value);
 }
 
 export function validateCreateUserRequest(value: any): value is CreateUserRequest {
@@ -195,5 +193,13 @@ export function validateCreateUserRequest(value: any): value is CreateUserReques
 
 export function validateCreateUserResponse(value: any): value is CreateUserResponse {
     return !(value === null) && typeof value === \\"object\\" && typeof value[\\"success\\"] === \\"boolean\\" && typeof value[\\"created_at\\"] === \\"string\\";
+}
+
+export function validateBaseError(value: any): value is BaseError {
+    return !(value === null) && typeof value === \\"object\\" && typeof value[\\"message\\"] === \\"string\\";
+}
+
+export function validateForbiddenError(value: any): value is ForbiddenError {
+    return !(value === null) && typeof value === \\"object\\" && typeof value[\\"message\\"] === \\"string\\" && typeof value[\\"signedInAs\\"] === \\"string\\";
 }"
 `;

--- a/lib/src/generators/typescript/axios-client.ts
+++ b/lib/src/generators/typescript/axios-client.ts
@@ -151,7 +151,7 @@ function generateEndpointMethod(
               /*dotDotDotToken*/ undefined,
               REQUEST_PARAMETER,
               /*questionToken*/ undefined,
-              typeNode(endpoint.requestType)
+              typeNode(api.types, endpoint.requestType)
             )
           ]
         : []),
@@ -165,7 +165,7 @@ function generateEndpointMethod(
                   /*dotDotDotToken*/ undefined,
                   pathComponent.name,
                   /*questionToken*/ undefined,
-                  typeNode(pathComponent.type)
+                  typeNode(api.types, pathComponent.type)
                 )
               : null
         )
@@ -177,7 +177,7 @@ function generateEndpointMethod(
           /*dotDotDotToken*/ undefined,
           headerName,
           /*questionToken*/ undefined,
-          typeNode(header.type)
+          typeNode(api.types, header.type)
         )
       ),
       ...endpoint.queryParams.map(queryParam =>
@@ -187,11 +187,11 @@ function generateEndpointMethod(
           /*dotDotDotToken*/ undefined,
           queryParam.name,
           /*questionToken*/ undefined,
-          typeNode(queryParam.type)
+          typeNode(api.types, queryParam.type)
         )
       )
     ],
-    promiseTypeNode(unionType(...generateReturnTypes(endpoint))),
+    promiseTypeNode(api.types, unionType(...generateReturnTypes(endpoint))),
     generateEndpointBody(endpointName, endpoint, includeRequest)
   );
 }

--- a/lib/src/generators/typescript/express-server.ts
+++ b/lib/src/generators/typescript/express-server.ts
@@ -618,7 +618,7 @@ export function generateEndpointHandlerSource(
                 /*dotDotDotToken*/ undefined,
                 ts.createIdentifier("request"),
                 /*questionToken*/ undefined,
-                typeNode(endpoint.requestType)
+                typeNode(api.types, endpoint.requestType)
               )
             ]),
         ...compact(
@@ -631,7 +631,7 @@ export function generateEndpointHandlerSource(
                     /*dotDotDotToken*/ undefined,
                     ts.createIdentifier(pathComponent.name),
                     /*questionToken*/ undefined,
-                    typeNode(pathComponent.type)
+                    typeNode(api.types, pathComponent.type)
                   )
                 : null
           )
@@ -643,11 +643,12 @@ export function generateEndpointHandlerSource(
             /*dotDotDotToken*/ undefined,
             ts.createIdentifier(headerName),
             /*questionToken*/ undefined,
-            typeNode(header.type)
+            typeNode(api.types, header.type)
           )
         )
       ],
       promiseTypeNode(
+        api.types,
         unionType(
           ...[
             objectType({

--- a/lib/src/generators/typescript/types.spec.ts
+++ b/lib/src/generators/typescript/types.spec.ts
@@ -288,6 +288,52 @@ describe("TypeScript types generator", () => {
     field3?: boolean;
 };"
 `);
+      expect(
+        generateTypesSource({
+          endpoints: {},
+          types: {
+            Example: objectType(
+              {
+                field4: STRING
+              },
+              ["extended1"]
+            ),
+            extended1: objectType(
+              {
+                field2: optionalType(BOOLEAN),
+                field3: NUMBER
+              },
+              ["extended2"]
+            ),
+            extended2: objectType({
+              field1: NUMBER,
+              field2: STRING
+            })
+          },
+          description: {
+            name: "name",
+            description: "description"
+          }
+        })
+      ).toMatchInlineSnapshot(`
+"export type Example = {
+    field1: number;
+    field2?: boolean;
+    field3: number;
+    field4: string;
+};
+
+export type extended1 = {
+    field1: number;
+    field2?: boolean;
+    field3: number;
+};
+
+export type extended2 = {
+    field1: number;
+    field2: string;
+};"
+`);
     });
 
     test("array", () => {

--- a/lib/src/generators/typescript/validators.spec.ts
+++ b/lib/src/generators/typescript/validators.spec.ts
@@ -382,6 +382,48 @@ export function validateExample(value: any): value is Example {
     return !(value === null) && typeof value === \\"object\\" && typeof value[\\"field1\\"] === \\"number\\" && typeof value[\\"field2\\"] === \\"string\\" && typeof value[\\"field3\\"] === \\"boolean\\";
 }"
 `);
+      expect(
+        generateValidatorsSource({
+          endpoints: {},
+          types: {
+            Example: objectType(
+              {
+                field4: STRING
+              },
+              ["extended1"]
+            ),
+            extended1: objectType(
+              {
+                field2: optionalType(BOOLEAN),
+                field3: NUMBER
+              },
+              ["extended2"]
+            ),
+            extended2: objectType({
+              field1: NUMBER,
+              field2: STRING
+            })
+          },
+          description: {
+            name: "name",
+            description: "description"
+          }
+        })
+      ).toMatchInlineSnapshot(`
+"import { Example, extended1, extended2 } from \\"./types\\";
+
+export function validateExample(value: any): value is Example {
+    return !(value === null) && typeof value === \\"object\\" && typeof value[\\"field1\\"] === \\"number\\" && (value[\\"field2\\"] === undefined || typeof value[\\"field2\\"] === \\"boolean\\") && typeof value[\\"field3\\"] === \\"number\\" && typeof value[\\"field4\\"] === \\"string\\";
+}
+
+export function validateExtended1(value: any): value is extended1 {
+    return !(value === null) && typeof value === \\"object\\" && typeof value[\\"field1\\"] === \\"number\\" && (value[\\"field2\\"] === undefined || typeof value[\\"field2\\"] === \\"boolean\\") && typeof value[\\"field3\\"] === \\"number\\";
+}
+
+export function validateExtended2(value: any): value is extended2 {
+    return !(value === null) && typeof value === \\"object\\" && typeof value[\\"field1\\"] === \\"number\\" && typeof value[\\"field2\\"] === \\"string\\";
+}"
+`);
     });
 
     test("array", () => {

--- a/lib/src/parsing/type-parser.ts
+++ b/lib/src/parsing/type-parser.ts
@@ -121,6 +121,19 @@ export function extractObjectType(
   sourceFile: ts.SourceFile,
   declaration: ts.TypeLiteralNode | ts.InterfaceDeclaration
 ): ObjectType {
+  const extendsTypeNames = [];
+  if (ts.isInterfaceDeclaration(declaration)) {
+    for (const heritageClause of declaration.heritageClauses || []) {
+      for (const type of heritageClause.types) {
+        if (
+          ts.isExpressionWithTypeArguments(type) &&
+          ts.isIdentifier(type.expression)
+        ) {
+          extendsTypeNames.push(type.expression.getText(sourceFile));
+        }
+      }
+    }
+  }
   const properties: {
     [key: string]: Type;
   } = {};
@@ -143,7 +156,7 @@ export function extractObjectType(
     }
     properties[member.name.getText(sourceFile)] = type;
   }
-  return objectType(properties);
+  return objectType(properties, extendsTypeNames);
 }
 
 export function extractArrayType(

--- a/lib/src/validator.ts
+++ b/lib/src/validator.ts
@@ -112,6 +112,9 @@ function validateType(api: Api, type: Type, errors: ErrorMessage[]): void {
       for (const property of Object.values(type.properties)) {
         validateType(api, property, errors);
       }
+      for (const extended of Object.values(type.extends)) {
+        validateType(api, extended, errors);
+      }
       break;
     case "array":
       validateType(api, type.elements, errors);


### PR DESCRIPTION
This adds support for extending interfaces.

For example:
```typescript
export interface BaseError {
  message: string;
}

export interface ForbiddenError extends BaseError {
  signedInAs: string;
}
```