### PR TITLE
Verification component to verify DataExpressions with JSON schemas.

### DIFF
--- a/lib/src/utilities/data-expression-utils.spec.ts
+++ b/lib/src/utilities/data-expression-utils.spec.ts
@@ -1,0 +1,118 @@
+import {
+  ArrayExpression,
+  BooleanExpression,
+  NullExpression,
+  NumberExpression,
+  ObjectExpression,
+  StringExpression,
+  TypeKind
+} from "../models/types";
+import { valueFromDataExpression } from "./data-expression-utils";
+
+describe("data expression utils", () => {
+  describe("valueFromDataExpression", () => {
+    it("converts null expressions to null", () => {
+      const data: NullExpression = {
+        kind: TypeKind.NULL
+      };
+      expect(valueFromDataExpression(data)).toBeNull();
+    });
+
+    it("converts boolean expressions to boolean values", () => {
+      const data: BooleanExpression = {
+        kind: TypeKind.BOOLEAN_LITERAL,
+        value: true
+      };
+      expect(valueFromDataExpression(data)).toBe(true);
+    });
+
+    it("converts string expressions to string values", () => {
+      const data: StringExpression = {
+        kind: TypeKind.STRING_LITERAL,
+        value: "hello there"
+      };
+      expect(valueFromDataExpression(data)).toBe("hello there");
+    });
+
+    it("converts number expressions to number values", () => {
+      const data: NumberExpression = {
+        kind: TypeKind.NUMBER_LITERAL,
+        value: 456
+      };
+      expect(valueFromDataExpression(data)).toBe(456);
+    });
+
+    it("converts array expressions to array objects", () => {
+      const data: ArrayExpression = {
+        kind: TypeKind.ARRAY,
+        elements: [
+          {
+            kind: TypeKind.STRING_LITERAL,
+            value: "hello"
+          },
+          {
+            kind: TypeKind.NUMBER_LITERAL,
+            value: 123
+          },
+          {
+            kind: TypeKind.BOOLEAN_LITERAL,
+            value: false
+          },
+          {
+            kind: TypeKind.NULL
+          }
+        ]
+      };
+      expect(valueFromDataExpression(data)).toStrictEqual([
+        "hello",
+        123,
+        false,
+        null
+      ]);
+    });
+
+    it("converts object expressions to objects", () => {
+      const data: ObjectExpression = {
+        kind: TypeKind.OBJECT,
+        properties: [
+          {
+            name: "nameA",
+            expression: {
+              kind: TypeKind.STRING_LITERAL,
+              value: "one"
+            }
+          },
+          {
+            name: "nameB",
+            expression: {
+              kind: TypeKind.OBJECT,
+              properties: [
+                {
+                  name: "nameB1",
+                  expression: {
+                    kind: TypeKind.NUMBER_LITERAL,
+                    value: 2
+                  }
+                },
+                {
+                  name: "nameB2",
+                  expression: {
+                    kind: TypeKind.BOOLEAN_LITERAL,
+                    value: false
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      };
+      expect(valueFromDataExpression(data)).toStrictEqual({
+        nameA: "one",
+        nameB: {
+          nameB1: 2,
+          nameB2: false
+        }
+      });
+    });
+  });
+});

--- a/lib/src/utilities/data-expression-utils.ts
+++ b/lib/src/utilities/data-expression-utils.ts
@@ -1,0 +1,27 @@
+import { DataExpression, TypeKind } from "../models/types";
+
+export function valueFromDataExpression(data: DataExpression): any {
+  switch (data.kind) {
+    case TypeKind.NULL:
+      return null;
+    case TypeKind.BOOLEAN_LITERAL:
+    case TypeKind.STRING_LITERAL:
+    case TypeKind.NUMBER_LITERAL:
+      return data.value;
+    case TypeKind.ARRAY:
+      return data.elements.reduce<Array<any>>(
+        (arrayAcc, element) =>
+          arrayAcc.concat(valueFromDataExpression(element)),
+        []
+      );
+    case TypeKind.OBJECT:
+      return data.properties.reduce<object>((objAcc, property) => {
+        return {
+          [property.name]: valueFromDataExpression(property.expression),
+          ...objAcc
+        };
+      }, {});
+    default:
+      throw new Error("unexpected data expression");
+  }
+}

--- a/lib/src/verifiers/utilities/json-schema-verifier.spec.ts
+++ b/lib/src/verifiers/utilities/json-schema-verifier.spec.ts
@@ -18,118 +18,12 @@ import {
   TypeKind,
   UnionType
 } from "../../models/types";
-import { dataExpressionToJson, verifyJsonSchema } from "./json-schema-verifier";
+import { verifyJsonSchema } from "./json-schema-verifier";
 
 describe("json schema verifier", () => {
-  describe("dataExpressionToJson", () => {
-    it("converts null expressions to null", () => {
-      const data: NullExpression = {
-        kind: TypeKind.NULL
-      };
-      expect(dataExpressionToJson(data)).toBeNull();
-    });
-
-    it("converts boolean expressions to boolean values", () => {
-      const data: BooleanExpression = {
-        kind: TypeKind.BOOLEAN_LITERAL,
-        value: true
-      };
-      expect(dataExpressionToJson(data)).toBe(true);
-    });
-
-    it("converts string expressions to string values", () => {
-      const data: StringExpression = {
-        kind: TypeKind.STRING_LITERAL,
-        value: "hello there"
-      };
-      expect(dataExpressionToJson(data)).toBe("hello there");
-    });
-
-    it("converts number expressions to number values", () => {
-      const data: NumberExpression = {
-        kind: TypeKind.NUMBER_LITERAL,
-        value: 456
-      };
-      expect(dataExpressionToJson(data)).toBe(456);
-    });
-
-    it("converts array expressions to array objects", () => {
-      const data: ArrayExpression = {
-        kind: TypeKind.ARRAY,
-        elements: [
-          {
-            kind: TypeKind.STRING_LITERAL,
-            value: "hello"
-          },
-          {
-            kind: TypeKind.NUMBER_LITERAL,
-            value: 123
-          },
-          {
-            kind: TypeKind.BOOLEAN_LITERAL,
-            value: false
-          },
-          {
-            kind: TypeKind.NULL
-          }
-        ]
-      };
-      expect(dataExpressionToJson(data)).toStrictEqual([
-        "hello",
-        123,
-        false,
-        null
-      ]);
-    });
-
-    it("converts object expressions to objects", () => {
-      const data: ObjectExpression = {
-        kind: TypeKind.OBJECT,
-        properties: [
-          {
-            name: "nameA",
-            expression: {
-              kind: TypeKind.STRING_LITERAL,
-              value: "one"
-            }
-          },
-          {
-            name: "nameB",
-            expression: {
-              kind: TypeKind.OBJECT,
-              properties: [
-                {
-                  name: "nameB1",
-                  expression: {
-                    kind: TypeKind.NUMBER_LITERAL,
-                    value: 2
-                  }
-                },
-                {
-                  name: "nameB2",
-                  expression: {
-                    kind: TypeKind.BOOLEAN_LITERAL,
-                    value: false
-                  }
-                }
-              ]
-            }
-          }
-        ]
-      };
-      expect(dataExpressionToJson(data)).toStrictEqual({
-        nameA: "one",
-        nameB: {
-          nameB1: 2,
-          nameB2: false
-        }
-      });
-    });
-  });
-
   describe("verifyJsonSchema", () => {
     describe("null schema", () => {
-      it("validates", () => {
+      it("validates null expression", () => {
         const dataType: NullType = {
           kind: TypeKind.NULL
         };
@@ -139,7 +33,7 @@ describe("json schema verifier", () => {
         expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
       });
 
-      it("invalidates", () => {
+      it("invalidates non null expression", () => {
         const dataType: NullType = {
           kind: TypeKind.NULL
         };
@@ -152,7 +46,7 @@ describe("json schema verifier", () => {
     });
 
     describe("boolean schema", () => {
-      it("validates", () => {
+      it("validates boolean expression", () => {
         const dataType: BooleanType = {
           kind: TypeKind.BOOLEAN
         };
@@ -163,7 +57,7 @@ describe("json schema verifier", () => {
         expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
       });
 
-      it("invalidates", () => {
+      it("invalidates non boolean expression", () => {
         const dataType: BooleanType = {
           kind: TypeKind.BOOLEAN
         };
@@ -174,7 +68,7 @@ describe("json schema verifier", () => {
         expect(() => verifyJsonSchema(dataType, data, [])).toThrow();
       });
 
-      it("validates literal", () => {
+      it("validates matching boolean literal", () => {
         const dataType: BooleanLiteral = {
           kind: TypeKind.BOOLEAN_LITERAL,
           value: false
@@ -186,7 +80,7 @@ describe("json schema verifier", () => {
         expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
       });
 
-      it("invalidates literal", () => {
+      it("invalidates non matching boolean literal", () => {
         const dataType: BooleanLiteral = {
           kind: TypeKind.BOOLEAN_LITERAL,
           value: false
@@ -200,7 +94,7 @@ describe("json schema verifier", () => {
     });
 
     describe("string schema", () => {
-      it("validates", () => {
+      it("validates string expression", () => {
         const dataType: StringType = {
           kind: TypeKind.STRING
         };
@@ -211,7 +105,7 @@ describe("json schema verifier", () => {
         expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
       });
 
-      it("invalidates", () => {
+      it("invalidates non string expression", () => {
         const dataType: StringType = {
           kind: TypeKind.STRING
         };
@@ -222,7 +116,7 @@ describe("json schema verifier", () => {
         expect(() => verifyJsonSchema(dataType, data, [])).toThrow();
       });
 
-      it("validates literal", () => {
+      it("validates matching string literal", () => {
         const dataType: StringLiteral = {
           kind: TypeKind.STRING_LITERAL,
           value: "hello"
@@ -234,7 +128,7 @@ describe("json schema verifier", () => {
         expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
       });
 
-      it("invalidates literal", () => {
+      it("invalidates non matching string literal", () => {
         const dataType: StringLiteral = {
           kind: TypeKind.STRING_LITERAL,
           value: "hello"
@@ -248,7 +142,7 @@ describe("json schema verifier", () => {
     });
 
     describe("number schema", () => {
-      it("validates", () => {
+      it("validates number expression", () => {
         const dataType: NumberType = {
           kind: TypeKind.NUMBER
         };
@@ -259,7 +153,7 @@ describe("json schema verifier", () => {
         expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
       });
 
-      it("invalidates", () => {
+      it("invalidates number expression", () => {
         const dataType: NumberType = {
           kind: TypeKind.NUMBER
         };
@@ -270,7 +164,7 @@ describe("json schema verifier", () => {
         expect(() => verifyJsonSchema(dataType, data, [])).toThrow();
       });
 
-      it("validates literal", () => {
+      it("validates matching number literal", () => {
         const dataType: NumberLiteral = {
           kind: TypeKind.NUMBER_LITERAL,
           value: 54
@@ -282,7 +176,7 @@ describe("json schema verifier", () => {
         expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
       });
 
-      it("invalidates literal", () => {
+      it("invalidates non matching number literal", () => {
         const dataType: NumberLiteral = {
           kind: TypeKind.NUMBER_LITERAL,
           value: 54
@@ -296,7 +190,7 @@ describe("json schema verifier", () => {
     });
 
     describe("array schema", () => {
-      it("validates", () => {
+      it("validates array expression", () => {
         const dataType: ArrayType = {
           kind: TypeKind.ARRAY,
           elements: {
@@ -319,7 +213,21 @@ describe("json schema verifier", () => {
         expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
       });
 
-      it("invalidates", () => {
+      it("validates an empty array expression", () => {
+        const dataType: ArrayType = {
+          kind: TypeKind.ARRAY,
+          elements: {
+            kind: TypeKind.NUMBER
+          }
+        };
+        const data: ArrayExpression = {
+          kind: TypeKind.ARRAY,
+          elements: []
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
+      });
+
+      it("invalidates non array expression", () => {
         const dataType: ArrayType = {
           kind: TypeKind.ARRAY,
           elements: {
@@ -344,7 +252,7 @@ describe("json schema verifier", () => {
     });
 
     describe("object schema", () => {
-      it("validates", () => {
+      it("validates object expression", () => {
         const dataType: ObjectType = {
           kind: TypeKind.OBJECT,
           properties: [
@@ -404,6 +312,26 @@ describe("json schema verifier", () => {
                     }
                   }
                 ]
+              }
+            }
+          ]
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
+      });
+
+      it("validates object with extra attributes", () => {
+        const dataType: ObjectType = {
+          kind: TypeKind.OBJECT,
+          properties: []
+        };
+        const data: ObjectExpression = {
+          kind: TypeKind.OBJECT,
+          properties: [
+            {
+              name: "nameA",
+              expression: {
+                kind: TypeKind.STRING_LITERAL,
+                value: "hello"
               }
             }
           ]
@@ -476,7 +404,7 @@ describe("json schema verifier", () => {
     });
 
     describe("schemas with references", () => {
-      it("validates", () => {
+      it("validates object with reference expressions", () => {
         const dataType: ObjectType = {
           kind: TypeKind.OBJECT,
           properties: [
@@ -515,7 +443,7 @@ describe("json schema verifier", () => {
         expect(() => verifyJsonSchema(dataType, data, typeStore)).not.toThrow();
       });
 
-      it("invalidates", () => {
+      it("invalidates if referenced expressions do not exist", () => {
         const dataType: ObjectType = {
           kind: TypeKind.OBJECT,
           properties: [
@@ -556,7 +484,7 @@ describe("json schema verifier", () => {
     });
 
     describe("schemas with unions", () => {
-      it("validates", () => {
+      it("validates any expression matching the union", () => {
         const dataType: UnionType = {
           kind: TypeKind.UNION,
           types: [
@@ -580,7 +508,7 @@ describe("json schema verifier", () => {
         expect(() => verifyJsonSchema(dataType, dataB, [])).not.toThrow();
       });
 
-      it("invalidates", () => {
+      it("invalidates an expression that does not match the union", () => {
         const dataType: UnionType = {
           kind: TypeKind.UNION,
           types: [

--- a/lib/src/verifiers/utilities/json-schema-verifier.spec.ts
+++ b/lib/src/verifiers/utilities/json-schema-verifier.spec.ts
@@ -1,0 +1,603 @@
+import { TypeNode } from "../../models/nodes";
+import {
+  ArrayExpression,
+  ArrayType,
+  BooleanExpression,
+  BooleanLiteral,
+  BooleanType,
+  NullExpression,
+  NullType,
+  NumberExpression,
+  NumberLiteral,
+  NumberType,
+  ObjectExpression,
+  ObjectType,
+  StringExpression,
+  StringLiteral,
+  StringType,
+  TypeKind,
+  UnionType
+} from "../../models/types";
+import { dataExpressionToJson, verifyJsonSchema } from "./json-schema-verifier";
+
+describe("json schema verifier", () => {
+  describe("dataExpressionToJson", () => {
+    it("converts null expressions to null", () => {
+      const data: NullExpression = {
+        kind: TypeKind.NULL
+      };
+      expect(dataExpressionToJson(data)).toBeNull();
+    });
+
+    it("converts boolean expressions to boolean values", () => {
+      const data: BooleanExpression = {
+        kind: TypeKind.BOOLEAN_LITERAL,
+        value: true
+      };
+      expect(dataExpressionToJson(data)).toBe(true);
+    });
+
+    it("converts string expressions to string values", () => {
+      const data: StringExpression = {
+        kind: TypeKind.STRING_LITERAL,
+        value: "hello there"
+      };
+      expect(dataExpressionToJson(data)).toBe("hello there");
+    });
+
+    it("converts number expressions to number values", () => {
+      const data: NumberExpression = {
+        kind: TypeKind.NUMBER_LITERAL,
+        value: 456
+      };
+      expect(dataExpressionToJson(data)).toBe(456);
+    });
+
+    it("converts array expressions to array objects", () => {
+      const data: ArrayExpression = {
+        kind: TypeKind.ARRAY,
+        elements: [
+          {
+            kind: TypeKind.STRING_LITERAL,
+            value: "hello"
+          },
+          {
+            kind: TypeKind.NUMBER_LITERAL,
+            value: 123
+          },
+          {
+            kind: TypeKind.BOOLEAN_LITERAL,
+            value: false
+          },
+          {
+            kind: TypeKind.NULL
+          }
+        ]
+      };
+      expect(dataExpressionToJson(data)).toStrictEqual([
+        "hello",
+        123,
+        false,
+        null
+      ]);
+    });
+
+    it("converts object expressions to objects", () => {
+      const data: ObjectExpression = {
+        kind: TypeKind.OBJECT,
+        properties: [
+          {
+            name: "nameA",
+            expression: {
+              kind: TypeKind.STRING_LITERAL,
+              value: "one"
+            }
+          },
+          {
+            name: "nameB",
+            expression: {
+              kind: TypeKind.OBJECT,
+              properties: [
+                {
+                  name: "nameB1",
+                  expression: {
+                    kind: TypeKind.NUMBER_LITERAL,
+                    value: 2
+                  }
+                },
+                {
+                  name: "nameB2",
+                  expression: {
+                    kind: TypeKind.BOOLEAN_LITERAL,
+                    value: false
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      };
+      expect(dataExpressionToJson(data)).toStrictEqual({
+        nameA: "one",
+        nameB: {
+          nameB1: 2,
+          nameB2: false
+        }
+      });
+    });
+  });
+
+  describe("verifyJsonSchema", () => {
+    describe("null schema", () => {
+      it("validates", () => {
+        const dataType: NullType = {
+          kind: TypeKind.NULL
+        };
+        const data: NullExpression = {
+          kind: TypeKind.NULL
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
+      });
+
+      it("invalidates", () => {
+        const dataType: NullType = {
+          kind: TypeKind.NULL
+        };
+        const data: StringExpression = {
+          kind: TypeKind.STRING_LITERAL,
+          value: "hello"
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).toThrow();
+      });
+    });
+
+    describe("boolean schema", () => {
+      it("validates", () => {
+        const dataType: BooleanType = {
+          kind: TypeKind.BOOLEAN
+        };
+        const data: BooleanExpression = {
+          kind: TypeKind.BOOLEAN_LITERAL,
+          value: true
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
+      });
+
+      it("invalidates", () => {
+        const dataType: BooleanType = {
+          kind: TypeKind.BOOLEAN
+        };
+        const data: StringExpression = {
+          kind: TypeKind.STRING_LITERAL,
+          value: "hello"
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).toThrow();
+      });
+
+      it("validates literal", () => {
+        const dataType: BooleanLiteral = {
+          kind: TypeKind.BOOLEAN_LITERAL,
+          value: false
+        };
+        const data: BooleanExpression = {
+          kind: TypeKind.BOOLEAN_LITERAL,
+          value: false
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
+      });
+
+      it("invalidates literal", () => {
+        const dataType: BooleanLiteral = {
+          kind: TypeKind.BOOLEAN_LITERAL,
+          value: false
+        };
+        const data: BooleanExpression = {
+          kind: TypeKind.BOOLEAN_LITERAL,
+          value: true
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).toThrow();
+      });
+    });
+
+    describe("string schema", () => {
+      it("validates", () => {
+        const dataType: StringType = {
+          kind: TypeKind.STRING
+        };
+        const data: StringExpression = {
+          kind: TypeKind.STRING_LITERAL,
+          value: "hello"
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
+      });
+
+      it("invalidates", () => {
+        const dataType: StringType = {
+          kind: TypeKind.STRING
+        };
+        const data: NumberExpression = {
+          kind: TypeKind.NUMBER_LITERAL,
+          value: 54
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).toThrow();
+      });
+
+      it("validates literal", () => {
+        const dataType: StringLiteral = {
+          kind: TypeKind.STRING_LITERAL,
+          value: "hello"
+        };
+        const data: StringExpression = {
+          kind: TypeKind.STRING_LITERAL,
+          value: "hello"
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
+      });
+
+      it("invalidates literal", () => {
+        const dataType: StringLiteral = {
+          kind: TypeKind.STRING_LITERAL,
+          value: "hello"
+        };
+        const data: StringExpression = {
+          kind: TypeKind.STRING_LITERAL,
+          value: "not hello"
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).toThrow();
+      });
+    });
+
+    describe("number schema", () => {
+      it("validates", () => {
+        const dataType: NumberType = {
+          kind: TypeKind.NUMBER
+        };
+        const data: NumberExpression = {
+          kind: TypeKind.NUMBER_LITERAL,
+          value: 54
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
+      });
+
+      it("invalidates", () => {
+        const dataType: NumberType = {
+          kind: TypeKind.NUMBER
+        };
+        const data: StringExpression = {
+          kind: TypeKind.STRING_LITERAL,
+          value: "hello"
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).toThrow();
+      });
+
+      it("validates literal", () => {
+        const dataType: NumberLiteral = {
+          kind: TypeKind.NUMBER_LITERAL,
+          value: 54
+        };
+        const data: NumberExpression = {
+          kind: TypeKind.NUMBER_LITERAL,
+          value: 54
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
+      });
+
+      it("invalidates literal", () => {
+        const dataType: NumberLiteral = {
+          kind: TypeKind.NUMBER_LITERAL,
+          value: 54
+        };
+        const data: NumberExpression = {
+          kind: TypeKind.NUMBER_LITERAL,
+          value: 53
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).toThrow();
+      });
+    });
+
+    describe("array schema", () => {
+      it("validates", () => {
+        const dataType: ArrayType = {
+          kind: TypeKind.ARRAY,
+          elements: {
+            kind: TypeKind.STRING
+          }
+        };
+        const data: ArrayExpression = {
+          kind: TypeKind.ARRAY,
+          elements: [
+            {
+              kind: TypeKind.STRING_LITERAL,
+              value: "hello"
+            },
+            {
+              kind: TypeKind.STRING_LITERAL,
+              value: "bye"
+            }
+          ]
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
+      });
+
+      it("invalidates", () => {
+        const dataType: ArrayType = {
+          kind: TypeKind.ARRAY,
+          elements: {
+            kind: TypeKind.STRING
+          }
+        };
+        const data: ArrayExpression = {
+          kind: TypeKind.ARRAY,
+          elements: [
+            {
+              kind: TypeKind.STRING_LITERAL,
+              value: "hello"
+            },
+            {
+              kind: TypeKind.NUMBER_LITERAL,
+              value: 54
+            }
+          ]
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).toThrow();
+      });
+    });
+
+    describe("object schema", () => {
+      it("validates", () => {
+        const dataType: ObjectType = {
+          kind: TypeKind.OBJECT,
+          properties: [
+            {
+              name: "nameA",
+              type: {
+                kind: TypeKind.STRING
+              },
+              optional: false
+            },
+            {
+              name: "nameB",
+              type: {
+                kind: TypeKind.OBJECT,
+                properties: [
+                  {
+                    name: "nameB1",
+                    type: {
+                      kind: TypeKind.BOOLEAN
+                    },
+                    optional: true
+                  },
+                  {
+                    name: "nameB2",
+                    type: {
+                      kind: TypeKind.NUMBER_LITERAL,
+                      value: 54
+                    },
+                    optional: false
+                  }
+                ]
+              },
+              optional: false
+            }
+          ]
+        };
+        const data: ObjectExpression = {
+          kind: TypeKind.OBJECT,
+          properties: [
+            {
+              name: "nameA",
+              expression: {
+                kind: TypeKind.STRING_LITERAL,
+                value: "hello"
+              }
+            },
+            {
+              name: "nameB",
+              expression: {
+                kind: TypeKind.OBJECT,
+                properties: [
+                  {
+                    name: "nameB2",
+                    expression: {
+                      kind: TypeKind.NUMBER_LITERAL,
+                      value: 54
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).not.toThrow();
+      });
+
+      it("invalidates missing required attributes", () => {
+        const dataType: ObjectType = {
+          kind: TypeKind.OBJECT,
+          properties: [
+            {
+              name: "nameA",
+              type: {
+                kind: TypeKind.STRING
+              },
+              optional: false
+            },
+            {
+              name: "nameB",
+              type: {
+                kind: TypeKind.STRING
+              },
+              optional: true
+            }
+          ]
+        };
+        const data: ObjectExpression = {
+          kind: TypeKind.OBJECT,
+          properties: [
+            {
+              name: "nameB",
+              expression: {
+                kind: TypeKind.STRING_LITERAL,
+                value: "hello"
+              }
+            }
+          ]
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).toThrow();
+      });
+
+      it("invalidates incorrect attribute types", () => {
+        const dataType: ObjectType = {
+          kind: TypeKind.OBJECT,
+          properties: [
+            {
+              name: "nameA",
+              type: {
+                kind: TypeKind.STRING
+              },
+              optional: false
+            }
+          ]
+        };
+        const data: ObjectExpression = {
+          kind: TypeKind.OBJECT,
+          properties: [
+            {
+              name: "nameA",
+              expression: {
+                kind: TypeKind.NUMBER_LITERAL,
+                value: 54
+              }
+            }
+          ]
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).toThrow();
+      });
+    });
+
+    describe("schemas with references", () => {
+      it("validates", () => {
+        const dataType: ObjectType = {
+          kind: TypeKind.OBJECT,
+          properties: [
+            {
+              name: "nameA",
+              type: {
+                kind: TypeKind.TYPE_REFERENCE,
+                name: "UUID",
+                referenceKind: TypeKind.STRING,
+                location: ""
+              },
+              optional: false
+            }
+          ]
+        };
+        const data: ObjectExpression = {
+          kind: TypeKind.OBJECT,
+          properties: [
+            {
+              name: "nameA",
+              expression: {
+                kind: TypeKind.STRING_LITERAL,
+                value: "someid"
+              }
+            }
+          ]
+        };
+        const typeStore: TypeNode[] = [
+          {
+            name: "UUID",
+            type: {
+              kind: TypeKind.STRING
+            }
+          }
+        ];
+        expect(() => verifyJsonSchema(dataType, data, typeStore)).not.toThrow();
+      });
+
+      it("invalidates", () => {
+        const dataType: ObjectType = {
+          kind: TypeKind.OBJECT,
+          properties: [
+            {
+              name: "nameA",
+              type: {
+                kind: TypeKind.TYPE_REFERENCE,
+                name: "UUID",
+                referenceKind: TypeKind.STRING,
+                location: ""
+              },
+              optional: false
+            }
+          ]
+        };
+        const data: ObjectExpression = {
+          kind: TypeKind.OBJECT,
+          properties: [
+            {
+              name: "nameA",
+              expression: {
+                kind: TypeKind.NUMBER_LITERAL,
+                value: 54
+              }
+            }
+          ]
+        };
+        const typeStore: TypeNode[] = [
+          {
+            name: "UUID",
+            type: {
+              kind: TypeKind.STRING
+            }
+          }
+        ];
+        expect(() => verifyJsonSchema(dataType, data, typeStore)).toThrow();
+      });
+    });
+
+    describe("schemas with unions", () => {
+      it("validates", () => {
+        const dataType: UnionType = {
+          kind: TypeKind.UNION,
+          types: [
+            {
+              kind: TypeKind.STRING
+            },
+            {
+              kind: TypeKind.NUMBER
+            }
+          ]
+        };
+        const dataA: StringExpression = {
+          kind: TypeKind.STRING_LITERAL,
+          value: "hello"
+        };
+        const dataB: NumberExpression = {
+          kind: TypeKind.NUMBER_LITERAL,
+          value: 54
+        };
+        expect(() => verifyJsonSchema(dataType, dataA, [])).not.toThrow();
+        expect(() => verifyJsonSchema(dataType, dataB, [])).not.toThrow();
+      });
+
+      it("invalidates", () => {
+        const dataType: UnionType = {
+          kind: TypeKind.UNION,
+          types: [
+            {
+              kind: TypeKind.STRING
+            },
+            {
+              kind: TypeKind.NUMBER
+            }
+          ]
+        };
+        const data: BooleanExpression = {
+          kind: TypeKind.BOOLEAN_LITERAL,
+          value: true
+        };
+        expect(() => verifyJsonSchema(dataType, data, [])).toThrow();
+      });
+    });
+  });
+});

--- a/lib/src/verifiers/utilities/json-schema-verifier.ts
+++ b/lib/src/verifiers/utilities/json-schema-verifier.ts
@@ -1,0 +1,54 @@
+import {
+  JsonSchemaType,
+  jsonTypeSchema
+} from "../../generators/contract/json-schema";
+import { TypeNode } from "../../models/nodes";
+import { DataExpression, DataType, TypeKind } from "../../models/types";
+import Ajv = require("ajv");
+
+export function verifyJsonSchema(
+  dataType: DataType,
+  data: DataExpression,
+  typeStore: TypeNode[]
+) {
+  const ajv = new Ajv();
+  const schema = {
+    ...jsonTypeSchema(dataType),
+    definitions: typeStore.reduce<{ [key: string]: JsonSchemaType }>(
+      (defAcc, typeNode) => {
+        return { [typeNode.name]: jsonTypeSchema(typeNode.type), ...defAcc };
+      },
+      {}
+    )
+  };
+  const validateFn = ajv.compile(schema);
+  const valid = validateFn(dataExpressionToJson(data));
+  if (!valid) {
+    throw new Error(`Invalid: ${ajv.errorsText(validateFn.errors)}`);
+  }
+}
+
+export function dataExpressionToJson(data: DataExpression): any {
+  switch (data.kind) {
+    case TypeKind.NULL:
+      return null;
+    case TypeKind.BOOLEAN_LITERAL:
+    case TypeKind.STRING_LITERAL:
+    case TypeKind.NUMBER_LITERAL:
+      return data.value;
+    case TypeKind.ARRAY:
+      return data.elements.reduce<Array<any>>(
+        (arrayAcc, element) => arrayAcc.concat(dataExpressionToJson(element)),
+        []
+      );
+    case TypeKind.OBJECT:
+      return data.properties.reduce<object>((objAcc, property) => {
+        return {
+          [property.name]: dataExpressionToJson(property.expression),
+          ...objAcc
+        };
+      }, {});
+    default:
+      throw new Error("unexpected data expression");
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/cors": "^2.8.4",
     "@types/express": "^4.16.0",
     "@types/randomstring": "^1.1.6",
+    "ajv": "^6.9.1",
     "assert-never": "^1.1.0",
     "cors": "^2.8.5",
     "express": "^4.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -392,6 +392,16 @@ ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
+ajv@^6.9.1:
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.9.1.tgz#a4d3683d74abc5670e75f0b16520f70a20ea8dc1"
+  integrity sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
 ansi-escapes@^3.0.0, ansi-escapes@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
@@ -1644,6 +1654,11 @@ fast-deep-equal@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
   integrity sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
+
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
 fast-glob@^2.0.2:
   version "2.2.3"
@@ -2951,6 +2966,11 @@ json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
   integrity sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -4759,6 +4779,13 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+uri-js@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  dependencies:
+    punycode "^2.1.0"
 
 urix@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
The `json-schema-verifier` compares `DataExpression`s  with JSON schemas (converted from `DataTypes` using the existing JSON schema generator logic.