### PR TITLE
Parse request path into a structured list and make RequestNode required

### DIFF
--- a/lib/src/assert-never.ts
+++ b/lib/src/assert-never.ts
@@ -1,7 +1,0 @@
-// Equivalent to https://github.com/aikoven/assert-never.
-// Unfortunately importing it from node_modules causes issues.
-export default function assertNever(value: never): never {
-  throw new Error(
-    `Unhandled discriminated union member: ${JSON.stringify(value)}`
-  );
-}

--- a/lib/src/generators/contract/json-schema.ts
+++ b/lib/src/generators/contract/json-schema.ts
@@ -1,5 +1,5 @@
+import assertNever from "assert-never";
 import * as YAML from "js-yaml";
-import assertNever from "../../assert-never";
 import { Api, normalizedObjectType, Type, Types } from "../../models";
 import compact = require("lodash/compact");
 

--- a/lib/src/generators/contract/openapi2-schema.ts
+++ b/lib/src/generators/contract/openapi2-schema.ts
@@ -1,4 +1,4 @@
-import assertNever from "../../assert-never";
+import assertNever from "assert-never";
 import { normalizedObjectType, Type, Types } from "../../models";
 import compact = require("lodash/compact");
 

--- a/lib/src/generators/contract/openapi2.ts
+++ b/lib/src/generators/contract/openapi2.ts
@@ -1,6 +1,6 @@
 import { HttpContentType } from "@airtasker/spot";
+import assertNever from "assert-never";
 import * as YAML from "js-yaml";
-import assertNever from "../../assert-never";
 import { Api, Endpoint, Type } from "../../models";
 import { isVoid } from "../../validator";
 import {

--- a/lib/src/generators/contract/openapi3-schema.ts
+++ b/lib/src/generators/contract/openapi3-schema.ts
@@ -1,5 +1,5 @@
 import { HttpContentType } from "@airtasker/spot";
-import assertNever from "../../assert-never";
+import assertNever from "assert-never";
 import { normalizedObjectType, Type, Types } from "../../models";
 import compact = require("lodash/compact");
 

--- a/lib/src/generators/contract/openapi3.ts
+++ b/lib/src/generators/contract/openapi3.ts
@@ -1,5 +1,5 @@
+import assertNever from "assert-never";
 import * as YAML from "js-yaml";
-import assertNever from "../../assert-never";
 import { Api, Endpoint, Type } from "../../models";
 import { isVoid } from "../../validator";
 import {

--- a/lib/src/generators/typescript/axios-client.ts
+++ b/lib/src/generators/typescript/axios-client.ts
@@ -1,5 +1,5 @@
+import assertNever from "assert-never";
 import * as ts from "typescript";
-import assertNever from "../../assert-never";
 import {
   Api,
   DynamicPathComponent,

--- a/lib/src/generators/typescript/types.ts
+++ b/lib/src/generators/typescript/types.ts
@@ -1,5 +1,5 @@
+import assertNever from "assert-never";
 import * as ts from "typescript";
-import assertNever from "../../assert-never";
 import {
   Api,
   ArrayType,

--- a/lib/src/generators/typescript/validators.ts
+++ b/lib/src/generators/typescript/validators.ts
@@ -1,5 +1,5 @@
+import assertNever from "assert-never";
 import * as ts from "typescript";
-import assertNever from "../../assert-never";
 import {
   Api,
   ArrayType,

--- a/lib/src/mockserver/dummy.ts
+++ b/lib/src/mockserver/dummy.ts
@@ -1,5 +1,5 @@
+import assertNever from "assert-never";
 import { generate as generateRandomString } from "randomstring";
-import assertNever from "../assert-never";
 import { normalizedObjectType, Type, Types } from "../models";
 
 /**

--- a/lib/src/mockserver/matcher.ts
+++ b/lib/src/mockserver/matcher.ts
@@ -1,4 +1,4 @@
-import assertNever from "../assert-never";
+import assertNever from "assert-never";
 import { Endpoint } from "../models";
 
 /**

--- a/lib/src/validator.ts
+++ b/lib/src/validator.ts
@@ -1,4 +1,4 @@
-import assertNever from "./assert-never";
+import assertNever from "assert-never";
 import { Api, Type, VOID } from "./models";
 import uniq = require("lodash/uniq");
 

--- a/libnext/src/models/nodes.ts
+++ b/libnext/src/models/nodes.ts
@@ -22,10 +22,22 @@ export interface EndpointNode {
   name: string;
   description?: string;
   method: HttpMethod;
-  path: string;
-  request?: RequestNode;
+  path: PathComponent[];
+  request: RequestNode;
   responses: ResponseNode[];
   defaultResponse?: DefaultResponseNode;
+}
+
+export type PathComponent = StaticPathComponent | DynamicPathComponent;
+
+export interface StaticPathComponent {
+  kind: "static";
+  content: string;
+}
+
+export interface DynamicPathComponent {
+  kind: "dynamic";
+  paramName: string;
 }
 
 export interface RequestNode {

--- a/libnext/src/parsers/nodes/endpoint-parser.spec.ts
+++ b/libnext/src/parsers/nodes/endpoint-parser.spec.ts
@@ -42,7 +42,16 @@ describe("@endpoint parser", () => {
     expect(result.description).toEqual("endpoint description");
     expect(result.method).toEqual("PUT");
     expect(result.name).toEqual("TestEndpoint");
-    expect(result.path).toEqual("/users/:id");
+    expect(result.path).toEqual([
+      {
+        content: "/users/",
+        kind: "static"
+      },
+      {
+        kind: "dynamic",
+        paramName: "id"
+      }
+    ]);
     expect(result.request).not.toBeUndefined;
     expect(result.responses).toHaveLength(2);
     expect(result.defaultResponse).not.toBeUndefined;

--- a/libnext/src/parsers/nodes/endpoint-parser.ts
+++ b/libnext/src/parsers/nodes/endpoint-parser.ts
@@ -1,7 +1,17 @@
 import { ClassDeclaration, ObjectLiteralExpression } from "ts-simple-ast";
 import { HttpMethod } from "../../models/http";
-import { DynamicPathComponent, EndpointNode, PathComponent } from "../../models/nodes";
-import { classMethodWithDecorator, extractDecoratorFactoryConfiguration, extractJsDocComment, extractStringProperty, isHttpMethod } from "../utilities/parser-utility";
+import {
+  DynamicPathComponent,
+  EndpointNode,
+  PathComponent
+} from "../../models/nodes";
+import {
+  classMethodWithDecorator,
+  extractDecoratorFactoryConfiguration,
+  extractJsDocComment,
+  extractStringProperty,
+  isHttpMethod
+} from "../utilities/parser-utility";
 import { parseDefaultResponse } from "./default-response-parser";
 import { parseRequest } from "./request-parser";
 import { parseResponse } from "./response-parser";
@@ -19,11 +29,13 @@ export function parseEndpoint(klass: ClassDeclaration): EndpointNode {
   const name = klass.getNameOrThrow();
   const path = extractPathProperty(configuration, "path");
   const requestMethod = classMethodWithDecorator(klass, "request");
-  const request = requestMethod ? parseRequest(requestMethod) : {
-    headers: [],
-    pathParams: [],
-    queryParams: []
-  };
+  const request = requestMethod
+    ? parseRequest(requestMethod)
+    : {
+        headers: [],
+        pathParams: [],
+        queryParams: []
+      };
   const responses = klass
     .getMethods()
     .filter(klassMethod => klassMethod.getDecorator("response") !== undefined)
@@ -70,7 +82,7 @@ function extractHttpMethodProperty(
 
 /**
  * Extract a list of path components from a string path.
- * 
+ *
  * An example of valid path is "/users/:id".
  *
  * @param objectLiteral an object literal
@@ -78,9 +90,10 @@ function extractHttpMethodProperty(
  */
 function extractPathProperty(
   objectLiteral: ObjectLiteralExpression,
-  propertyName: string): PathComponent[] {
-    const stringPath = extractStringProperty(objectLiteral, propertyName);
-    const pathComponents: PathComponent[] = [];
+  propertyName: string
+): PathComponent[] {
+  const stringPath = extractStringProperty(objectLiteral, propertyName);
+  const pathComponents: PathComponent[] = [];
   if (stringPath.length > 0) {
     let componentStartPosition = 0;
     do {
@@ -96,7 +109,7 @@ function extractPathProperty(
             nextNonNamePositionRelative === -1
               ? undefined
               : nextNonNamePositionRelative
-          ),
+          )
         };
         pathComponents.push(dynamicPathComponent);
         componentStartPosition =
@@ -105,7 +118,10 @@ function extractPathProperty(
             : componentStartPosition + 1 + nextNonNamePositionRelative;
       } else {
         // The static component extends until the next parameter, which starts with ":".
-        const nextColumnPosition = stringPath.indexOf(":", componentStartPosition);
+        const nextColumnPosition = stringPath.indexOf(
+          ":",
+          componentStartPosition
+        );
         pathComponents.push({
           kind: "static",
           content: stringPath.substring(

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/cors": "^2.8.4",
     "@types/express": "^4.16.0",
     "@types/randomstring": "^1.1.6",
+    "assert-never": "^1.1.0",
     "cors": "^2.8.5",
     "express": "^4.16.4",
     "fs-extra": "^7.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -59,5 +59,6 @@
     "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
+  "include": ["node_modules/assert-never"],
   "exclude": ["build", "index.d.ts", "**/*.spec.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -540,6 +540,11 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
+assert-never@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assert-never/-/assert-never-1.1.0.tgz#e7ac87d6d0191f19f19694c1266a2dd5c9e3becb"
+  integrity sha512-2UWrFcOh9vapYO4Me26dZWgFK4x0F9cyVR17v/hkf/J6z6RtZGKFWzmWMg65+9fQLpAv0o7wx+U8b3DFLSh1rw==
+
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"


### PR DESCRIPTION
This will make it a lot easier to write generators based on the internal data models.