### PR TITLE
Helpful error message for missing String declaration

### DIFF
--- a/lib/src/parsers/utilities/parser-utility.ts
+++ b/lib/src/parsers/utilities/parser-utility.ts
@@ -449,7 +449,17 @@ export function getTargetDeclarationFromTypeReference(
     : symbol;
   const declarations = targetSymbol.getDeclarations();
   if (declarations.length !== 1) {
-    throw new Error("expected exactly one declaration");
+    const location = typeReference.getSourceFile().getFilePath();
+    const line = typeReference.getStartLineNumber();
+    // String interface must not be redefined and must be imported from the Spot native types
+    const errorMsg = `${location}#${line}: expected exactly one declaration for ${symbol.getName()}`;
+    if (symbol.getName() === "String") {
+      throw new Error(
+        `${errorMsg}\nDid you forget to import String? => import { String } from "@airtasker/spot"`
+      );
+    } else {
+      throw new Error(errorMsg);
+    }
   }
   const targetDeclaration = declarations[0];
   if (

--- a/lib/src/parsers/utilities/type-parser.spec.ts
+++ b/lib/src/parsers/utilities/type-parser.spec.ts
@@ -171,7 +171,7 @@ describe("type node parser", () => {
   describe("object types", () => {
     test("parses object literal type", () => {
       const typeNode = createTypeNode(`
-        { 
+        {
           /** Some description for title */
           title: string;
           year?: number;
@@ -343,7 +343,7 @@ function createTypeNode(...types: string[]): TypeNode {
     type ChainedAlias = AliasedCustomPrimitive;
   `;
   const sourceFile = createSourceFile(
-    { path: "main", content: content },
+    { path: "main", content },
     { path: "alias", content: `export type TypeAlias = string;` }
   );
   const interphace = sourceFile.getInterfaceOrThrow("TestInterface");

--- a/lib/src/parsers/utilities/type-parser.spec.ts
+++ b/lib/src/parsers/utilities/type-parser.spec.ts
@@ -143,6 +143,22 @@ describe("type node parser", () => {
       });
     });
 
+    test("identifies that the String type has not been imported", () => {
+      const content = `
+        interface TestInterface {
+          testProperty: String;
+        }
+      `;
+      const sourceFile = createSourceFile({ path: "main", content });
+      const interphace = sourceFile.getInterfaceOrThrow("TestInterface");
+      const property = interphace.getPropertyOrThrow("testProperty");
+      const typeNode = property.getTypeNodeOrThrow();
+
+      expect(() => parseTypeNode(typeNode)).toThrowError(
+        'expected exactly one declaration for String\nDid you forget to import String? => import { String } from "@airtasker/spot"'
+      );
+    });
+
     test("parses aliased custom primitive", () => {
       const typeNode = createTypeNode("AliasedCustomPrimitive");
 


### PR DESCRIPTION
When using the `String` native type, the TypeScript compiler does not complain as there exists native `String` interfaces in TypeScript. However, Spot will complain with an unhelpful message. A more helpful error message has been added to help with understanding the error.