### PR TITLE
Release v0.2.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ EXAMPLE
   $ spot mock api.ts
 ```
 
-_See code: [build/cli/src/commands/checksum.js](https://github.com/airtasker/spot/blob/v0.2.15/build/cli/src/commands/checksum.js)_
+_See code: [build/cli/src/commands/checksum.js](https://github.com/airtasker/spot/blob/v0.2.16/build/cli/src/commands/checksum.js)_
 
 ## `spot generate`
 
@@ -158,7 +158,7 @@ EXAMPLE
   $ spot generate --contract api.ts --language yaml --generator openapi3 --out output/
 ```
 
-_See code: [build/cli/src/commands/generate.js](https://github.com/airtasker/spot/blob/v0.2.15/build/cli/src/commands/generate.js)_
+_See code: [build/cli/src/commands/generate.js](https://github.com/airtasker/spot/blob/v0.2.16/build/cli/src/commands/generate.js)_
 
 ## `spot help [COMMAND]`
 
@@ -196,7 +196,7 @@ EXAMPLE
   - package.json
 ```
 
-_See code: [build/cli/src/commands/init.js](https://github.com/airtasker/spot/blob/v0.2.15/build/cli/src/commands/init.js)_
+_See code: [build/cli/src/commands/init.js](https://github.com/airtasker/spot/blob/v0.2.16/build/cli/src/commands/init.js)_
 
 ## `spot lint SPOT_CONTRACT`
 
@@ -216,7 +216,7 @@ EXAMPLE
   $ spot lint api.ts
 ```
 
-_See code: [build/cli/src/commands/lint.js](https://github.com/airtasker/spot/blob/v0.2.15/build/cli/src/commands/lint.js)_
+_See code: [build/cli/src/commands/lint.js](https://github.com/airtasker/spot/blob/v0.2.16/build/cli/src/commands/lint.js)_
 
 ## `spot mock SPOT_CONTRACT`
 
@@ -238,7 +238,7 @@ EXAMPLE
   $ spot mock api.ts
 ```
 
-_See code: [build/cli/src/commands/mock.js](https://github.com/airtasker/spot/blob/v0.2.15/build/cli/src/commands/mock.js)_
+_See code: [build/cli/src/commands/mock.js](https://github.com/airtasker/spot/blob/v0.2.16/build/cli/src/commands/mock.js)_
 
 ## `spot test SPOT_CONTRACT`
 
@@ -264,7 +264,7 @@ EXAMPLES
   $ spot test api.ts -u http://localhost:3000 -t MyEndpoint:myTest
 ```
 
-_See code: [build/cli/src/commands/test.js](https://github.com/airtasker/spot/blob/v0.2.15/build/cli/src/commands/test.js)_
+_See code: [build/cli/src/commands/test.js](https://github.com/airtasker/spot/blob/v0.2.16/build/cli/src/commands/test.js)_
 
 ## `spot validate SPOT_CONTRACT`
 
@@ -284,5 +284,5 @@ EXAMPLE
   $ spot validate api.ts
 ```
 
-_See code: [build/cli/src/commands/validate.js](https://github.com/airtasker/spot/blob/v0.2.15/build/cli/src/commands/validate.js)_
+_See code: [build/cli/src/commands/validate.js](https://github.com/airtasker/spot/blob/v0.2.16/build/cli/src/commands/validate.js)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airtasker/spot",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "author": "Francois Wouts, Leslie Fung",
   "bin": {
     "spot": "./bin/run"


### PR DESCRIPTION
- Fixes a bug where `string | null` triggered a false positive in the no-nested-types-within-unions linting rule.