### PR TITLE
Draft decorator

### DIFF
--- a/lib/src/checksum/hash.spec.ts
+++ b/lib/src/checksum/hash.spec.ts
@@ -23,6 +23,7 @@ describe("Hash", () => {
       const endpointDefinition: EndpointDefinition = {
         name: "testEndpoint",
         description: "test endpoint",
+        isDraft: false,
         tags: ["test"],
         method: "GET",
         path: "/test",

--- a/lib/src/cleansers/nodes/endpoint-cleanser.ts
+++ b/lib/src/cleansers/nodes/endpoint-cleanser.ts
@@ -11,6 +11,7 @@ export function cleanseEndpoint(
   const name = endpointNode.name.value;
   const description =
     endpointNode.description && endpointNode.description.value;
+  const isDraft = endpointNode.isDraft;
   const tags = endpointNode.tags ? endpointNode.tags.value : [];
   const method = endpointNode.method.value;
   const path = endpointNode.path.value;
@@ -28,6 +29,7 @@ export function cleanseEndpoint(
   return {
     name,
     description,
+    isDraft,
     tags,
     method,
     path,

--- a/lib/src/linting/rules/has-discriminator.spec.ts
+++ b/lib/src/linting/rules/has-discriminator.spec.ts
@@ -29,6 +29,7 @@ describe("rule: has-discriminator", () => {
           name: fakeLocatable("createUser"),
           method: fakeLocatable<HttpMethod>("POST"),
           path: fakeLocatable("/users"),
+          isDraft: false,
           request: fakeLocatable<RequestNode>({
             body: fakeLocatable<BodyNode>({
               type: unionType([
@@ -147,6 +148,7 @@ describe("rule: has-discriminator", () => {
           name: fakeLocatable("createUser"),
           method: fakeLocatable<HttpMethod>("POST"),
           path: fakeLocatable("/users"),
+          isDraft: false,
           request: fakeLocatable<RequestNode>({
             body: fakeLocatable<BodyNode>({
               type: unionType([
@@ -185,6 +187,7 @@ describe("rule: has-discriminator", () => {
           name: fakeLocatable("createUser"),
           method: fakeLocatable<HttpMethod>("POST"),
           path: fakeLocatable("/users"),
+          isDraft: false,
           tests: [],
           defaultResponse: fakeLocatable<DefaultResponseNode>({
             body: fakeLocatable<BodyNode>({
@@ -223,6 +226,7 @@ describe("rule: has-discriminator", () => {
           name: fakeLocatable("createUser"),
           method: fakeLocatable<HttpMethod>("POST"),
           path: fakeLocatable("/users"),
+          isDraft: false,
           tests: [],
           responses: [
             fakeLocatable<ResponseNode>({

--- a/lib/src/linting/rules/has-request-payload.spec.ts
+++ b/lib/src/linting/rules/has-request-payload.spec.ts
@@ -22,6 +22,7 @@ describe("rule: has-request-payload", () => {
           name: fakeLocatable("listUsers"),
           method: fakeLocatable<HttpMethod>("GET"),
           path: fakeLocatable("/users"),
+          isDraft: false,
           tests: [],
           responses: []
         }),
@@ -30,6 +31,7 @@ describe("rule: has-request-payload", () => {
           name: fakeLocatable("getUser"),
           method: fakeLocatable<HttpMethod>("GET"),
           path: fakeLocatable("/users/:userId"),
+          isDraft: false,
           tests: [],
           request: fakeLocatable<RequestNode>({
             pathParams: fakeLocatable([
@@ -48,6 +50,7 @@ describe("rule: has-request-payload", () => {
           name: fakeLocatable("createUser"),
           method: fakeLocatable<HttpMethod>("POST"),
           path: fakeLocatable("/users"),
+          isDraft: false,
           tests: [],
           request: fakeLocatable<RequestNode>({
             body: fakeLocatable<BodyNode>({
@@ -74,6 +77,7 @@ describe("rule: has-request-payload", () => {
           name: fakeLocatable("createUser"),
           method: fakeLocatable<HttpMethod>("GET"),
           path: fakeLocatable("/users"),
+          isDraft: false,
           tests: [],
           request: fakeLocatable<RequestNode>({
             body: fakeLocatable<BodyNode>({
@@ -105,6 +109,7 @@ describe("rule: has-request-payload", () => {
           name: fakeLocatable("createUser"),
           method: fakeLocatable<HttpMethod>("POST"),
           path: fakeLocatable("/users"),
+          isDraft: false,
           tests: [],
           responses: []
         })
@@ -129,6 +134,7 @@ describe("rule: has-request-payload", () => {
           name: fakeLocatable("createUser"),
           method: fakeLocatable<HttpMethod>("POST"),
           path: fakeLocatable("/users"),
+          isDraft: false,
           tests: [],
           request: fakeLocatable<RequestNode>({}),
           responses: []

--- a/lib/src/linting/rules/has-response-payload.spec.ts
+++ b/lib/src/linting/rules/has-response-payload.spec.ts
@@ -22,6 +22,7 @@ describe("rule: has-response-payload", () => {
           name: fakeLocatable("listUsers"),
           method: fakeLocatable<HttpMethod>("GET"),
           path: fakeLocatable("/users"),
+          isDraft: false,
           tests: [],
           responses: [],
           defaultResponse: fakeLocatable<DefaultResponseNode>({
@@ -37,6 +38,7 @@ describe("rule: has-response-payload", () => {
           name: fakeLocatable("listUsers"),
           method: fakeLocatable<HttpMethod>("GET"),
           path: fakeLocatable("/users"),
+          isDraft: false,
           tests: [],
           responses: [
             fakeLocatable<ResponseNode>({
@@ -66,6 +68,7 @@ describe("rule: has-response-payload", () => {
           name: fakeLocatable("listUsers"),
           method: fakeLocatable<HttpMethod>("GET"),
           path: fakeLocatable("/users"),
+          isDraft: false,
           tests: [],
           responses: [],
           defaultResponse: fakeLocatable<DefaultResponseNode>({})
@@ -91,6 +94,7 @@ describe("rule: has-response-payload", () => {
           name: fakeLocatable("listUsers"),
           method: fakeLocatable<HttpMethod>("GET"),
           path: fakeLocatable("/users"),
+          isDraft: false,
           tests: [],
           responses: [
             fakeLocatable<ResponseNode>({
@@ -119,6 +123,7 @@ describe("rule: has-response-payload", () => {
           name: fakeLocatable("listUsers"),
           method: fakeLocatable<HttpMethod>("GET"),
           path: fakeLocatable("/users"),
+          isDraft: false,
           tests: [],
           responses: []
         })
@@ -142,6 +147,7 @@ describe("rule: has-response-payload", () => {
           name: fakeLocatable("listUsers"),
           method: fakeLocatable<HttpMethod>("GET"),
           path: fakeLocatable("/users"),
+          isDraft: false,
           tests: [],
           responses: [
             fakeLocatable<ResponseNode>({

--- a/lib/src/mockserver/matcher.spec.ts
+++ b/lib/src/mockserver/matcher.spec.ts
@@ -27,7 +27,8 @@ describe("Matcher", () => {
           {
             ...BASE_ENDPOINT,
             method: "GET",
-            path: "/users"
+            path: "/users",
+            isDraft: false
           }
         )
       ).toBeTruthy();
@@ -41,7 +42,8 @@ describe("Matcher", () => {
           {
             ...BASE_ENDPOINT,
             method: "GET",
-            path: "/users"
+            path: "/users",
+            isDraft: false
           }
         )
       ).toBeTruthy();
@@ -55,7 +57,8 @@ describe("Matcher", () => {
           {
             ...BASE_ENDPOINT,
             method: "POST",
-            path: "/users/:userId"
+            path: "/users/:userId",
+            isDraft: false
           }
         )
       ).toBeTruthy();
@@ -69,7 +72,8 @@ describe("Matcher", () => {
           {
             ...BASE_ENDPOINT,
             method: "POST",
-            path: "/users/:userId/details"
+            path: "/users/:userId/details",
+            isDraft: false
           }
         )
       ).toBeTruthy();
@@ -85,7 +89,8 @@ describe("Matcher", () => {
           {
             ...BASE_ENDPOINT,
             method: "GET",
-            path: "/users"
+            path: "/users",
+            isDraft: false
           }
         )
       ).toBeFalsy();
@@ -101,7 +106,8 @@ describe("Matcher", () => {
           {
             ...BASE_ENDPOINT,
             method: "GET",
-            path: "/users"
+            path: "/users",
+            isDraft: false
           }
         )
       ).toBeFalsy();
@@ -115,7 +121,8 @@ describe("Matcher", () => {
           {
             ...BASE_ENDPOINT,
             method: "GET",
-            path: "/users"
+            path: "/users",
+            isDraft: false
           }
         )
       ).toBeFalsy();
@@ -131,7 +138,8 @@ describe("Matcher", () => {
           {
             ...BASE_ENDPOINT,
             method: "GET",
-            path: "/users"
+            path: "/users",
+            isDraft: false
           }
         )
       ).toBeFalsy();
@@ -145,7 +153,8 @@ describe("Matcher", () => {
           {
             ...BASE_ENDPOINT,
             method: "GET",
-            path: "/users/abc"
+            path: "/users/abc",
+            isDraft: false
           }
         )
       ).toBeFalsy();

--- a/lib/src/models/definitions.ts
+++ b/lib/src/models/definitions.ts
@@ -28,6 +28,7 @@ export interface SecurityHeaderDefinition {
 export interface EndpointDefinition {
   name: string;
   description?: string;
+  isDraft: boolean;
   tags: string[];
   method: HttpMethod;
   path: string;

--- a/lib/src/models/nodes.ts
+++ b/lib/src/models/nodes.ts
@@ -29,6 +29,7 @@ export interface SecurityHeaderNode {
 export interface EndpointNode {
   name: Locatable<string>;
   description?: Locatable<string>;
+  isDraft: boolean;
   tags?: Locatable<string[]>;
   method: Locatable<HttpMethod>;
   path: Locatable<string>;

--- a/lib/src/parsers/nodes/endpoint-parser.ts
+++ b/lib/src/parsers/nodes/endpoint-parser.ts
@@ -25,6 +25,7 @@ export function parseEndpoint(
 ): Locatable<EndpointNode> {
   const decorator = klass.getDecoratorOrThrow("endpoint");
   const description = extractJsDocCommentLocatable(klass);
+  const isDraft = klass.getDecorator("draft") !== undefined;
   const configuration = extractDecoratorFactoryConfiguration(decorator);
   const tags = extractOptionalStringArrayPropertyValueLocatable(
     configuration,
@@ -71,7 +72,8 @@ export function parseEndpoint(
       request,
       responses,
       defaultResponse,
-      tests
+      tests,
+      isDraft
     },
     location,
     line

--- a/lib/src/syntax/draft.ts
+++ b/lib/src/syntax/draft.ts
@@ -1,0 +1,15 @@
+/**
+ * Decorator for marking endpoints as draft. This should be used only in conjunction with an `@endpoint` decorated class.
+ * 
+ * @example
+```
+@draft
+@endpoint({
+  // ...
+})
+class CreateUserEndpoint {
+  // ...
+}
+```
+ */
+export declare function draft(target: any): void;

--- a/lib/src/syntax/index.ts
+++ b/lib/src/syntax/index.ts
@@ -10,3 +10,4 @@ export * from "./request";
 export * from "./response";
 export * from "./security-header";
 export * from "./types";
+export * from "./draft";

--- a/lib/src/verifiers/nodes/endpoint-verifier.spec.ts
+++ b/lib/src/verifiers/nodes/endpoint-verifier.spec.ts
@@ -11,6 +11,7 @@ describe("endpoint node verifier", () => {
       tags: fakeLocatable(["Some Tag"]),
       method: fakeLocatable<HttpMethod>("POST"),
       path: fakeLocatable("/a/:b/c"),
+      isDraft: false,
       request: fakeLocatable({
         pathParams: fakeLocatable([
           fakeLocatable<PathParamNode>({

--- a/lib/src/verifiers/nodes/test-verifier.spec.ts
+++ b/lib/src/verifiers/nodes/test-verifier.spec.ts
@@ -15,6 +15,7 @@ describe("test node verifier", () => {
     name: fakeLocatable("SomeEndpoint"),
     method: fakeLocatable<HttpMethod>("POST"),
     path: fakeLocatable("/company/:companyId/users"),
+    isDraft: false,
     request: fakeLocatable({
       headers: fakeLocatable([
         fakeLocatable<HeaderNode>({

--- a/lib/src/verifiers/unicity/endpoints.spec.ts
+++ b/lib/src/verifiers/unicity/endpoints.spec.ts
@@ -18,6 +18,7 @@ describe("unique endpoint names verifier", () => {
           tags: fakeLocatable([]),
           method: fakeLocatable<HttpMethod>("POST"),
           path: fakeLocatable("/a"),
+          isDraft: false,
           request: fakeLocatable({} as RequestNode),
           responses: [],
           tests: []
@@ -27,6 +28,7 @@ describe("unique endpoint names verifier", () => {
           tags: fakeLocatable([]),
           method: fakeLocatable<HttpMethod>("POST"),
           path: fakeLocatable("/b"),
+          isDraft: false,
           request: fakeLocatable({} as RequestNode),
           responses: [],
           tests: []
@@ -46,6 +48,7 @@ describe("unique endpoint names verifier", () => {
           tags: fakeLocatable([]),
           method: fakeLocatable<HttpMethod>("POST"),
           path: fakeLocatable("/a"),
+          isDraft: false,
           request: fakeLocatable({} as RequestNode),
           responses: [],
           tests: []
@@ -55,6 +58,7 @@ describe("unique endpoint names verifier", () => {
           tags: fakeLocatable([]),
           method: fakeLocatable<HttpMethod>("POST"),
           path: fakeLocatable("/b"),
+          isDraft: false,
           request: fakeLocatable({} as RequestNode),
           responses: [],
           tests: []


### PR DESCRIPTION
This adds `@draft` decorator to endpoint class. `@draft` decorator will later be used by generators to augment endpoint path to indicate that the endpoint is under construction.