### PR TITLE
Test runner debug mode

### DIFF
--- a/cli/src/commands/test.ts
+++ b/cli/src/commands/test.ts
@@ -1,7 +1,7 @@
 import { Command, flags } from "@oclif/command";
 import { safeParse } from "../common/safe-parse";
 import { TestFilter } from "../test-utils/common";
-import { runTest } from "../test-utils/test-runner";
+import { TestRunner } from "../test-utils/test-runner";
 
 const ARG_API = "spot_contract";
 
@@ -49,16 +49,19 @@ export default class Test extends Command {
     const { url: baseUrl, stateUrl: baseStateUrl, testFilter, debug } = flags;
     const { definition } = safeParse.call(this, args[ARG_API]);
 
-    const testConfig = {
+    const testRunnerConfig = {
       baseStateUrl: baseStateUrl ? baseStateUrl : `${baseUrl}/state`,
       baseUrl,
-      testFilter: testFilter ? parseTestFilter(testFilter) : undefined,
       debugMode: debug
     };
+    const testConfig = {
+      testFilter: testFilter ? parseTestFilter(testFilter) : undefined
+    };
 
-    const allPassed = await runTest(definition, testConfig);
+    const testRunner = new TestRunner(testRunnerConfig);
+    const passed = await testRunner.test(definition, testConfig);
 
-    if (!allPassed) {
+    if (!passed) {
       this.exit(1);
     }
   }

--- a/cli/src/test-utils/common.ts
+++ b/cli/src/test-utils/common.ts
@@ -1,0 +1,11 @@
+export interface TestConfig {
+  baseStateUrl: string;
+  baseUrl: string;
+  testFilter?: TestFilter;
+  debugMode?: boolean;
+}
+
+export interface TestFilter {
+  endpoint: string;
+  test?: string;
+}

--- a/cli/src/test-utils/common.ts
+++ b/cli/src/test-utils/common.ts
@@ -1,8 +1,5 @@
 export interface TestConfig {
-  baseStateUrl: string;
-  baseUrl: string;
   testFilter?: TestFilter;
-  debugMode?: boolean;
 }
 
 export interface TestFilter {

--- a/cli/src/test-utils/test-logger.ts
+++ b/cli/src/test-utils/test-logger.ts
@@ -1,38 +1,82 @@
 import chalk from "chalk";
 
-export const TestLogger = {
-  error,
-  log,
-  success,
-  warn
-};
+export class TestLogger {
+  private readonly debugMode: boolean;
+
+  constructor(opts?: LoggerOpts) {
+    this.debugMode = opts ? !!opts.debugMode : false;
+  }
+
+  // tslint:disable:no-console
+  debug(message: string, opts?: LogOpts): void {
+    if (this.debugMode) {
+      console.log(chalk.gray(this.transformMessage(message, opts)));
+    }
+  }
+
+  log(message: string, opts?: LogOpts): void {
+    console.log(chalk.dim.white(this.transformMessage(message, opts)));
+  }
+
+  success(message: string, opts?: LogOpts): void {
+    console.log(chalk.green(this.transformMessage(message, opts)));
+  }
+
+  warn(message: string, opts?: LogOpts): void {
+    console.log(chalk.yellow(this.transformMessage(message, opts)));
+  }
+
+  error(message: string, opts?: LogOpts): void {
+    console.log(chalk.red(this.transformMessage(message, opts)));
+  }
+  // tslint:enable:no-console
+
+  private transformMessage(message: string, customOpts?: LogOpts): string {
+    const opts = {
+      indent: customOpts ? customOpts.indent || 0 : 0
+    };
+    const indents = "\t".repeat(opts.indent);
+    return indents + message.replace(/\n/g, `\n${indents}`);
+  }
+}
+
+// export const TestLogger = {
+//   error,
+//   log,
+//   success,
+//   warn
+// };
 
 // tslint:disable:no-console
-function error(message: string, opts?: LoggerOpts) {
-  console.log(chalk.red(transformMessage(message, opts)));
-}
+// function error(message: string, opts?: LogOpts) {
+//   console.log(chalk.red(transformMessage(message, opts)));
+// }
 
-function log(message: string, opts?: LoggerOpts) {
-  console.log(chalk.dim.white(transformMessage(message, opts)));
-}
+// function log(message: string, opts?: LogOpts) {
+//   console.log(chalk.dim.white(transformMessage(message, opts)));
+// }
 
-function success(message: string, opts?: LoggerOpts) {
-  console.log(chalk.green(transformMessage(message, opts)));
-}
+// function success(message: string, opts?: LogOpts) {
+//   console.log(chalk.green(transformMessage(message, opts)));
+// }
 
-function warn(message: string, opts?: LoggerOpts) {
-  console.log(chalk.yellow(transformMessage(message, opts)));
-}
+// function warn(message: string, opts?: LogOpts) {
+//   console.log(chalk.yellow(transformMessage(message, opts)));
+// }
 // tslint:enable:no-console
 
-function transformMessage(message: string, customOpts?: LoggerOpts) {
-  const opts = {
-    indent: customOpts ? customOpts.indent || 0 : 0
-  };
-  const indents = "\t".repeat(opts.indent);
-  return indents + message.replace(/\n/g, `\n${indents}`);
-}
+// function transformMessage(message: string, customOpts?: LogOpts) {
+//   const opts = {
+//     indent: customOpts ? customOpts.indent || 0 : 0
+//   };
+//   const indents = "\t".repeat(opts.indent);
+//   return indents + message.replace(/\n/g, `\n${indents}`);
+// }
 
 interface LoggerOpts {
+  debugMode?: boolean;
+}
+
+interface LogOpts {
   indent?: number; // number of tabs
 }

--- a/cli/src/test-utils/test-logger.ts
+++ b/cli/src/test-utils/test-logger.ts
@@ -1,6 +1,11 @@
 import chalk from "chalk";
 
 export class TestLogger {
+  /** Prepares an object for printing */
+  static formatObject(obj: any): string {
+    return JSON.stringify(obj, undefined, 2);
+  }
+
   private readonly debugMode: boolean;
 
   constructor(opts?: LoggerOpts) {
@@ -10,7 +15,7 @@ export class TestLogger {
   // tslint:disable:no-console
   debug(message: string, opts?: LogOpts): void {
     if (this.debugMode) {
-      console.log(chalk.gray(this.transformMessage(message, opts)));
+      console.log(chalk.magenta(this.transformMessage(message, opts)));
     }
   }
 
@@ -39,39 +44,6 @@ export class TestLogger {
     return indents + message.replace(/\n/g, `\n${indents}`);
   }
 }
-
-// export const TestLogger = {
-//   error,
-//   log,
-//   success,
-//   warn
-// };
-
-// tslint:disable:no-console
-// function error(message: string, opts?: LogOpts) {
-//   console.log(chalk.red(transformMessage(message, opts)));
-// }
-
-// function log(message: string, opts?: LogOpts) {
-//   console.log(chalk.dim.white(transformMessage(message, opts)));
-// }
-
-// function success(message: string, opts?: LogOpts) {
-//   console.log(chalk.green(transformMessage(message, opts)));
-// }
-
-// function warn(message: string, opts?: LogOpts) {
-//   console.log(chalk.yellow(transformMessage(message, opts)));
-// }
-// tslint:enable:no-console
-
-// function transformMessage(message: string, customOpts?: LogOpts) {
-//   const opts = {
-//     indent: customOpts ? customOpts.indent || 0 : 0
-//   };
-//   const indents = "\t".repeat(opts.indent);
-//   return indents + message.replace(/\n/g, `\n${indents}`);
-// }
 
 interface LoggerOpts {
   debugMode?: boolean;

--- a/cli/src/test-utils/test-runner.spec.ts
+++ b/cli/src/test-utils/test-runner.spec.ts
@@ -3,12 +3,19 @@ import { cleanse } from "../../../lib/src/cleansers/cleanser";
 import { ContractDefinition } from "../../../lib/src/models/definitions";
 import { parse } from "../../../lib/src/parsers/parser";
 import { verify } from "../../../lib/src/verifiers/verifier";
-import { runTest } from "./test-runner";
+import { TestRunner } from "./test-runner";
 
 describe("test runner", () => {
   const baseStateUrl = "http://localhost:9988/state";
   const baseUrl = "http://localhost:9988";
-  const testConfig = { baseStateUrl, baseUrl };
+  const testRunnerConfig = {
+    baseStateUrl,
+    baseUrl,
+    debugMode: true
+  };
+  // const testConfig = { baseStateUrl, baseUrl };
+
+  const testRunner = new TestRunner(testRunnerConfig);
 
   afterEach(() => {
     nock.cleanAll();
@@ -31,7 +38,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, testConfig);
+    const result = await testRunner.test(contract);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(true);
   });
@@ -54,7 +61,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, testConfig);
+    const result = await testRunner.test(contract);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(true);
   });
@@ -83,7 +90,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, testConfig);
+    const result = await testRunner.test(contract);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(true);
   });
@@ -113,7 +120,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, testConfig);
+    const result = await testRunner.test(contract);
     expect(scopeA.isDone()).toBe(true);
     expect(scopeB.isDone()).toBe(true);
     expect(result).toBe(true);
@@ -144,13 +151,9 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(
-      contract,
-      Object.assign(
-        { testFilter: { endpoint: "CreateCompany", test: "badRequestTest" } },
-        testConfig
-      )
-    );
+    const result = await testRunner.test(contract, {
+      testFilter: { endpoint: "CreateCompany", test: "badRequestTest" }
+    });
 
     expect(scopeA.isDone()).toBe(false);
     expect(scopeB.isDone()).toBe(true);
@@ -176,7 +179,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, testConfig);
+    const result = await testRunner.test(contract);
     expect(initializeScope.isDone()).toBe(true);
     expect(tearDownScope.isDone()).toBe(true);
     expect(setupScope.isDone()).toBe(false);
@@ -196,7 +199,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, testConfig);
+    const result = await testRunner.test(contract);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(false);
   });
@@ -219,7 +222,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(400);
 
-    const result = await runTest(contract, testConfig);
+    const result = await testRunner.test(contract);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(false);
   });
@@ -242,7 +245,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, testConfig);
+    const result = await testRunner.test(contract);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(false);
   });
@@ -264,7 +267,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, testConfig);
+    const result = await testRunner.test(contract);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(false);
   });
@@ -286,7 +289,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, testConfig);
+    const result = await testRunner.test(contract);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(false);
   });
@@ -309,7 +312,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, testConfig);
+    const result = await testRunner.test(contract);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(false);
   });
@@ -333,7 +336,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, testConfig);
+    const result = await testRunner.test(contract);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(true);
   });
@@ -356,7 +359,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, testConfig);
+    const result = await testRunner.test(contract);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(true);
   });

--- a/cli/src/test-utils/test-runner.spec.ts
+++ b/cli/src/test-utils/test-runner.spec.ts
@@ -6,8 +6,9 @@ import { verify } from "../../../lib/src/verifiers/verifier";
 import { runTest } from "./test-runner";
 
 describe("test runner", () => {
-  const stateUrl = "http://localhost:9988/state";
+  const baseStateUrl = "http://localhost:9988/state";
   const baseUrl = "http://localhost:9988";
+  const testConfig = { baseStateUrl, baseUrl };
 
   afterEach(() => {
     nock.cleanAll();
@@ -30,7 +31,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, stateUrl, baseUrl);
+    const result = await runTest(contract, testConfig);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(true);
   });
@@ -53,7 +54,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, stateUrl, baseUrl);
+    const result = await runTest(contract, testConfig);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(true);
   });
@@ -82,7 +83,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, stateUrl, baseUrl);
+    const result = await runTest(contract, testConfig);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(true);
   });
@@ -112,7 +113,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, stateUrl, baseUrl);
+    const result = await runTest(contract, testConfig);
     expect(scopeA.isDone()).toBe(true);
     expect(scopeB.isDone()).toBe(true);
     expect(result).toBe(true);
@@ -143,10 +144,13 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, stateUrl, baseUrl, {
-      endpoint: "CreateCompany",
-      test: "badRequestTest"
-    });
+    const result = await runTest(
+      contract,
+      Object.assign(
+        { testFilter: { endpoint: "CreateCompany", test: "badRequestTest" } },
+        testConfig
+      )
+    );
 
     expect(scopeA.isDone()).toBe(false);
     expect(scopeB.isDone()).toBe(true);
@@ -172,7 +176,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, stateUrl, baseUrl);
+    const result = await runTest(contract, testConfig);
     expect(initializeScope.isDone()).toBe(true);
     expect(tearDownScope.isDone()).toBe(true);
     expect(setupScope.isDone()).toBe(false);
@@ -192,7 +196,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, stateUrl, baseUrl);
+    const result = await runTest(contract, testConfig);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(false);
   });
@@ -215,7 +219,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(400);
 
-    const result = await runTest(contract, stateUrl, baseUrl);
+    const result = await runTest(contract, testConfig);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(false);
   });
@@ -238,7 +242,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, stateUrl, baseUrl);
+    const result = await runTest(contract, testConfig);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(false);
   });
@@ -260,7 +264,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, stateUrl, baseUrl);
+    const result = await runTest(contract, testConfig);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(false);
   });
@@ -282,7 +286,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, stateUrl, baseUrl);
+    const result = await runTest(contract, testConfig);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(false);
   });
@@ -305,7 +309,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, stateUrl, baseUrl);
+    const result = await runTest(contract, testConfig);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(false);
   });
@@ -329,7 +333,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, stateUrl, baseUrl);
+    const result = await runTest(contract, testConfig);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(true);
   });
@@ -352,7 +356,7 @@ describe("test runner", () => {
       .post("/state/teardown")
       .reply(200);
 
-    const result = await runTest(contract, stateUrl, baseUrl);
+    const result = await runTest(contract, testConfig);
     expect(scope.isDone()).toBe(true);
     expect(result).toBe(true);
   });

--- a/cli/src/test-utils/test-runner.spec.ts
+++ b/cli/src/test-utils/test-runner.spec.ts
@@ -13,7 +13,6 @@ describe("test runner", () => {
     baseUrl,
     debugMode: true
   };
-  // const testConfig = { baseStateUrl, baseUrl };
 
   const testRunner = new TestRunner(testRunnerConfig);
 
@@ -43,7 +42,7 @@ describe("test runner", () => {
     expect(result).toBe(true);
   });
 
-  test("single provider state", async () => {
+  test.only("single provider state", async () => {
     const contract = parseAndCleanse(
       "./cli/src/test-utils/test-runner-examples/single-provider-state.ts"
     );

--- a/cli/src/test-utils/test-runner.spec.ts
+++ b/cli/src/test-utils/test-runner.spec.ts
@@ -42,7 +42,7 @@ describe("test runner", () => {
     expect(result).toBe(true);
   });
 
-  test.only("single provider state", async () => {
+  test("single provider state", async () => {
     const contract = parseAndCleanse(
       "./cli/src/test-utils/test-runner-examples/single-provider-state.ts"
     );

--- a/cli/src/test-utils/test-runner.ts
+++ b/cli/src/test-utils/test-runner.ts
@@ -17,467 +17,467 @@ import { TestConfig } from "./common";
 import { TestLogger } from "./test-logger";
 import { TestTimer } from "./test-timer";
 
-/**
- * Run the contract test suite for a contract.
- *
- * @param definition contract definition
- * @param baseStateUrl base state change URL
- * @param baseUrl base URL
- * @param testFilter optional test filter
- */
-export async function runTest(
-  definition: ContractDefinition,
-  config: TestConfig
-): Promise<boolean> {
-  const testSuiteStartTime = TestTimer.startTime();
+export class TestRunner {
+  private readonly config: TestRunnerConfig;
+  private readonly logger: TestLogger;
 
-  let allPassed = true;
+  constructor(config: TestRunnerConfig) {
+    this.config = config;
+    this.logger = new TestLogger({ debugMode: config.debugMode });
+  }
 
-  for (const endpoint of definition.endpoints) {
-    for (const test of endpoint.tests) {
-      if (config.testFilter) {
-        if (
-          config.testFilter.endpoint !== endpoint.name ||
-          (config.testFilter.test && config.testFilter.test !== test.name)
-        ) {
-          TestLogger.warn(`Test ${endpoint.name}:${test.name} skipped`);
-          continue;
+  /**
+   * Run the contract test suite for a contract.
+   *
+   * @param definition contract definition
+   * @param config test configuration
+   */
+  async test(
+    definition: ContractDefinition,
+    config?: TestConfig
+  ): Promise<boolean> {
+    const testSuiteStartTime = TestTimer.startTime();
+
+    let allPassed = true;
+
+    for (const endpoint of definition.endpoints) {
+      for (const test of endpoint.tests) {
+        if (config && config.testFilter) {
+          if (
+            config.testFilter.endpoint !== endpoint.name ||
+            (config.testFilter.test && config.testFilter.test !== test.name)
+          ) {
+            this.logger.warn(`Test ${endpoint.name}:${test.name} skipped`);
+            continue;
+          }
         }
-      }
-      const testStartTime = TestTimer.startTime();
+        const testStartTime = TestTimer.startTime();
 
-      TestLogger.log(`Testing ${endpoint.name}:${test.name}`);
-      const correlatedResponse = findCorrelatedResponse(endpoint, test);
-      const result = await executeTest(
-        test,
-        config.baseStateUrl,
-        config.baseUrl,
+        this.logger.log(`Testing ${endpoint.name}:${test.name}`);
+        const correlatedResponse = this.findCorrelatedResponse(endpoint, test);
+        const result = await this.executeTest(
+          test,
+          endpoint,
+          correlatedResponse,
+          definition.types
+        );
+
+        if (result) {
+          this.logger.success(
+            `Test ${endpoint.name}:${
+              test.name
+            } passed (${TestTimer.formattedDiff(testStartTime)})`,
+            { indent: 1 }
+          );
+        } else {
+          this.logger.error(
+            `Test ${endpoint.name}:${
+              test.name
+            } failed (${TestTimer.formattedDiff(testStartTime)})`,
+            { indent: 1 }
+          );
+        }
+        allPassed = allPassed && result;
+      }
+    }
+
+    this.logger.log(
+      `Total time: ${TestTimer.formattedDiff(testSuiteStartTime)}\n`
+    );
+
+    return allPassed;
+  }
+
+  /**
+   * Run a particular contract test.
+   *
+   * @param test test definition
+   * @param endpoint endpoint definition
+   * @param correlatedResponse expected test response
+   * @param typeStore reference type definitions
+   */
+  private async executeTest(
+    test: TestDefinition,
+    endpoint: EndpointDefinition,
+    correlatedResponse: DefaultResponseDefinition,
+    typeStore: TypeNode[]
+  ): Promise<boolean> {
+    if (
+      (await this.executeStateInitialization()) &&
+      (await this.executeStateSetup(test))
+    ) {
+      const testResult = await this.executeRequestUnderTest(
         endpoint,
+        test,
         correlatedResponse,
-        definition.types
+        typeStore
       );
-
-      if (result) {
-        TestLogger.success(
-          `Test ${endpoint.name}:${test.name} passed (${TestTimer.formattedDiff(
-            testStartTime
-          )})`,
-          { indent: 1 }
-        );
-      } else {
-        TestLogger.error(
-          `Test ${endpoint.name}:${test.name} failed (${TestTimer.formattedDiff(
-            testStartTime
-          )})`,
-          { indent: 1 }
-        );
-      }
-      allPassed = allPassed && result;
+      const stateTearDownResult = await this.executeStateTeardown();
+      return testResult && stateTearDownResult;
+    } else {
+      await this.executeStateTeardown();
+      return false;
     }
   }
 
-  TestLogger.log(
-    `Total time: ${TestTimer.formattedDiff(testSuiteStartTime)}\n`
-  );
-
-  return allPassed;
-}
-
-/**
- * Run a particular contract test.
- *
- * @param test test definition
- * @param baseStateUrl base state change URL
- * @param baseUrl base URL
- * @param endpoint endpoint definition
- * @param correlatedResponse expected test response
- * @param typeStore reference type definitions
- */
-async function executeTest(
-  test: TestDefinition,
-  baseStateUrl: string,
-  baseUrl: string,
-  endpoint: EndpointDefinition,
-  correlatedResponse: DefaultResponseDefinition,
-  typeStore: TypeNode[]
-): Promise<boolean> {
-  if (
-    (await executeStateInitialization(baseStateUrl)) &&
-    (await executeStateSetup(test, baseStateUrl))
-  ) {
-    const testResult = await executeRequestUnderTest(
-      endpoint,
-      test,
-      baseUrl,
-      correlatedResponse,
-      typeStore
-    );
-    const stateTearDownResult = await executeStateTeardown(baseStateUrl);
-    return testResult && stateTearDownResult;
-  } else {
-    await executeStateTeardown(baseStateUrl);
-    return false;
+  /**
+   * Find the the response that matches the response status for a particular test.
+   * If no exact response status is found, the default response is used. Otherwise
+   * an error it thrown.
+   *
+   * @param endpoint endpoint definition
+   * @param test test definition
+   */
+  private findCorrelatedResponse(
+    endpoint: EndpointDefinition,
+    test: TestDefinition
+  ): DefaultResponseDefinition {
+    const correlatedResponse =
+      endpoint.responses.find(
+        response => response.status === test.response.status
+      ) || endpoint.defaultResponse;
+    if (!correlatedResponse) {
+      throw new Error(
+        `a response with status ${
+          test.response.status
+        } was not found and a default response has not been defined`
+      );
+    }
+    return correlatedResponse;
   }
-}
 
-/**
- * Find the the response that matches the response status for a particular test.
- * If no exact response status is found, the default response is used. Otherwise
- * an error it thrown.
- *
- * @param endpoint endpoint definition
- * @param test test definition
- */
-function findCorrelatedResponse(
-  endpoint: EndpointDefinition,
-  test: TestDefinition
-): DefaultResponseDefinition {
-  const correlatedResponse =
-    endpoint.responses.find(
-      response => response.status === test.response.status
-    ) || endpoint.defaultResponse;
-  if (!correlatedResponse) {
-    throw new Error(
-      `a response with status ${
-        test.response.status
-      } was not found and a default response has not been defined`
-    );
-  }
-  return correlatedResponse;
-}
-
-/**
- * Generate the axios configuration necessary to execute the request
- * under test. All responses statuses are considered valid with this
- * configuration.
- *
- * @param endpoint endpoint definition
- * @param test test definition
- * @param baseUrl base URL
- */
-function generateAxiosConfig(
-  endpoint: EndpointDefinition,
-  test: TestDefinition,
-  baseUrl: string
-): AxiosRequestConfig {
-  const urlPath = endpoint.path
-    .split("/")
-    .map(value => {
-      if (value.startsWith(":")) {
-        if (test.request) {
-          const pathParam = test.request.pathParams.find(pathParam => {
-            return pathParam.name === value.substring(1);
-          });
-          if (pathParam) {
-            return valueFromDataExpression(pathParam.expression);
+  /**
+   * Generate the axios configuration necessary to execute the request
+   * under test. All responses statuses are considered valid with this
+   * configuration.
+   *
+   * @param endpoint endpoint definition
+   * @param test test definition
+   */
+  private generateAxiosConfig(
+    endpoint: EndpointDefinition,
+    test: TestDefinition
+  ): AxiosRequestConfig {
+    const urlPath = endpoint.path
+      .split("/")
+      .map(value => {
+        if (value.startsWith(":")) {
+          if (test.request) {
+            const pathParam = test.request.pathParams.find(pathParam => {
+              return pathParam.name === value.substring(1);
+            });
+            if (pathParam) {
+              return valueFromDataExpression(pathParam.expression);
+            } else {
+              throw new Error(
+                `Unable to find path param for ${value} in ${endpoint.path}`
+              );
+            }
           } else {
             throw new Error(
               `Unable to find path param for ${value} in ${endpoint.path}`
             );
           }
         } else {
-          throw new Error(
-            `Unable to find path param for ${value} in ${endpoint.path}`
-          );
+          return value;
         }
-      } else {
-        return value;
-      }
-    })
-    .join("/");
+      })
+      .join("/");
 
-  const config: AxiosRequestConfig = {
-    baseURL: baseUrl,
-    url: urlPath,
-    method: endpoint.method,
-    validateStatus: () => true // never invalidate the status
-  };
-
-  if (test.request) {
-    config.headers = test.request.headers.reduce<AxiosHeaders>(
-      (acc, header) => {
-        acc[header.name] = valueFromDataExpression(header.expression);
-        return acc;
-      },
-      {}
-    );
-
-    config.params = test.request.queryParams.reduce<GenericParams>(
-      (acc, param) => {
-        acc[param.name] = valueFromDataExpression(param.expression);
-        return acc;
-      },
-      {}
-    );
-
-    config.paramsSerializer = params => {
-      return qsStringify(params);
+    const config: AxiosRequestConfig = {
+      baseURL: this.config.baseUrl,
+      url: urlPath,
+      method: endpoint.method,
+      validateStatus: () => true // never invalidate the status
     };
 
-    if (test.request.body) {
-      config.data = valueFromDataExpression(test.request.body);
+    if (test.request) {
+      config.headers = test.request.headers.reduce<AxiosHeaders>(
+        (acc, header) => {
+          acc[header.name] = valueFromDataExpression(header.expression);
+          return acc;
+        },
+        {}
+      );
+
+      config.params = test.request.queryParams.reduce<GenericParams>(
+        (acc, param) => {
+          acc[param.name] = valueFromDataExpression(param.expression);
+          return acc;
+        },
+        {}
+      );
+
+      config.paramsSerializer = params => {
+        return qsStringify(params);
+      };
+
+      if (test.request.body) {
+        config.data = valueFromDataExpression(test.request.body);
+      }
     }
+    return config;
   }
-  return config;
-}
 
-/**
- * Executes the request under test.
- *
- * @param endpoint endpoint definition
- * @param test test definition
- * @param baseUrl base URL
- * @param correlatedResponse expected test response
- * @param typeStore reference type definitions
- */
-async function executeRequestUnderTest(
-  endpoint: EndpointDefinition,
-  test: TestDefinition,
-  baseUrl: string,
-  correlatedResponse: DefaultResponseDefinition,
-  typeStore: TypeNode[]
-) {
-  const testStartTime = process.hrtime();
+  /**
+   * Executes the request under test.
+   *
+   * @param endpoint endpoint definition
+   * @param test test definition
+   * @param baseUrl base URL
+   * @param correlatedResponse expected test response
+   * @param typeStore reference type definitions
+   */
+  private async executeRequestUnderTest(
+    endpoint: EndpointDefinition,
+    test: TestDefinition,
+    correlatedResponse: DefaultResponseDefinition,
+    typeStore: TypeNode[]
+  ) {
+    const testStartTime = process.hrtime();
 
-  const config = generateAxiosConfig(endpoint, test, baseUrl);
-  TestLogger.log(
-    `Performing request under test: ${config.method} ${config.url}`,
-    { indent: 1 }
-  );
-  TestLogger.log(
-    `Request complete (${TestTimer.formattedDiff(testStartTime)})`,
-    { indent: 2 }
-  );
-  const response = await axios.request(config);
-  const statusResult = verifyStatus(test, response);
-  // TODO: check headers
-  const bodyResult = verifyBody(correlatedResponse, response, typeStore);
-
-  return statusResult && bodyResult;
-}
-
-/**
- * Execute the state initialization request.
- *
- * @param baseStateUrl base state change URL
- */
-async function executeStateInitialization(
-  baseStateUrl: string
-): Promise<boolean> {
-  const testInitStartTime = process.hrtime();
-
-  try {
-    TestLogger.log("Performing state initialization request", { indent: 1 });
-    await axios.post(`${baseStateUrl}/initialize`);
-    TestLogger.success(
-      `State initialization request success (${TestTimer.formattedDiff(
-        testInitStartTime
-      )})`,
+    const config = this.generateAxiosConfig(endpoint, test);
+    this.logger.log(
+      `Performing request under test: ${config.method} ${config.url}`,
+      { indent: 1 }
+    );
+    this.logger.log(
+      `Request complete (${TestTimer.formattedDiff(testStartTime)})`,
       { indent: 2 }
     );
-    return true;
-  } catch (error) {
-    if (error.response) {
-      TestLogger.error(
-        `State initialization request failed: received ${
-          error.response.status
-        } status (${TestTimer.formattedDiff(
-          testInitStartTime
-        )})\nReceived:\n${JSON.stringify(error.response.data, undefined, 2)}`,
-        { indent: 2 }
-      );
-    } else if (error.request) {
-      TestLogger.error(
-        `State initialization request failed: no response (${TestTimer.formattedDiff(
-          testInitStartTime
-        )})`,
-        { indent: 2 }
-      );
-    } else {
-      TestLogger.error(
-        `State initialization request failed: ${
-          error.message
-        } (${TestTimer.formattedDiff(testInitStartTime)})`,
-        { indent: 2 }
-      );
-    }
-    return false;
+    const response = await axios.request(config);
+    const statusResult = this.verifyStatus(test, response);
+    // TODO: check headers
+    const bodyResult = this.verifyBody(correlatedResponse, response, typeStore);
+
+    return statusResult && bodyResult;
   }
-}
 
-/**
- * Execute state setup requests defined for a test.
- *
- * @param test test definition
- * @param baseStateUrl base state change URL
- */
-async function executeStateSetup(
-  test: TestDefinition,
-  baseStateUrl: string
-): Promise<boolean> {
-  for (const state of test.states) {
-    const testSetupStartTime = process.hrtime();
+  /**
+   * Execute the state initialization request.
+   *
+   * @param baseStateUrl base state change URL
+   */
+  private async executeStateInitialization(): Promise<boolean> {
+    const testInitStartTime = process.hrtime();
 
-    TestLogger.log(`Performing state setup request: ${state.name}`, {
-      indent: 1
-    });
-    const data = {
-      name: state.name,
-      params: state.params.reduce<GenericParams>((acc, param) => {
-        acc[param.name] = valueFromDataExpression(param.expression);
-        return acc;
-      }, {})
-    };
     try {
-      await axios.post(`${baseStateUrl}/setup`, data);
-      TestLogger.success(
-        `State setup request (${state.name}) success (${TestTimer.formattedDiff(
-          testSetupStartTime
+      this.logger.log("Performing state initialization request", { indent: 1 });
+      await axios.post(`${this.config.baseStateUrl}/initialize`);
+      this.logger.success(
+        `State initialization request success (${TestTimer.formattedDiff(
+          testInitStartTime
         )})`,
         { indent: 2 }
       );
+      return true;
     } catch (error) {
       if (error.response) {
-        TestLogger.error(
-          `State change request (${state.name}) failed: received ${
+        this.logger.error(
+          `State initialization request failed: received ${
             error.response.status
           } status (${TestTimer.formattedDiff(
-            testSetupStartTime
+            testInitStartTime
           )})\nReceived:\n${JSON.stringify(error.response.data, undefined, 2)}`,
           { indent: 2 }
         );
       } else if (error.request) {
-        TestLogger.error(
-          `State change request (${
-            state.name
-          }) failed: no response (${TestTimer.formattedDiff(
-            testSetupStartTime
+        this.logger.error(
+          `State initialization request failed: no response (${TestTimer.formattedDiff(
+            testInitStartTime
           )})`,
           { indent: 2 }
         );
       } else {
-        TestLogger.error(
-          `State change request (${state.name}) failed: ${
+        this.logger.error(
+          `State initialization request failed: ${
             error.message
-          } (${TestTimer.formattedDiff(testSetupStartTime)})`,
+          } (${TestTimer.formattedDiff(testInitStartTime)})`,
           { indent: 2 }
         );
       }
       return false;
     }
   }
-  return true;
-}
 
-/**
- * Execute the state teardown request.
- *
- * @param baseStateUrl base state change URL
- */
-async function executeStateTeardown(baseStateUrl: string): Promise<boolean> {
-  const testTeardownStartTime = process.hrtime();
+  /**
+   * Execute state setup requests defined for a test.
+   *
+   * @param test test definition
+   */
+  private async executeStateSetup(test: TestDefinition): Promise<boolean> {
+    for (const state of test.states) {
+      const testSetupStartTime = process.hrtime();
 
-  try {
-    TestLogger.log("Performing state teardown request", { indent: 1 });
-    await axios.post(`${baseStateUrl}/teardown`);
-    TestLogger.success(
-      `State teardown request success (${TestTimer.formattedDiff(
-        testTeardownStartTime
-      )})`,
-      { indent: 2 }
-    );
+      this.logger.log(`Performing state setup request: ${state.name}`, {
+        indent: 1
+      });
+      const data = {
+        name: state.name,
+        params: state.params.reduce<GenericParams>((acc, param) => {
+          acc[param.name] = valueFromDataExpression(param.expression);
+          return acc;
+        }, {})
+      };
+      try {
+        await axios.post(`${this.config.baseStateUrl}/setup`, data);
+        this.logger.success(
+          `State setup request (${
+            state.name
+          }) success (${TestTimer.formattedDiff(testSetupStartTime)})`,
+          { indent: 2 }
+        );
+      } catch (error) {
+        if (error.response) {
+          this.logger.error(
+            `State change request (${state.name}) failed: received ${
+              error.response.status
+            } status (${TestTimer.formattedDiff(
+              testSetupStartTime
+            )})\nReceived:\n${JSON.stringify(
+              error.response.data,
+              undefined,
+              2
+            )}`,
+            { indent: 2 }
+          );
+        } else if (error.request) {
+          this.logger.error(
+            `State change request (${
+              state.name
+            }) failed: no response (${TestTimer.formattedDiff(
+              testSetupStartTime
+            )})`,
+            { indent: 2 }
+          );
+        } else {
+          this.logger.error(
+            `State change request (${state.name}) failed: ${
+              error.message
+            } (${TestTimer.formattedDiff(testSetupStartTime)})`,
+            { indent: 2 }
+          );
+        }
+        return false;
+      }
+    }
     return true;
-  } catch (error) {
-    if (error.response) {
-      TestLogger.error(
-        `State teardown request failed: received ${
-          error.response.status
-        } status (${TestTimer.formattedDiff(
-          testTeardownStartTime
-        )})\nReceived:\n${JSON.stringify(error.response.data, undefined, 2)}`,
-        { indent: 2 }
-      );
-    } else if (error.request) {
-      TestLogger.error(
-        `State teardown request failed: no response (${TestTimer.formattedDiff(
+  }
+
+  /**
+   * Execute the state teardown request.
+   */
+  private async executeStateTeardown(): Promise<boolean> {
+    const testTeardownStartTime = process.hrtime();
+
+    try {
+      this.logger.log("Performing state teardown request", { indent: 1 });
+      await axios.post(`${this.config.baseStateUrl}/teardown`);
+      this.logger.success(
+        `State teardown request success (${TestTimer.formattedDiff(
           testTeardownStartTime
         )})`,
         { indent: 2 }
       );
+      return true;
+    } catch (error) {
+      if (error.response) {
+        this.logger.error(
+          `State teardown request failed: received ${
+            error.response.status
+          } status (${TestTimer.formattedDiff(
+            testTeardownStartTime
+          )})\nReceived:\n${JSON.stringify(error.response.data, undefined, 2)}`,
+          { indent: 2 }
+        );
+      } else if (error.request) {
+        this.logger.error(
+          `State teardown request failed: no response (${TestTimer.formattedDiff(
+            testTeardownStartTime
+          )})`,
+          { indent: 2 }
+        );
+      } else {
+        this.logger.error(
+          `State teardown request failed: ${
+            error.message
+          } (${TestTimer.formattedDiff(testTeardownStartTime)})`,
+          { indent: 2 }
+        );
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Check if an axios response status matches the expected status of a test.
+   *
+   * @param test test definition
+   * @param response axios response
+   */
+  private verifyStatus(
+    test: TestDefinition,
+    response: AxiosResponse<any>
+  ): boolean {
+    if (test.response.status === response.status) {
+      this.logger.success("Status matched", { indent: 2 });
+      return true;
     } else {
-      TestLogger.error(
-        `State teardown request failed: ${
-          error.message
-        } (${TestTimer.formattedDiff(testTeardownStartTime)})`,
+      this.logger.error(
+        `Expected status ${test.response.status}, got ${response.status}`,
         { indent: 2 }
       );
+      return false;
     }
-    return false;
+  }
+
+  /**
+   * Check if an exios response body matches the expected body of an expected response definition.
+   *
+   * @param expectedResponse expected response
+   * @param response axios response
+   * @param typeStore reference type definitions
+   */
+  private verifyBody(
+    expectedResponse: DefaultResponseDefinition,
+    response: AxiosResponse<any>,
+    typeStore: TypeNode[]
+  ): boolean {
+    if (!expectedResponse.body) {
+      return true;
+    }
+
+    const jsv = new JsonSchemaValidator();
+    const schema = {
+      ...jsonTypeSchema(expectedResponse.body.type),
+      definitions: typeStore.reduce<{ [key: string]: JsonSchemaType }>(
+        (defAcc, typeNode) => {
+          return { [typeNode.name]: jsonTypeSchema(typeNode.type), ...defAcc };
+        },
+        {}
+      )
+    };
+    const validateFn = jsv.compile(schema);
+    const valid = validateFn(response.data);
+    if (valid) {
+      this.logger.success("Body compliant", { indent: 2 });
+      return true;
+    } else {
+      this.logger.error(
+        `Body is not compliant: ${jsv.errorsText(
+          validateFn.errors
+        )}\nReceived:\n${JSON.stringify(response.data, undefined, 2)}`,
+        { indent: 2 }
+      );
+      return false;
+    }
   }
 }
 
-/**
- * Check if an axios response status matches the expected status of a test.
- *
- * @param test test definition
- * @param response axios response
- */
-function verifyStatus(
-  test: TestDefinition,
-  response: AxiosResponse<any>
-): boolean {
-  if (test.response.status === response.status) {
-    TestLogger.success("Status matched", { indent: 2 });
-    return true;
-  } else {
-    TestLogger.error(
-      `Expected status ${test.response.status}, got ${response.status}`,
-      { indent: 2 }
-    );
-    return false;
-  }
-}
-
-/**
- * Check if an exios response body matches the expected body of an expected response definition.
- *
- * @param expectedResponse expected response
- * @param response axios response
- * @param typeStore reference type definitions
- */
-function verifyBody(
-  expectedResponse: DefaultResponseDefinition,
-  response: AxiosResponse<any>,
-  typeStore: TypeNode[]
-): boolean {
-  if (!expectedResponse.body) {
-    return true;
-  }
-
-  const jsv = new JsonSchemaValidator();
-  const schema = {
-    ...jsonTypeSchema(expectedResponse.body.type),
-    definitions: typeStore.reduce<{ [key: string]: JsonSchemaType }>(
-      (defAcc, typeNode) => {
-        return { [typeNode.name]: jsonTypeSchema(typeNode.type), ...defAcc };
-      },
-      {}
-    )
-  };
-  const validateFn = jsv.compile(schema);
-  const valid = validateFn(response.data);
-  if (valid) {
-    TestLogger.success("Body compliant", { indent: 2 });
-    return true;
-  } else {
-    TestLogger.error(
-      `Body is not compliant: ${jsv.errorsText(
-        validateFn.errors
-      )}\nReceived:\n${JSON.stringify(response.data, undefined, 2)}`,
-      { indent: 2 }
-    );
-    return false;
-  }
+export interface TestRunnerConfig {
+  baseStateUrl: string;
+  baseUrl: string;
+  debugMode: boolean;
 }
 
 interface AxiosHeaders {

--- a/cli/src/test-utils/test-runner.ts
+++ b/cli/src/test-utils/test-runner.ts
@@ -463,15 +463,14 @@ export class TestRunner {
     if (valid) {
       this.logger.success("Body compliant", { indent: 2 });
       return true;
-    } else {
-      this.logger.error(
-        `Body is not compliant: ${jsv.errorsText(
-          validateFn.errors
-        )}\nReceived:\n${TestLogger.formatObject(response.data)}`,
-        { indent: 2 }
-      );
-      return false;
     }
+    this.logger.error(
+      `Body is not compliant: ${jsv.errorsText(
+        validateFn.errors
+      )}\nReceived:\n${TestLogger.formatObject(response.data)}`,
+      { indent: 2 }
+    );
+    return false;
   }
 }
 

--- a/cli/src/test-utils/test-runner.ts
+++ b/cli/src/test-utils/test-runner.ts
@@ -13,6 +13,7 @@ import {
 } from "../../../lib/src/models/definitions";
 import { TypeNode } from "../../../lib/src/models/nodes";
 import { valueFromDataExpression } from "../../../lib/src/utilities/data-expression-utils";
+import { TestConfig } from "./common";
 import { TestLogger } from "./test-logger";
 import { TestTimer } from "./test-timer";
 
@@ -26,9 +27,7 @@ import { TestTimer } from "./test-timer";
  */
 export async function runTest(
   definition: ContractDefinition,
-  baseStateUrl: string,
-  baseUrl: string,
-  testFilter?: TestFilter
+  config: TestConfig
 ): Promise<boolean> {
   const testSuiteStartTime = TestTimer.startTime();
 
@@ -36,10 +35,10 @@ export async function runTest(
 
   for (const endpoint of definition.endpoints) {
     for (const test of endpoint.tests) {
-      if (testFilter) {
+      if (config.testFilter) {
         if (
-          testFilter.endpoint !== endpoint.name ||
-          (testFilter.test && testFilter.test !== test.name)
+          config.testFilter.endpoint !== endpoint.name ||
+          (config.testFilter.test && config.testFilter.test !== test.name)
         ) {
           TestLogger.warn(`Test ${endpoint.name}:${test.name} skipped`);
           continue;
@@ -51,8 +50,8 @@ export async function runTest(
       const correlatedResponse = findCorrelatedResponse(endpoint, test);
       const result = await executeTest(
         test,
-        baseStateUrl,
-        baseUrl,
+        config.baseStateUrl,
+        config.baseUrl,
         endpoint,
         correlatedResponse,
         definition.types
@@ -487,9 +486,4 @@ interface AxiosHeaders {
 
 interface GenericParams {
   [key: string]: any;
-}
-
-export interface TestFilter {
-  endpoint: string;
-  test?: string;
 }


### PR DESCRIPTION
The Spot test runner does not print out responses when validations succeed. There can be cases where it is useful to see what data is returned from the provider to assist debugging even if the data is compliant with the contract. For example an expected body "{}" definition is compliant with any response body returned. However the status code may be incorrect. The user has no simple way to see the actual response body to debug any issues. A debug mode will be added to enable this.