### PR TITLE
Add @securityHeader decorator used to indicate the global authentication header

### DIFF
--- a/lib/src/cleansers/nodes/api-cleanser.ts
+++ b/lib/src/cleansers/nodes/api-cleanser.ts
@@ -1,9 +1,13 @@
 import { ApiDefinition } from "../../models/definitions";
 import { ApiNode } from "../../models/nodes";
+import { cleanseSecurityHeader } from "./security-header-cleanser";
 
 export function cleanseApi(apiNode: ApiNode): ApiDefinition {
   const name = apiNode.name.value;
   const description = apiNode.description && apiNode.description.value;
+  const securityHeader =
+    apiNode.securityHeader &&
+    cleanseSecurityHeader(apiNode.securityHeader.value);
 
-  return { name, description };
+  return { name, description, securityHeader };
 }

--- a/lib/src/cleansers/nodes/security-header-cleanser.ts
+++ b/lib/src/cleansers/nodes/security-header-cleanser.ts
@@ -1,0 +1,12 @@
+import { SecurityHeaderDefinition } from "../../models/definitions";
+import { SecurityHeaderNode } from "../../models/nodes";
+
+export function cleanseSecurityHeader(
+  securityHeaderNode: SecurityHeaderNode
+): SecurityHeaderDefinition {
+  const name = securityHeaderNode.name.value;
+  const description =
+    securityHeaderNode.description && securityHeaderNode.description.value;
+  const type = securityHeaderNode.type;
+  return { name, description, type };
+}

--- a/lib/src/generators/contract/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/openapi2.spec.ts.snap
@@ -265,9 +265,11 @@ exports[`OpenAPI 2 generator produces valid code: json 1`] = `
       \\"name\\": \\"x-auth-token\\"
     }
   },
-  \\"security\\": {
-    \\"securityHeader\\": []
-  }
+  \\"security\\": [
+    {
+      \\"securityHeader\\": []
+    }
+  ]
 }"
 `;
 
@@ -452,6 +454,6 @@ securityDefinitions:
     in: header
     name: x-auth-token
 security:
-  securityHeader: []
+  - securityHeader: []
 "
 `;

--- a/lib/src/generators/contract/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/openapi2.spec.ts.snap
@@ -257,6 +257,16 @@ exports[`OpenAPI 2 generator produces valid code: json 1`] = `
     \\"Address\\": {
       \\"type\\": \\"string\\"
     }
+  },
+  \\"securityDefinitions\\": {
+    \\"securityHeader\\": {
+      \\"type\\": \\"apiKey\\",
+      \\"in\\": \\"header\\",
+      \\"name\\": \\"x-auth-token\\"
+    }
+  },
+  \\"security\\": {
+    \\"securityHeader\\": []
   }
 }"
 `;
@@ -436,5 +446,12 @@ definitions:
     type: string
   Address:
     type: string
+securityDefinitions:
+  securityHeader:
+    type: apiKey
+    in: header
+    name: x-auth-token
+security:
+  securityHeader: []
 "
 `;

--- a/lib/src/generators/contract/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/openapi3.spec.ts.snap
@@ -11,9 +11,11 @@ exports[`OpenAPI 3 generator produces valid code: json 1`] = `
       \\"name\\": \\"TODO\\"
     }
   },
-  \\"security\\": {
-    \\"securityHeader\\": []
-  },
+  \\"security\\": [
+    {
+      \\"securityHeader\\": []
+    }
+  ],
   \\"paths\\": {
     \\"/company/{companyId}/users/{userId}\\": {
       \\"post\\": {
@@ -323,7 +325,7 @@ info:
   contact:
     name: TODO
 security:
-  securityHeader: []
+  - securityHeader: []
 paths:
   '/company/{companyId}/users/{userId}':
     post:

--- a/lib/src/generators/contract/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/openapi3.spec.ts.snap
@@ -11,6 +11,9 @@ exports[`OpenAPI 3 generator produces valid code: json 1`] = `
       \\"name\\": \\"TODO\\"
     }
   },
+  \\"security\\": {
+    \\"securityHeader\\": []
+  },
   \\"paths\\": {
     \\"/company/{companyId}/users/{userId}\\": {
       \\"post\\": {
@@ -299,6 +302,13 @@ exports[`OpenAPI 3 generator produces valid code: json 1`] = `
       \\"Address\\": {
         \\"type\\": \\"string\\"
       }
+    },
+    \\"securitySchemes\\": {
+      \\"securityHeader\\": {
+        \\"type\\": \\"apiKey\\",
+        \\"in\\": \\"header\\",
+        \\"name\\": \\"x-auth-token\\"
+      }
     }
   }
 }"
@@ -312,6 +322,8 @@ info:
   description: This is the company API. It does cool things
   contact:
     name: TODO
+security:
+  securityHeader: []
 paths:
   '/company/{companyId}/users/{userId}':
     post:
@@ -501,5 +513,10 @@ components:
       type: string
     Address:
       type: string
+  securitySchemes:
+    securityHeader:
+      type: apiKey
+      in: header
+      name: x-auth-token
 "
 `;

--- a/lib/src/generators/contract/openapi2.ts
+++ b/lib/src/generators/contract/openapi2.ts
@@ -89,9 +89,11 @@ export function openApiV2(contractDefinition: ContractDefinition): OpenApiV2 {
               description: contractDefinition.api.securityHeader.description
             }
           },
-          security: {
-            [SECURITY_HEADER_SCHEME_NAME]: []
-          }
+          security: [
+            {
+              [SECURITY_HEADER_SCHEME_NAME]: []
+            }
+          ]
         }
       : {})
   };
@@ -211,7 +213,7 @@ export interface OpenApiV2 {
   };
   security?: {
     [securitySchemeName: string]: string[];
-  };
+  }[];
 }
 
 export interface OpenAPIV2TagObject {

--- a/lib/src/generators/contract/openapi2.ts
+++ b/lib/src/generators/contract/openapi2.ts
@@ -14,6 +14,8 @@ import {
   openApi2TypeSchema
 } from "./openapi2-schema";
 
+const SECURITY_HEADER_SCHEME_NAME = "securityHeader";
+
 export function generateOpenApiV2(
   contractDefinition: ContractDefinition,
   format: "json" | "yaml"
@@ -76,7 +78,22 @@ export function openApiV2(contractDefinition: ContractDefinition): OpenApiV2 {
     }>((acc, typeNode) => {
       acc[typeNode.name] = openApi2TypeSchema(typeNode.type);
       return acc;
-    }, {})
+    }, {}),
+    ...(contractDefinition.api.securityHeader
+      ? {
+          securityDefinitions: {
+            [SECURITY_HEADER_SCHEME_NAME]: {
+              type: "apiKey",
+              in: "header",
+              name: contractDefinition.api.securityHeader.name,
+              description: contractDefinition.api.securityHeader.description
+            }
+          },
+          security: {
+            [SECURITY_HEADER_SCHEME_NAME]: []
+          }
+        }
+      : {})
   };
 }
 
@@ -189,6 +206,12 @@ export interface OpenApiV2 {
   definitions: {
     [typeName: string]: OpenAPI2SchemaType;
   };
+  securityDefinitions?: {
+    [securitySchemeName: string]: OpenAPIV2SecurityScheme;
+  };
+  security?: {
+    [securitySchemeName: string]: string[];
+  };
 }
 
 export interface OpenAPIV2TagObject {
@@ -239,3 +262,13 @@ export interface OpenAPIV2Response {
 export type OpenAPIV2Header = {
   description?: string;
 } & OpenAPI2SchemaType;
+
+// TODO: Consider adding support for other security schemes.
+export type OpenAPIV2SecurityScheme = OpenApiV2SecurityScheme_ApiKey;
+
+export interface OpenApiV2SecurityScheme_ApiKey {
+  type: "apiKey";
+  description?: string;
+  name: string;
+  in: "query" | "header";
+}

--- a/lib/src/generators/contract/openapi3.ts
+++ b/lib/src/generators/contract/openapi3.ts
@@ -41,9 +41,11 @@ export function openApiV3(contractDefinition: ContractDefinition): OpenApiV3 {
     },
     ...(contractDefinition.api.securityHeader
       ? {
-          security: {
-            [SECURITY_HEADER_SCHEME_NAME]: []
-          }
+          security: [
+            {
+              [SECURITY_HEADER_SCHEME_NAME]: []
+            }
+          ]
         }
       : {}),
     paths: contractDefinition.endpoints.reduce(
@@ -212,7 +214,7 @@ export interface OpenApiV3 {
   }[];
   security?: {
     [securitySchemeName: string]: string[];
-  };
+  }[];
   paths: {
     [endpointPath: string]: {
       [method: string]: OpenAPIV3Operation;

--- a/lib/src/models/definitions.ts
+++ b/lib/src/models/definitions.ts
@@ -16,6 +16,13 @@ export interface TypeDefinition {
 export interface ApiDefinition {
   name: string;
   description?: string;
+  securityHeader?: SecurityHeaderDefinition;
+}
+
+export interface SecurityHeaderDefinition {
+  name: string;
+  description?: string;
+  type: DataType;
 }
 
 export interface EndpointDefinition {

--- a/lib/src/models/nodes.ts
+++ b/lib/src/models/nodes.ts
@@ -1,6 +1,6 @@
 import { HttpMethod } from "./http";
-import { DataType } from "./types";
 import { Locatable } from "./locatable";
+import { DataType } from "./types";
 
 export interface ContractNode {
   api: Locatable<ApiNode>;
@@ -17,6 +17,13 @@ export interface TypeNode {
 export interface ApiNode {
   name: Locatable<string>;
   description?: Locatable<string>;
+  securityHeader?: Locatable<SecurityHeaderNode>;
+}
+
+export interface SecurityHeaderNode {
+  name: Locatable<string>;
+  description?: Locatable<string>;
+  type: DataType;
 }
 
 export interface EndpointNode {

--- a/lib/src/parsers/nodes/api-parser.spec.ts
+++ b/lib/src/parsers/nodes/api-parser.spec.ts
@@ -1,14 +1,18 @@
+import { TypeKind } from "../../models/types";
 import { createSourceFile } from "../../test/helper";
 import { parseApi } from "./api-parser";
 
 describe("@api parser", () => {
   test("parses all information", () => {
     const content = `
-      import { api } from "@airtasker/spot"
+      import { api, securityHeader } from "@airtasker/spot"
 
       /** api description */
       @api({ name: "My API" })
-      class MyApi {}
+      class MyApi {
+        @securityHeader
+        'x-auth-token'?: string;
+      }
     `;
     const sourceFile = createSourceFile({
       path: "main",
@@ -27,6 +31,21 @@ describe("@api parser", () => {
           value: "api description",
           location: expect.stringMatching(/main\.ts$/),
           line: 3
+        },
+        securityHeader: {
+          value: {
+            name: {
+              value: "x-auth-token",
+              location: expect.stringMatching(/main\.ts$/),
+              line: 7
+            },
+            description: undefined,
+            type: {
+              kind: TypeKind.STRING
+            }
+          },
+          location: expect.stringMatching(/main\.ts$/),
+          line: 6
         }
       },
       location: expect.stringMatching(/main\.ts$/),
@@ -54,7 +73,8 @@ describe("@api parser", () => {
           location: expect.stringMatching(/main\.ts$/),
           line: 3
         },
-        description: undefined
+        description: undefined,
+        securityHeader: undefined
       },
       location: expect.stringMatching(/main\.ts$/),
       line: 3

--- a/lib/src/parsers/nodes/api-parser.ts
+++ b/lib/src/parsers/nodes/api-parser.ts
@@ -2,10 +2,12 @@ import { ClassDeclaration } from "ts-simple-ast";
 import { Locatable } from "../../models/locatable";
 import { ApiNode } from "../../models/nodes";
 import {
+  classPropertyWithDecorator,
   extractDecoratorFactoryConfiguration,
   extractJsDocCommentLocatable,
   extractStringPropertyValueLocatable
 } from "../utilities/parser-utility";
+import { parseSecurityHeader } from "./security-header-parser";
 
 /**
  * Parse an `@api` decorated class.
@@ -17,11 +19,17 @@ export function parseApi(klass: ClassDeclaration): Locatable<ApiNode> {
   const description = extractJsDocCommentLocatable(klass);
   const configuration = extractDecoratorFactoryConfiguration(decorator);
   const name = extractStringPropertyValueLocatable(configuration, "name");
+  const securityHeaderProperty = classPropertyWithDecorator(
+    klass,
+    "securityHeader"
+  );
+  const securityHeader =
+    securityHeaderProperty && parseSecurityHeader(securityHeaderProperty);
   const location = decorator.getSourceFile().getFilePath();
   const line = decorator.getStartLineNumber();
 
   return {
-    value: { name, description },
+    value: { name, description, securityHeader },
     location,
     line
   };

--- a/lib/src/parsers/nodes/security-header-parser.spec.ts
+++ b/lib/src/parsers/nodes/security-header-parser.spec.ts
@@ -1,0 +1,53 @@
+import { ClassDeclaration } from "ts-simple-ast";
+import { TypeKind } from "../../models/types";
+import { createSourceFile } from "../../test/helper";
+import { parseSecurityHeader } from "./security-header-parser";
+
+describe("@securityHeader parser", () => {
+  test("parses all information", () => {
+    const klass = createClassDeclaration(`
+      /** security header description */
+      @securityHeader
+      'x-auth-token'?: string;
+    `);
+    const property = klass.getPropertyOrThrow("'x-auth-token'");
+
+    expect(parseSecurityHeader(property)).toStrictEqual({
+      value: {
+        name: {
+          value: "x-auth-token",
+          location: expect.stringMatching(/main\.ts$/),
+          line: 6
+        },
+        description: {
+          value: "security header description",
+          location: expect.stringMatching(/main\.ts$/),
+          line: 4
+        },
+        type: {
+          kind: TypeKind.STRING
+        }
+      },
+      location: expect.stringMatching(/main\.ts$/),
+      line: 5
+    });
+  });
+});
+
+function createClassDeclaration(classContent: string): ClassDeclaration {
+  const content = `
+    import { securityHeader, headers, body } from "@airtasker/spot"
+
+    class TestClass {
+      ${classContent.trim()}
+    }
+  `;
+
+  const sourceFile = createSourceFile({
+    path: "main",
+    content: content.trim()
+  });
+  const klass = sourceFile.getClassOrThrow("TestClass");
+
+  return klass;
+}

--- a/lib/src/parsers/nodes/security-header-parser.ts
+++ b/lib/src/parsers/nodes/security-header-parser.ts
@@ -1,0 +1,32 @@
+import { PropertyDeclaration } from "ts-simple-ast";
+import { Locatable } from "../../models/locatable";
+import { SecurityHeaderNode } from "../../models/nodes";
+import {
+  extractJsDocCommentLocatable,
+  extractPropertyNameLocatable
+} from "../utilities/parser-utility";
+import { parseType } from "../utilities/type-parser";
+
+/**
+ * Parse a `@securityHeader` decorated method.
+ *
+ * @param a field declaration
+ */
+export function parseSecurityHeader(
+  property: PropertyDeclaration
+): Locatable<SecurityHeaderNode> {
+  const decorator = property.getDecoratorOrThrow("securityHeader");
+
+  const name = extractPropertyNameLocatable(property);
+  const description = extractJsDocCommentLocatable(property);
+  const type = parseType(property.getTypeNodeOrThrow());
+
+  const location = decorator.getSourceFile().getFilePath();
+  const line = decorator.getStartLineNumber();
+
+  return {
+    value: { name, description, type },
+    location,
+    line
+  };
+}

--- a/lib/src/parsers/utilities/parser-utility.ts
+++ b/lib/src/parsers/utilities/parser-utility.ts
@@ -6,6 +6,7 @@ import {
   MethodDeclaration,
   ObjectLiteralExpression,
   ParameterDeclaration,
+  PropertyDeclaration,
   PropertySignature,
   QuestionTokenableNode,
   ts,
@@ -91,7 +92,7 @@ export function extractJsDocCommentLocatable(
  * @param property property signature
  */
 export function extractPropertyNameLocatable(
-  property: PropertySignature
+  property: PropertyDeclaration | PropertySignature
 ): Locatable<string> {
   const nameNode = property.getNameNode();
 
@@ -255,6 +256,31 @@ export function classMethodWithDecorator(
     throw new Error(
       `expected decorator @${decoratorName} to be used only once, found ${
         matchingMethods.length
+      } usages`
+    );
+  }
+  return undefined;
+}
+
+/**
+ * Retrieve a property from a class declaration with a particular decorator.
+ *
+ * @param klass class declaration
+ * @param decoratorName name of decorator to search for
+ */
+export function classPropertyWithDecorator(
+  klass: ClassDeclaration,
+  decoratorName: string
+): PropertyDeclaration | undefined {
+  const matchingProperties = klass
+    .getProperties()
+    .filter(property => property.getDecorator(decoratorName) !== undefined);
+  if (matchingProperties.length === 1) {
+    return matchingProperties[0];
+  } else if (matchingProperties.length > 1) {
+    throw new Error(
+      `expected decorator @${decoratorName} to be used only once, found ${
+        matchingProperties.length
       } usages`
     );
   }

--- a/lib/src/syntax/index.ts
+++ b/lib/src/syntax/index.ts
@@ -7,4 +7,5 @@ export * from "./path-params";
 export * from "./query-params";
 export * from "./request";
 export * from "./response";
+export * from "./security-header";
 export * from "./types";

--- a/lib/src/syntax/security-header.ts
+++ b/lib/src/syntax/security-header.ts
@@ -1,0 +1,17 @@
+/**
+ * Decorator for describing a security header used across the entire API.
+ * 
+ * This should be used only once within an `@api` decorated class.
+ * 
+ * @example
+```
+@api({
+  // ...
+})
+class Api {
+  @securityHeader
+  'x-auth-token': string;
+}
+```
+ */
+export declare function securityHeader(target: any, propertyKey: string): void;

--- a/lib/src/test/examples/contract.ts
+++ b/lib/src/test/examples/contract.ts
@@ -9,12 +9,16 @@ import {
   request,
   response
 } from "@airtasker/spot";
+import { securityHeader } from "lib/src/syntax/security-header";
 import "./contract-endpoint";
 import { Address, ErrorBody, UserBody } from "./models";
 
 /** This is the company API. It does cool things */
 @api({ name: "company-api" })
-class ExampleApi {}
+class ExampleApi {
+  @securityHeader
+  "x-auth-token": string;
+}
 
 /** Creates a user in a company */
 @endpoint({

--- a/lib/src/verifiers/nodes/api-verifier.spec.ts
+++ b/lib/src/verifiers/nodes/api-verifier.spec.ts
@@ -10,7 +10,7 @@ describe("api node verifier", () => {
         line: 4
       }
     };
-    expect(verifyApiNode(apiNode)).toHaveLength(0);
+    expect(verifyApiNode(apiNode, [])).toHaveLength(0);
   });
 
   test("invalid for incorrect usage", () => {
@@ -21,7 +21,7 @@ describe("api node verifier", () => {
         line: 4
       }
     };
-    const errors = verifyApiNode(apiNode);
+    const errors = verifyApiNode(apiNode, []);
     expect(errors).toHaveLength(2);
     expect(errors).toContainEqual({
       message: "api name may not contain leading or trailing white space",

--- a/lib/src/verifiers/nodes/api-verifier.ts
+++ b/lib/src/verifiers/nodes/api-verifier.ts
@@ -1,7 +1,11 @@
-import { ApiNode } from "../../models/nodes";
+import { ApiNode, TypeNode } from "../../models/nodes";
 import { VerificationError } from "../verification-error";
+import { verifySecurityHeaderNode } from "./security-header-verifier";
 
-export function verifyApiNode(api: ApiNode): VerificationError[] {
+export function verifyApiNode(
+  api: ApiNode,
+  typeStore: TypeNode[]
+): VerificationError[] {
   let errors: VerificationError[] = [];
 
   if (/(^\s+)|(\s+$)/.test(api.name.value)) {
@@ -18,6 +22,11 @@ export function verifyApiNode(api: ApiNode): VerificationError[] {
       location: api.name.location,
       line: api.name.line
     });
+  }
+  if (api.securityHeader) {
+    errors.push(
+      ...verifySecurityHeaderNode(api.securityHeader.value, typeStore)
+    );
   }
   return errors;
 }

--- a/lib/src/verifiers/nodes/security-header-verifier.spec.ts
+++ b/lib/src/verifiers/nodes/security-header-verifier.spec.ts
@@ -1,0 +1,39 @@
+import { SecurityHeaderNode } from "../../models/nodes";
+import { TypeKind } from "../../models/types";
+import { verifySecurityHeaderNode } from "./security-header-verifier";
+
+describe("security header node verifier", () => {
+  test("valid for correct usage", () => {
+    const responseNode: SecurityHeaderNode = {
+      name: {
+        value: "x-auth-token",
+        location: "somelocation.ts",
+        line: 5
+      },
+      type: {
+        kind: TypeKind.STRING
+      }
+    };
+    expect(verifySecurityHeaderNode(responseNode, [])).toHaveLength(0);
+  });
+
+  test("invalid for incorrect usage", () => {
+    const responseNode: SecurityHeaderNode = {
+      name: {
+        value: "x-auth-token",
+        location: "somelocation.ts",
+        line: 5
+      },
+      type: {
+        kind: TypeKind.NUMBER
+      }
+    };
+    const errors = verifySecurityHeaderNode(responseNode, []);
+    expect(errors).toHaveLength(1);
+    expect(errors).toContainEqual({
+      message: "security header type may only be a string type",
+      location: "somelocation.ts",
+      line: 5
+    });
+  });
+});

--- a/lib/src/verifiers/nodes/security-header-verifier.ts
+++ b/lib/src/verifiers/nodes/security-header-verifier.ts
@@ -1,0 +1,23 @@
+import { SecurityHeaderNode, TypeNode } from "../../models/nodes";
+import { TypeKind } from "../../models/types";
+import { possibleRootKinds } from "../utilities/type-resolver";
+import { VerificationError } from "../verification-error";
+
+export function verifySecurityHeaderNode(
+  securityHeader: SecurityHeaderNode,
+  typeStore: TypeNode[]
+): VerificationError[] {
+  let errors: VerificationError[] = [];
+
+  const typeKinds = possibleRootKinds(securityHeader.type, typeStore);
+
+  if (!typeKinds.every(kind => kind === TypeKind.STRING)) {
+    errors.push({
+      message: "security header type may only be a string type",
+      location: securityHeader.name.location,
+      line: securityHeader.name.line
+    });
+  }
+
+  return errors;
+}

--- a/lib/src/verifiers/verifier.ts
+++ b/lib/src/verifiers/verifier.ts
@@ -7,7 +7,7 @@ import { VerificationError } from "./verification-error";
 export function verify(contract: ContractNode): VerificationError[] {
   let errors: VerificationError[] = [];
 
-  errors.push(...verifyApiNode(contract.api.value));
+  errors.push(...verifyApiNode(contract.api.value, contract.types));
 
   contract.endpoints.forEach(endpoint =>
     errors.push(...verifyEndpointNode(endpoint.value, contract.types))


### PR DESCRIPTION
This adds:
- a @securityHeader decorator to be used in a top-level API declaration
- logic for parsing @securityHeader
- OpenAPI 2 & 3 output

For reference, please check:
- https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md
- https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md