### PR TITLE
Set required property only when needed

### DIFF
--- a/lib/src/generators/contract/openapi3-schema.spec.ts
+++ b/lib/src/generators/contract/openapi3-schema.spec.ts
@@ -141,7 +141,6 @@ Object {
       expect(openApi3TypeSchema([], objectType([]))).toMatchInlineSnapshot(`
 Object {
   "properties": Object {},
-  "required": Array [],
   "type": "object",
 }
 `);
@@ -166,6 +165,27 @@ Object {
   "required": Array [
     "singleField",
   ],
+  "type": "object",
+}
+`);
+      expect(
+        openApi3TypeSchema(
+          [],
+          objectType([
+            {
+              name: "singleOptionalField",
+              type: NUMBER,
+              optional: true
+            }
+          ])
+        )
+      ).toMatchInlineSnapshot(`
+Object {
+  "properties": Object {
+    "singleOptionalField": Object {
+      "type": "number",
+    },
+  },
   "type": "object",
 }
 `);
@@ -651,7 +671,6 @@ Object {
           "type": "string",
         },
       },
-      "required": Array [],
       "type": "object",
     },
     Object {
@@ -663,7 +682,6 @@ Object {
           "type": "string",
         },
       },
-      "required": Array [],
       "type": "object",
     },
   ],

--- a/lib/src/generators/contract/openapi3-schema.ts
+++ b/lib/src/generators/contract/openapi3-schema.ts
@@ -72,10 +72,11 @@ export function openApi3TypeSchema(
       };
     case TypeKind.OBJECT:
       return type.properties.reduce<
-        OpenAPI3SchemaTypeObject & { required: string[] }
+        OpenAPI3SchemaTypeObject
       >(
         (acc, property) => {
           if (!property.optional) {
+            if (acc.required === undefined) { acc.required = []; }
             acc.required.push(property.name);
           }
           acc.properties[property.name] = openApi3TypeSchema(
@@ -86,8 +87,7 @@ export function openApi3TypeSchema(
         },
         {
           type: "object",
-          properties: {},
-          required: []
+          properties: {}
         }
       );
     case TypeKind.ARRAY:

--- a/lib/src/generators/contract/openapi3-schema.ts
+++ b/lib/src/generators/contract/openapi3-schema.ts
@@ -71,12 +71,12 @@ export function openApi3TypeSchema(
         format: "int32"
       };
     case TypeKind.OBJECT:
-      return type.properties.reduce<
-        OpenAPI3SchemaTypeObject
-      >(
+      return type.properties.reduce<OpenAPI3SchemaTypeObject>(
         (acc, property) => {
           if (!property.optional) {
-            if (acc.required === undefined) { acc.required = []; }
+            if (acc.required === undefined) {
+              acc.required = [];
+            }
             acc.required.push(property.name);
           }
           acc.properties[property.name] = openApi3TypeSchema(


### PR DESCRIPTION
Having a `"required": []` property is not a valid openapi3-schema, this pull request prevents spot from adding the `required` field if there are no required properties.

**To illustrate, if I had this on spot:**
```typescript
interface MyObject {
  my_property?: string;
}
```

**it would generate:**
```json
"MyObject": {
  "type": "object",
  "properties": {
    "my_property": {
      "type": "string"
    }
  },
  "required": [] // <--- wrong
}
```

**After fixing:**
```json
"MyObject": {
  "type": "object",
  "properties": {
    "my_property": {
      "type": "string"
    }
  }
}
```
