### PR TITLE
Renamed parseType function to parseTypeNode

### DIFF
--- a/lib/src/parsers/nodes/body-parser.ts
+++ b/lib/src/parsers/nodes/body-parser.ts
@@ -2,7 +2,7 @@ import { ParameterDeclaration } from "ts-simple-ast";
 import { Locatable } from "../../models/locatable";
 import { BodyNode } from "../../models/nodes";
 import { ensureNodeNotOptional } from "../utilities/parser-utility";
-import { parseType } from "../utilities/type-parser";
+import { parseTypeNode } from "../utilities/type-parser";
 
 /**
  * Parse an `@body` decorated parameter.
@@ -14,7 +14,7 @@ export function parseBody(
 ): Locatable<BodyNode> {
   const decorator = parameter.getDecoratorOrThrow("body");
   ensureNodeNotOptional(parameter);
-  const dataType = parseType(parameter.getTypeNodeOrThrow());
+  const dataType = parseTypeNode(parameter.getTypeNodeOrThrow());
   const location = decorator.getSourceFile().getFilePath();
   const line = decorator.getStartLineNumber();
   return {

--- a/lib/src/parsers/nodes/headers-parser.ts
+++ b/lib/src/parsers/nodes/headers-parser.ts
@@ -7,7 +7,7 @@ import {
   extractObjectParameterProperties,
   extractPropertyName
 } from "../utilities/parser-utility";
-import { parseType } from "../utilities/type-parser";
+import { parseTypeNode } from "../utilities/type-parser";
 
 /**
  * Parse a `@headers` decorated parameter.
@@ -40,7 +40,7 @@ function parseHeader(property: PropertySignature): Locatable<HeaderNode> {
     line: property.getStartLineNumber()
   };
   const description = extractJsDocCommentLocatable(property);
-  const type = parseType(property.getTypeNodeOrThrow());
+  const type = parseTypeNode(property.getTypeNodeOrThrow());
   const optional = property.hasQuestionToken();
   const header = { name, description, type, optional };
   return {

--- a/lib/src/parsers/nodes/path-params-parser.ts
+++ b/lib/src/parsers/nodes/path-params-parser.ts
@@ -7,7 +7,7 @@ import {
   extractObjectParameterProperties,
   extractPropertyName
 } from "../utilities/parser-utility";
-import { parseType } from "../utilities/type-parser";
+import { parseTypeNode } from "../utilities/type-parser";
 
 /**
  * Parse an `@pathParams` decorated parameter.
@@ -42,7 +42,7 @@ function parsePathParam(property: PropertySignature): Locatable<PathParamNode> {
     line: property.getStartLineNumber()
   };
   const description = extractJsDocCommentLocatable(property);
-  const type = parseType(property.getTypeNodeOrThrow());
+  const type = parseTypeNode(property.getTypeNodeOrThrow());
   const pathParam = { name, description, type };
   return {
     value: pathParam,

--- a/lib/src/parsers/nodes/query-params-parser.ts
+++ b/lib/src/parsers/nodes/query-params-parser.ts
@@ -7,7 +7,7 @@ import {
   extractObjectParameterProperties,
   extractPropertyName
 } from "../utilities/parser-utility";
-import { parseType } from "../utilities/type-parser";
+import { parseTypeNode } from "../utilities/type-parser";
 
 /**
  * Parse an `@queryParams` decorated parameter.
@@ -42,7 +42,7 @@ function parseQueryParam(
     line: property.getStartLineNumber()
   };
   const description = extractJsDocCommentLocatable(property);
-  const type = parseType(property.getTypeNodeOrThrow());
+  const type = parseTypeNode(property.getTypeNodeOrThrow());
   const optional = property.hasQuestionToken();
   const queryParam = { name, description, type, optional };
   return {

--- a/lib/src/parsers/parser.ts
+++ b/lib/src/parsers/parser.ts
@@ -5,7 +5,10 @@ import { ReferenceType } from "../models/types";
 import { parseApi } from "./nodes/api-parser";
 import { parseEndpoint } from "./nodes/endpoint-parser";
 import { extractJsDocComment } from "./utilities/parser-utility";
-import { parseInterfaceDeclaration, parseType } from "./utilities/type-parser";
+import {
+  parseInterfaceDeclaration,
+  parseTypeNode
+} from "./utilities/type-parser";
 import {
   retrieveTypeReferencesFromEndpoints,
   retrieveTypeReferencesFromType,
@@ -115,7 +118,7 @@ function parseRootSourceFile(
     if (typeAlias !== undefined) {
       const name = typeAlias.getName();
       const description = extractJsDocComment(typeAlias);
-      const type = parseType(typeAlias.getTypeNodeOrThrow());
+      const type = parseTypeNode(typeAlias.getTypeNodeOrThrow());
       return { description, name, type };
     }
 

--- a/lib/src/parsers/utilities/type-parser.spec.ts
+++ b/lib/src/parsers/utilities/type-parser.spec.ts
@@ -9,32 +9,32 @@ import {
   UnionType
 } from "../../models/types";
 import { createSourceFile } from "../../test/helper";
-import { parseInterfaceDeclaration, parseType } from "./type-parser";
+import { parseInterfaceDeclaration, parseTypeNode } from "./type-parser";
 
 describe("type parser", () => {
   describe("primitive types", () => {
     test("parses the null type", () => {
       const typeNode = createTypeNode("null");
 
-      expect(parseType(typeNode)).toStrictEqual(NULL);
+      expect(parseTypeNode(typeNode)).toStrictEqual(NULL);
     });
 
     test("parses the boolean type", () => {
       const typeNode = createTypeNode("boolean");
 
-      expect(parseType(typeNode)).toStrictEqual(BOOLEAN);
+      expect(parseTypeNode(typeNode)).toStrictEqual(BOOLEAN);
     });
 
     test("parses the string type", () => {
       const typeNode = createTypeNode("string");
 
-      expect(parseType(typeNode)).toStrictEqual(STRING);
+      expect(parseTypeNode(typeNode)).toStrictEqual(STRING);
     });
 
     test("parses the number type", () => {
       const typeNode = createTypeNode("number");
 
-      expect(parseType(typeNode)).toStrictEqual(NUMBER);
+      expect(parseTypeNode(typeNode)).toStrictEqual(NUMBER);
     });
   });
 
@@ -42,7 +42,7 @@ describe("type parser", () => {
     test("parses literal true boolean", () => {
       const typeNode = createTypeNode("true");
 
-      expect(parseType(typeNode)).toStrictEqual({
+      expect(parseTypeNode(typeNode)).toStrictEqual({
         kind: TypeKind.BOOLEAN_LITERAL,
         value: true
       });
@@ -51,7 +51,7 @@ describe("type parser", () => {
     test("parses literal false boolean", () => {
       const typeNode = createTypeNode("false");
 
-      expect(parseType(typeNode)).toStrictEqual({
+      expect(parseTypeNode(typeNode)).toStrictEqual({
         kind: TypeKind.BOOLEAN_LITERAL,
         value: false
       });
@@ -60,7 +60,7 @@ describe("type parser", () => {
     test("parses literal string", () => {
       const typeNode = createTypeNode('"myStringLiteral"');
 
-      expect(parseType(typeNode)).toStrictEqual({
+      expect(parseTypeNode(typeNode)).toStrictEqual({
         kind: TypeKind.STRING_LITERAL,
         value: "myStringLiteral"
       });
@@ -69,7 +69,7 @@ describe("type parser", () => {
     test("parses literal number", () => {
       const typeNode = createTypeNode("54");
 
-      expect(parseType(typeNode)).toStrictEqual({
+      expect(parseTypeNode(typeNode)).toStrictEqual({
         kind: TypeKind.NUMBER_LITERAL,
         value: 54
       });
@@ -77,7 +77,7 @@ describe("type parser", () => {
 
     test("parses type aliased literal", () => {
       const typeNode = createTypeNode("TrueAlias");
-      expect(parseType(typeNode)).toStrictEqual({
+      expect(parseTypeNode(typeNode)).toStrictEqual({
         kind: TypeKind.TYPE_REFERENCE,
         referenceKind: TypeKind.BOOLEAN_LITERAL,
         name: "TrueAlias",
@@ -90,7 +90,7 @@ describe("type parser", () => {
     test("parses Integer type", () => {
       const typeNode = createTypeNode("Integer");
 
-      expect(parseType(typeNode)).toStrictEqual({
+      expect(parseTypeNode(typeNode)).toStrictEqual({
         kind: TypeKind.INTEGER
       });
     });
@@ -98,7 +98,7 @@ describe("type parser", () => {
     test("parses Date type", () => {
       const typeNode = createTypeNode("Date");
 
-      expect(parseType(typeNode)).toStrictEqual({
+      expect(parseTypeNode(typeNode)).toStrictEqual({
         kind: TypeKind.DATE
       });
     });
@@ -106,7 +106,7 @@ describe("type parser", () => {
     test("parses DateTime type", () => {
       const typeNode = createTypeNode("DateTime");
 
-      expect(parseType(typeNode)).toStrictEqual({
+      expect(parseTypeNode(typeNode)).toStrictEqual({
         kind: TypeKind.DATE_TIME
       });
     });
@@ -114,7 +114,7 @@ describe("type parser", () => {
     test("parses aliased custom primitive", () => {
       const typeNode = createTypeNode("AliasedCustomPrimitive");
 
-      expect(parseType(typeNode)).toStrictEqual({
+      expect(parseTypeNode(typeNode)).toStrictEqual({
         kind: TypeKind.TYPE_REFERENCE,
         referenceKind: TypeKind.INTEGER,
         name: "AliasedCustomPrimitive",
@@ -127,7 +127,7 @@ describe("type parser", () => {
     test("parses custom string", () => {
       const typeNode = createTypeNode("TypeAlias");
 
-      expect(parseType(typeNode)).toStrictEqual({
+      expect(parseTypeNode(typeNode)).toStrictEqual({
         kind: TypeKind.TYPE_REFERENCE,
         referenceKind: TypeKind.STRING,
         name: "TypeAlias",
@@ -151,7 +151,7 @@ describe("type parser", () => {
         }
       `);
 
-      const result = parseType(typeNode) as ObjectType;
+      const result = parseTypeNode(typeNode) as ObjectType;
 
       expect(result.kind).toEqual(TypeKind.OBJECT);
       expect(result.properties).toHaveLength(2);
@@ -172,7 +172,7 @@ describe("type parser", () => {
     test("parses object interface type", () => {
       const typeNode = createTypeNode("ObjectInterface");
 
-      expect(parseType(typeNode)).toStrictEqual({
+      expect(parseTypeNode(typeNode)).toStrictEqual({
         kind: TypeKind.TYPE_REFERENCE,
         referenceKind: TypeKind.OBJECT,
         name: "ObjectInterface",
@@ -183,7 +183,7 @@ describe("type parser", () => {
     test("parses extended object interface type", () => {
       const typeNode = createTypeNode("ComplexInterface");
 
-      expect(parseType(typeNode)).toStrictEqual({
+      expect(parseTypeNode(typeNode)).toStrictEqual({
         kind: TypeKind.TYPE_REFERENCE,
         referenceKind: TypeKind.OBJECT,
         name: "ComplexInterface",
@@ -194,7 +194,7 @@ describe("type parser", () => {
     test("parses array type", () => {
       const typeNode = createTypeNode("string[]");
 
-      expect(parseType(typeNode)).toStrictEqual({
+      expect(parseTypeNode(typeNode)).toStrictEqual({
         kind: TypeKind.ARRAY,
         elements: STRING
       });
@@ -205,7 +205,7 @@ describe("type parser", () => {
     test("parses union types", () => {
       const typeNode = createTypeNode("string", "number", "null");
 
-      const result = parseType(typeNode) as UnionType;
+      const result = parseTypeNode(typeNode) as UnionType;
 
       expect(result.kind).toEqual(TypeKind.UNION);
       expect(result.types).toHaveLength(3);
@@ -217,7 +217,7 @@ describe("type parser", () => {
     test("parses chained type alias", () => {
       const typeNode = createTypeNode("ChainedAlias");
 
-      expect(parseType(typeNode)).toStrictEqual({
+      expect(parseTypeNode(typeNode)).toStrictEqual({
         kind: TypeKind.TYPE_REFERENCE,
         referenceKind: TypeKind.TYPE_REFERENCE,
         name: "ChainedAlias",

--- a/lib/src/parsers/utilities/type-parser.ts
+++ b/lib/src/parsers/utilities/type-parser.ts
@@ -42,7 +42,7 @@ import {
  *
  * @param type AST type node
  */
-export function parseType(typeNode: TypeNode): DataType {
+export function parseTypeNode(typeNode: TypeNode): DataType {
   // Type references must be parsed first to ensure internal type aliases are handled
   if (TypeGuards.isTypeReferenceNode(typeNode)) {
     return parseTypeReference(typeNode);
@@ -106,7 +106,7 @@ function parseTypeReference(
       return referenceType(
         name,
         declaration.getSourceFile().getFilePath(),
-        parseType(targetTypeNode).kind
+        parseTypeNode(targetTypeNode).kind
       );
     }
   } else {
@@ -146,7 +146,7 @@ function parseLiteralType(typeNode: LiteralTypeNode): PrimitiveLiteral {
  * @param typeNode AST type node
  */
 function parseArrayType(typeNode: ArrayTypeNode): ArrayType {
-  const elementDataType = parseType(typeNode.getElementTypeNode());
+  const elementDataType = parseTypeNode(typeNode.getElementTypeNode());
   return arrayType(elementDataType);
 }
 
@@ -166,7 +166,7 @@ function parseObjectLiteralType(typeNode: TypeLiteralNode): ObjectType {
       return {
         name: propertySignature.getName(),
         description: extractJsDocComment(propertySignature),
-        type: parseType(propertySignature.getTypeNodeOrThrow()),
+        type: parseTypeNode(propertySignature.getTypeNodeOrThrow()),
         optional: propertySignature.hasQuestionToken()
       };
     });
@@ -184,9 +184,9 @@ function parseUnionType(typeNode: UnionTypeNode): DataType {
     .filter(type => !type.getType().isUndefined());
   if (allowedTargetTypes.length === 1) {
     // not a union
-    return parseType(allowedTargetTypes[0]);
+    return parseTypeNode(allowedTargetTypes[0]);
   } else if (allowedTargetTypes.length > 1) {
-    return unionType(allowedTargetTypes.map(type => parseType(type)));
+    return unionType(allowedTargetTypes.map(type => parseTypeNode(type)));
   } else {
     throw new Error("union type error");
   }
@@ -215,7 +215,7 @@ export function parseInterfaceDeclaration(
       return {
         name: propertySignature.getName(),
         description: extractJsDocComment(propertySignature),
-        type: parseType(propertySignature.getTypeNodeOrThrow()),
+        type: parseTypeNode(propertySignature.getTypeNodeOrThrow()),
         optional: propertySignature.hasQuestionToken()
       };
     });

--- a/lib/src/parsers/utilities/type-reference-resolver.ts
+++ b/lib/src/parsers/utilities/type-reference-resolver.ts
@@ -19,7 +19,7 @@ import {
   ReferenceType,
   TypeKind
 } from "../../models/types";
-import { parseInterfaceDeclaration, parseType } from "./type-parser";
+import { parseInterfaceDeclaration, parseTypeNode } from "./type-parser";
 
 /**
  * Recursively retrieves all type references from a data type including itself.
@@ -48,7 +48,7 @@ export function retrieveTypeReferencesFromType(
         const typeAlias = file.getTypeAliasOrThrow(dataType.name);
         return [dataType].concat(
           retrieveTypeReferencesFromType(
-            parseType(typeAlias.getTypeNodeOrThrow()),
+            parseTypeNode(typeAlias.getTypeNodeOrThrow()),
             projectContext
           )
         );
@@ -58,7 +58,7 @@ export function retrieveTypeReferencesFromType(
         if (typeAlias !== undefined) {
           return [dataType].concat(
             retrieveTypeReferencesFromType(
-              parseType(typeAlias.getTypeNodeOrThrow()),
+              parseTypeNode(typeAlias.getTypeNodeOrThrow()),
               projectContext
             )
           );


### PR DESCRIPTION
Renamed the `parseType` function (which parses a `ts-simple-ast` `TypeNode` to `parseTypeNode` to prepare for parsing `@interaction` which will require a function to parse a `ts-simple-ast` `Type`.