### PR TITLE
Update TypeScript to 3.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lodash": "^4.17.11",
     "randomstring": "^1.1.5",
     "tslib": "^1",
-    "typescript": "^3.1.3"
+    "typescript": "^3.2.2"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -58,11 +58,6 @@
     "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
-  "references": [
-    {
-      "path": "./cli"
-    }
-  ],
   "exclude": [
     "build",
     "index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4639,10 +4639,10 @@ type-is@~1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
-typescript@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.3.tgz#01b70247a6d3c2467f70c45795ef5ea18ce191d5"
-  integrity sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==
+typescript@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
+  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
This also fixes up the root `tsconfig.json`, which was otherwise resulting in duplicate JS files and breaking the `yarn pack` incantation.