### PR TITLE
Always provide a RequestNode in EndpointNode

### DIFF
--- a/libnext/src/models/nodes.ts
+++ b/libnext/src/models/nodes.ts
@@ -23,7 +23,7 @@ export interface EndpointNode {
   description?: string;
   method: HttpMethod;
   path: string;
-  request?: RequestNode;
+  request: RequestNode;
   responses: ResponseNode[];
   defaultResponse?: DefaultResponseNode;
 }

--- a/libnext/src/parsers/nodes/endpoint-parser.ts
+++ b/libnext/src/parsers/nodes/endpoint-parser.ts
@@ -25,7 +25,13 @@ export function parseEndpoint(klass: ClassDeclaration): EndpointNode {
   const name = klass.getNameOrThrow();
   const path = extractStringProperty(configuration, "path");
   const requestMethod = classMethodWithDecorator(klass, "request");
-  const request = requestMethod ? parseRequest(requestMethod) : undefined;
+  const request = requestMethod
+    ? parseRequest(requestMethod)
+    : {
+        headers: [],
+        pathParams: [],
+        queryParams: []
+      };
   const responses = klass
     .getMethods()
     .filter(klassMethod => klassMethod.getDecorator("response") !== undefined)


### PR DESCRIPTION
This means there's now only one way of describing an endpoint without any request information, instead of two.