### PR TITLE
Test runner skips draft endpoint test

### DIFF
--- a/lib/src/testing/__examples__/draft-endpoint.ts
+++ b/lib/src/testing/__examples__/draft-endpoint.ts
@@ -1,0 +1,71 @@
+import {
+  api,
+  body,
+  draft,
+  endpoint,
+  headers,
+  request,
+  response,
+  String,
+  test
+} from "@airtasker/spot";
+
+@api({ name: "company-api" })
+class CompanyApi {}
+
+@draft
+@endpoint({
+  method: "POST",
+  path: "/companies"
+})
+class CreateCompany {
+  @request
+  request(@body body: CreateCompanyRequestBody) {}
+
+  @response({ status: 201 })
+  successResponse(
+    @headers
+    headers: {
+      Location: String;
+    },
+    @body body: CompanyBody
+  ) {}
+
+  @test({
+    request: {
+      body: {
+        name: "My Company",
+        private: true
+      }
+    },
+    response: {
+      status: 201
+    }
+  })
+  successResponseTest() {}
+}
+
+@endpoint({
+  method: "GET",
+  path: "/companies"
+})
+class GetCompany {
+  @response({ status: 200 })
+  successResponse(@body body: CompanyBody) {}
+
+  @test({
+    response: {
+      status: 200
+    }
+  })
+  successResponseTest() {}
+}
+
+interface CreateCompanyRequestBody {
+  name: String;
+  private: boolean;
+}
+
+interface CompanyBody {
+  name: String;
+}

--- a/lib/src/testing/test-runner.spec.ts
+++ b/lib/src/testing/test-runner.spec.ts
@@ -147,6 +147,35 @@ describe("test runner", () => {
     expect(result).toBe(true);
   });
 
+  test("draft endpoint", async () => {
+    const contract = parseAndCleanse(
+      `${testExamplesBasePath}/draft-endpoint.ts`
+    );
+
+    const scopeDraft = nock(baseUrl)
+      .post("/companies", { private: true })
+      .reply(200);
+
+    const scopeNotDraft = nock(baseUrl)
+      .get("/companies")
+      .reply(200, { name: "test" });
+
+    const initializeScope = nock(baseUrl)
+      .post("/state/initialize")
+      .reply(200);
+
+    const tearDownScope = nock(baseUrl)
+      .post("/state/teardown")
+      .reply(200);
+
+    const result = await testRunner.test(contract);
+    expect(initializeScope.isDone()).toBe(true);
+    expect(tearDownScope.isDone()).toBe(true);
+    expect(scopeDraft.isDone()).toBe(false);
+    expect(scopeNotDraft.isDone()).toBe(true);
+    expect(result).toBe(true);
+  });
+
   test("test filtering", async () => {
     const contract = parseAndCleanse(
       `${testExamplesBasePath}/multiple-tests.ts`

--- a/lib/src/testing/test-runner.ts
+++ b/lib/src/testing/test-runner.ts
@@ -44,6 +44,12 @@ export class TestRunner {
 
     for (const endpoint of definition.endpoints) {
       for (const test of endpoint.tests) {
+        if (endpoint.isDraft) {
+          this.logger.warn(
+            `Draft endpoint test ${endpoint.name}:${test.name} skipped`
+          );
+          continue;
+        }
         if (config && config.testFilter) {
           if (
             config.testFilter.endpoint !== endpoint.name ||


### PR DESCRIPTION
To allow tests inside `@draft` decorated endpoint to be skipped by Spot test runner.