### PR TITLE
Simplify linting commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           name: Speccy OpenAPI 2
           command: ./bin/run generate --contract lib/src/__examples__/contract.ts -l yaml --generator openapi2 -o output/ && yarn --silent swagger2openapi output/contract.yml > output/contract.json && yarn speccy lint -s openapi-tags -s parameter-description output/contract.json
 
-  prettier-check:
+  lint-check:
     <<: *job_configuration
     steps:
       - checkout
@@ -57,28 +57,7 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-      - run:
-          name: Prettier
-          command: |
-            yarn prettier --list-different "**/*.js" "**/*.jsx" "**/*.ts" "**/*.tsx"
-
-  tslint-check:
-    <<: *job_configuration
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            - v1-dependencies-
-      - run: yarn install
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
-      - run:
-          name: TSLint
-          command: |
-            yarn tslint -p .
+      - run: yarn lint:check
 
   publish:
     <<: *job_configuration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,18 +87,14 @@ workflows:
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
-      - prettier-check:
-          filters:
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
-      - tslint-check:
+      - lint-check:
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - publish:
           requires:
             - build-and-test
-            - prettier-check
+            - lint-check
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/package.json
+++ b/package.json
@@ -81,8 +81,12 @@
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf build; tsc -p tsconfig.prod.json && rm -rf build/examples && oclif-dev manifest && oclif-dev readme",
     "test": "jest --testPathIgnorePatterns '<rootDir>/node_modules/' --testPathIgnorePatterns '<rootDir>/clients'",
-    "prettier:list": "prettier --list-different \"**/*.js\" \"**/*.jsx\" \"**/*.ts\" \"**/*.tsx\"",
-    "prettier:write": "prettier --write \"**/*.js\" \"**/*.jsx\" \"**/*.ts\" \"**/*.tsx\"",
+    "lint:check": "yarn prettier:check && yarn tslint:check",
+    "tslint:check": "tslint -p .",
+    "prettier:check": "prettier --list-different \"**/*.js\" \"**/*.jsx\" \"**/*.ts\" \"**/*.tsx\"",
+    "lint:fix": "yarn prettier:fix && yarn tslint:fix",
+    "tslint:fix": "tslint -p . --fix",
+    "prettier:fix": "prettier --write \"**/*.js\" \"**/*.jsx\" \"**/*.ts\" \"**/*.tsx\"",
     "release": "yarn version && oclif-dev readme && git add README.md && git commit README.md -m \"Update README\" && git push && npm publish --access=public"
   }
 }


### PR DESCRIPTION
It's much easier to run `yarn lint:fix` rather than remembering two different comments for Prettier and TSLint.