### PR TITLE
Test runner confusing reporting of response body match

### DIFF
--- a/cli/src/test-utils/test-runner.ts
+++ b/cli/src/test-utils/test-runner.ts
@@ -468,11 +468,11 @@ function verifyBody(
   const validateFn = jsv.compile(schema);
   const valid = validateFn(response.data);
   if (valid) {
-    TestLogger.success("Body matched", { indent: 2 });
+    TestLogger.success("Body compliant", { indent: 2 });
     return true;
   } else {
     TestLogger.error(
-      `Body does not match: ${jsv.errorsText(
+      `Body is not compliant: ${jsv.errorsText(
         validateFn.errors
       )}\nReceived:\n${JSON.stringify(response.data, undefined, 2)}`,
       { indent: 2 }


### PR DESCRIPTION
The Spot test runner reports response body compliance as "Body matched". This can be confusing especially in cases where a compliant body is simply an empty response "{}" as any response body is compliant. The test runner should report "Body compliant" instead.