### PR TITLE
Only allow HttpMethod for endpoint methods

### DIFF
--- a/lib/src/syntax/endpoint.ts
+++ b/lib/src/syntax/endpoint.ts
@@ -1,3 +1,5 @@
+import { HttpMethod } from "../models/http";
+
 /**
  * Endpoint decorator factory for describing an API.
  *
@@ -19,7 +21,7 @@ export function endpoint(config: EndpointConfig) {
 }
 interface EndpointConfig {
   /** HTTP method */
-  method: string;
+  method: HttpMethod;
   /** URL path */
   path: string;
   /** Endpoint grouping tags */


### PR DESCRIPTION
This will provide feedback earlier to developers when they use an incorrect method (or the wrong spelling, e.g. lowercase).