### PR TITLE
Reference types resolver bug

### DIFF
--- a/lib/src/generators/contract/__snapshots__/json-schema.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/json-schema.spec.ts.snap
@@ -31,6 +31,32 @@ exports[`JSON Schema generator produces valid code: json 1`] = `
         \\"data\\"
       ]
     },
+    \\"Profile\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"private\\": {
+          \\"type\\": \\"boolean\\"
+        },
+        \\"messageOptions\\": {
+          \\"$ref\\": \\"#/definitions/MessageOptions\\"
+        }
+      },
+      \\"required\\": [
+        \\"private\\",
+        \\"messageOptions\\"
+      ]
+    },
+    \\"MessageOptions\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"newsletter\\": {
+          \\"type\\": \\"boolean\\"
+        }
+      },
+      \\"required\\": [
+        \\"newsletter\\"
+      ]
+    },
     \\"ErrorBody\\": {
       \\"type\\": \\"object\\",
       \\"properties\\": {
@@ -84,32 +110,6 @@ exports[`JSON Schema generator produces valid code: json 1`] = `
         \\"data\\"
       ]
     },
-    \\"Profile\\": {
-      \\"type\\": \\"object\\",
-      \\"properties\\": {
-        \\"private\\": {
-          \\"type\\": \\"boolean\\"
-        },
-        \\"messageOptions\\": {
-          \\"$ref\\": \\"#/definitions/MessageOptions\\"
-        }
-      },
-      \\"required\\": [
-        \\"private\\",
-        \\"messageOptions\\"
-      ]
-    },
-    \\"MessageOptions\\": {
-      \\"type\\": \\"object\\",
-      \\"properties\\": {
-        \\"newsletter\\": {
-          \\"type\\": \\"boolean\\"
-        }
-      },
-      \\"required\\": [
-        \\"newsletter\\"
-      ]
-    },
     \\"Email\\": {
       \\"type\\": \\"string\\"
     },
@@ -141,6 +141,23 @@ definitions:
           - profile
     required:
       - data
+  Profile:
+    type: object
+    properties:
+      private:
+        type: boolean
+      messageOptions:
+        $ref: '#/definitions/MessageOptions'
+    required:
+      - private
+      - messageOptions
+  MessageOptions:
+    type: object
+    properties:
+      newsletter:
+        type: boolean
+    required:
+      - newsletter
   ErrorBody:
     type: object
     properties:
@@ -177,23 +194,6 @@ definitions:
           - address
     required:
       - data
-  Profile:
-    type: object
-    properties:
-      private:
-        type: boolean
-      messageOptions:
-        $ref: '#/definitions/MessageOptions'
-    required:
-      - private
-      - messageOptions
-  MessageOptions:
-    type: object
-    properties:
-      newsletter:
-        type: boolean
-    required:
-      - newsletter
   Email:
     type: string
   Address:

--- a/lib/src/generators/contract/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/openapi2.spec.ts.snap
@@ -145,50 +145,8 @@ exports[`OpenAPI 2 generator produces valid code: json 1`] = `
     }
   },
   \\"definitions\\": {
-    \\"UserBody\\": {
-      \\"type\\": \\"object\\",
-      \\"properties\\": {
-        \\"data\\": {
-          \\"type\\": \\"object\\",
-          \\"properties\\": {
-            \\"firstName\\": {
-              \\"type\\": \\"string\\"
-            },
-            \\"lastName\\": {
-              \\"type\\": \\"string\\"
-            },
-            \\"profile\\": {
-              \\"$ref\\": \\"#/definitions/Profile\\"
-            }
-          },
-          \\"required\\": [
-            \\"firstName\\",
-            \\"lastName\\",
-            \\"profile\\"
-          ]
-        }
-      },
-      \\"required\\": [
-        \\"data\\"
-      ]
-    },
-    \\"ErrorBody\\": {
-      \\"type\\": \\"object\\",
-      \\"properties\\": {
-        \\"name\\": {
-          \\"type\\": \\"string\\"
-        },
-        \\"message\\": {
-          \\"type\\": \\"array\\",
-          \\"items\\": {
-            \\"type\\": \\"string\\"
-          }
-        }
-      },
-      \\"required\\": [
-        \\"name\\",
-        \\"message\\"
-      ]
+    \\"Address\\": {
+      \\"type\\": \\"string\\"
     },
     \\"CreateUserRequestBody\\": {
       \\"type\\": \\"object\\",
@@ -225,6 +183,38 @@ exports[`OpenAPI 2 generator produces valid code: json 1`] = `
         \\"data\\"
       ]
     },
+    \\"Email\\": {
+      \\"type\\": \\"string\\"
+    },
+    \\"ErrorBody\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"name\\": {
+          \\"type\\": \\"string\\"
+        },
+        \\"message\\": {
+          \\"type\\": \\"array\\",
+          \\"items\\": {
+            \\"type\\": \\"string\\"
+          }
+        }
+      },
+      \\"required\\": [
+        \\"name\\",
+        \\"message\\"
+      ]
+    },
+    \\"MessageOptions\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"newsletter\\": {
+          \\"type\\": \\"boolean\\"
+        }
+      },
+      \\"required\\": [
+        \\"newsletter\\"
+      ]
+    },
     \\"Profile\\": {
       \\"type\\": \\"object\\",
       \\"properties\\": {
@@ -240,22 +230,32 @@ exports[`OpenAPI 2 generator produces valid code: json 1`] = `
         \\"messageOptions\\"
       ]
     },
-    \\"MessageOptions\\": {
+    \\"UserBody\\": {
       \\"type\\": \\"object\\",
       \\"properties\\": {
-        \\"newsletter\\": {
-          \\"type\\": \\"boolean\\"
+        \\"data\\": {
+          \\"type\\": \\"object\\",
+          \\"properties\\": {
+            \\"firstName\\": {
+              \\"type\\": \\"string\\"
+            },
+            \\"lastName\\": {
+              \\"type\\": \\"string\\"
+            },
+            \\"profile\\": {
+              \\"$ref\\": \\"#/definitions/Profile\\"
+            }
+          },
+          \\"required\\": [
+            \\"firstName\\",
+            \\"lastName\\",
+            \\"profile\\"
+          ]
         }
       },
       \\"required\\": [
-        \\"newsletter\\"
+        \\"data\\"
       ]
-    },
-    \\"Email\\": {
-      \\"type\\": \\"string\\"
-    },
-    \\"Address\\": {
-      \\"type\\": \\"string\\"
     }
   },
   \\"securityDefinitions\\": {
@@ -373,36 +373,8 @@ paths:
           headers: {}
           description: ''
 definitions:
-  UserBody:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          firstName:
-            type: string
-          lastName:
-            type: string
-          profile:
-            $ref: '#/definitions/Profile'
-        required:
-          - firstName
-          - lastName
-          - profile
-    required:
-      - data
-  ErrorBody:
-    type: object
-    properties:
-      name:
-        type: string
-      message:
-        type: array
-        items:
-          type: string
-    required:
-      - name
-      - message
+  Address:
+    type: string
   CreateUserRequestBody:
     type: object
     properties:
@@ -427,6 +399,27 @@ definitions:
           - address
     required:
       - data
+  Email:
+    type: string
+  ErrorBody:
+    type: object
+    properties:
+      name:
+        type: string
+      message:
+        type: array
+        items:
+          type: string
+    required:
+      - name
+      - message
+  MessageOptions:
+    type: object
+    properties:
+      newsletter:
+        type: boolean
+    required:
+      - newsletter
   Profile:
     type: object
     properties:
@@ -437,17 +430,24 @@ definitions:
     required:
       - private
       - messageOptions
-  MessageOptions:
+  UserBody:
     type: object
     properties:
-      newsletter:
-        type: boolean
+      data:
+        type: object
+        properties:
+          firstName:
+            type: string
+          lastName:
+            type: string
+          profile:
+            $ref: '#/definitions/Profile'
+        required:
+          - firstName
+          - lastName
+          - profile
     required:
-      - newsletter
-  Email:
-    type: string
-  Address:
-    type: string
+      - data
 securityDefinitions:
   securityHeader:
     type: apiKey

--- a/lib/src/generators/contract/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/openapi3.spec.ts.snap
@@ -192,50 +192,8 @@ exports[`OpenAPI 3 generator produces valid code: json 1`] = `
   },
   \\"components\\": {
     \\"schemas\\": {
-      \\"UserBody\\": {
-        \\"type\\": \\"object\\",
-        \\"properties\\": {
-          \\"data\\": {
-            \\"type\\": \\"object\\",
-            \\"properties\\": {
-              \\"firstName\\": {
-                \\"type\\": \\"string\\"
-              },
-              \\"lastName\\": {
-                \\"type\\": \\"string\\"
-              },
-              \\"profile\\": {
-                \\"$ref\\": \\"#/components/schemas/Profile\\"
-              }
-            },
-            \\"required\\": [
-              \\"firstName\\",
-              \\"lastName\\",
-              \\"profile\\"
-            ]
-          }
-        },
-        \\"required\\": [
-          \\"data\\"
-        ]
-      },
-      \\"ErrorBody\\": {
-        \\"type\\": \\"object\\",
-        \\"properties\\": {
-          \\"name\\": {
-            \\"type\\": \\"string\\"
-          },
-          \\"message\\": {
-            \\"type\\": \\"array\\",
-            \\"items\\": {
-              \\"type\\": \\"string\\"
-            }
-          }
-        },
-        \\"required\\": [
-          \\"name\\",
-          \\"message\\"
-        ]
+      \\"Address\\": {
+        \\"type\\": \\"string\\"
       },
       \\"CreateUserRequestBody\\": {
         \\"type\\": \\"object\\",
@@ -272,6 +230,38 @@ exports[`OpenAPI 3 generator produces valid code: json 1`] = `
           \\"data\\"
         ]
       },
+      \\"Email\\": {
+        \\"type\\": \\"string\\"
+      },
+      \\"ErrorBody\\": {
+        \\"type\\": \\"object\\",
+        \\"properties\\": {
+          \\"name\\": {
+            \\"type\\": \\"string\\"
+          },
+          \\"message\\": {
+            \\"type\\": \\"array\\",
+            \\"items\\": {
+              \\"type\\": \\"string\\"
+            }
+          }
+        },
+        \\"required\\": [
+          \\"name\\",
+          \\"message\\"
+        ]
+      },
+      \\"MessageOptions\\": {
+        \\"type\\": \\"object\\",
+        \\"properties\\": {
+          \\"newsletter\\": {
+            \\"type\\": \\"boolean\\"
+          }
+        },
+        \\"required\\": [
+          \\"newsletter\\"
+        ]
+      },
       \\"Profile\\": {
         \\"type\\": \\"object\\",
         \\"properties\\": {
@@ -287,22 +277,32 @@ exports[`OpenAPI 3 generator produces valid code: json 1`] = `
           \\"messageOptions\\"
         ]
       },
-      \\"MessageOptions\\": {
+      \\"UserBody\\": {
         \\"type\\": \\"object\\",
         \\"properties\\": {
-          \\"newsletter\\": {
-            \\"type\\": \\"boolean\\"
+          \\"data\\": {
+            \\"type\\": \\"object\\",
+            \\"properties\\": {
+              \\"firstName\\": {
+                \\"type\\": \\"string\\"
+              },
+              \\"lastName\\": {
+                \\"type\\": \\"string\\"
+              },
+              \\"profile\\": {
+                \\"$ref\\": \\"#/components/schemas/Profile\\"
+              }
+            },
+            \\"required\\": [
+              \\"firstName\\",
+              \\"lastName\\",
+              \\"profile\\"
+            ]
           }
         },
         \\"required\\": [
-          \\"newsletter\\"
+          \\"data\\"
         ]
-      },
-      \\"Email\\": {
-        \\"type\\": \\"string\\"
-      },
-      \\"Address\\": {
-        \\"type\\": \\"string\\"
       }
     },
     \\"securitySchemes\\": {
@@ -440,36 +440,8 @@ paths:
           description: ''
 components:
   schemas:
-    UserBody:
-      type: object
-      properties:
-        data:
-          type: object
-          properties:
-            firstName:
-              type: string
-            lastName:
-              type: string
-            profile:
-              $ref: '#/components/schemas/Profile'
-          required:
-            - firstName
-            - lastName
-            - profile
-      required:
-        - data
-    ErrorBody:
-      type: object
-      properties:
-        name:
-          type: string
-        message:
-          type: array
-          items:
-            type: string
-      required:
-        - name
-        - message
+    Address:
+      type: string
     CreateUserRequestBody:
       type: object
       properties:
@@ -494,6 +466,27 @@ components:
             - address
       required:
         - data
+    Email:
+      type: string
+    ErrorBody:
+      type: object
+      properties:
+        name:
+          type: string
+        message:
+          type: array
+          items:
+            type: string
+      required:
+        - name
+        - message
+    MessageOptions:
+      type: object
+      properties:
+        newsletter:
+          type: boolean
+      required:
+        - newsletter
     Profile:
       type: object
       properties:
@@ -504,17 +497,24 @@ components:
       required:
         - private
         - messageOptions
-    MessageOptions:
+    UserBody:
       type: object
       properties:
-        newsletter:
-          type: boolean
+        data:
+          type: object
+          properties:
+            firstName:
+              type: string
+            lastName:
+              type: string
+            profile:
+              $ref: '#/components/schemas/Profile'
+          required:
+            - firstName
+            - lastName
+            - profile
       required:
-        - newsletter
-    Email:
-      type: string
-    Address:
-      type: string
+        - data
   securitySchemes:
     securityHeader:
       type: apiKey

--- a/lib/src/generators/contract/openapi2.ts
+++ b/lib/src/generators/contract/openapi2.ts
@@ -70,12 +70,22 @@ export function openApiV2(contractDefinition: ContractDefinition): OpenApiV2 {
       };
       return acc;
     }, {}),
-    definitions: contractDefinition.types.reduce<{
-      [typeName: string]: OpenAPI2SchemaType;
-    }>((acc, typeNode) => {
-      acc[typeNode.name] = openApi2TypeSchema(typeNode.type);
-      return acc;
-    }, {}),
+    definitions: contractDefinition.types
+      .sort((a, b) => {
+        if (a.name < b.name) {
+          return -1;
+        }
+        if (a.name > b.name) {
+          return 1;
+        }
+        return 0;
+      })
+      .reduce<{
+        [typeName: string]: OpenAPI2SchemaType;
+      }>((acc, typeNode) => {
+        acc[typeNode.name] = openApi2TypeSchema(typeNode.type);
+        return acc;
+      }, {}),
     ...(contractDefinition.api.securityHeader
       ? {
           securityDefinitions: {

--- a/lib/src/generators/contract/openapi2.ts
+++ b/lib/src/generators/contract/openapi2.ts
@@ -71,11 +71,11 @@ export function openApiV2(contractDefinition: ContractDefinition): OpenApiV2 {
       return acc;
     }, {}),
     definitions: contractDefinition.types
-      .sort((a, b) => {
-        if (a.name < b.name) {
+      .sort((prevType, currType) => {
+        if (prevType.name < currType.name) {
           return -1;
         }
-        if (a.name > b.name) {
+        if (prevType.name > currType.name) {
           return 1;
         }
         return 0;

--- a/lib/src/generators/contract/openapi3.ts
+++ b/lib/src/generators/contract/openapi3.ts
@@ -100,11 +100,11 @@ export function openApiV3(contractDefinition: ContractDefinition): OpenApiV3 {
     }, {}),
     components: {
       schemas: contractDefinition.types
-        .sort((a, b) => {
-          if (a.name < b.name) {
+        .sort((prevType, currType) => {
+          if (prevType.name < currType.name) {
             return -1;
           }
-          if (a.name > b.name) {
+          if (prevType.name > currType.name) {
             return 1;
           }
           return 0;

--- a/lib/src/generators/contract/openapi3.ts
+++ b/lib/src/generators/contract/openapi3.ts
@@ -99,15 +99,25 @@ export function openApiV3(contractDefinition: ContractDefinition): OpenApiV3 {
       return acc;
     }, {}),
     components: {
-      schemas: contractDefinition.types.reduce<{
-        [typeName: string]: OpenAPI3SchemaType;
-      }>((acc, typeNode) => {
-        acc[typeNode.name] = openApi3TypeSchema(
-          contractDefinition.types,
-          typeNode.type
-        );
-        return acc;
-      }, {}),
+      schemas: contractDefinition.types
+        .sort((a, b) => {
+          if (a.name < b.name) {
+            return -1;
+          }
+          if (a.name > b.name) {
+            return 1;
+          }
+          return 0;
+        })
+        .reduce<{
+          [typeName: string]: OpenAPI3SchemaType;
+        }>((acc, typeNode) => {
+          acc[typeNode.name] = openApi3TypeSchema(
+            contractDefinition.types,
+            typeNode.type
+          );
+          return acc;
+        }, {}),
       securitySchemes: contractDefinition.api.securityHeader
         ? {
             [SECURITY_HEADER_SCHEME_NAME]: {

--- a/lib/src/parsers/parser.spec.ts
+++ b/lib/src/parsers/parser.spec.ts
@@ -3,7 +3,7 @@ import { parse } from "./parser";
 describe("parser", () => {
   test("parses all information", () => {
     const result = parse("./lib/src/test/examples/contract.ts");
-    expect(result.api).not.toBeUndefined;
+    expect(result.api).not.toBeUndefined();
     expect(result.endpoints).toHaveLength(2);
     expect(result.types).toHaveLength(7);
   });
@@ -12,7 +12,7 @@ describe("parser", () => {
     const result = parse(
       "./lib/src/test/examples/recursive-imports-and-exports/contract.ts"
     );
-    expect(result.api).not.toBeUndefined;
+    expect(result.api).not.toBeUndefined();
     expect(result.endpoints).toHaveLength(4);
   });
 });


### PR DESCRIPTION
Reference types are not being resolved correctly when parsing root level complex types (e.g. arrays, unions) on request/response bodies. Root level reference types will now simply run through the same recursive reference type resolver as non-root level reference types. This removes the root level unique reference optimisation parsing which provided a minor performance impact at best. 

The OpenAPI generator is now configured to alphabetise definitions/components to ensure snapshots (testing) are more immune to implementation changes.