### PR TITLE
Negative expression parsing

### DIFF
--- a/lib/src/parsers/utilities/expression-parser.spec.ts
+++ b/lib/src/parsers/utilities/expression-parser.spec.ts
@@ -46,6 +46,15 @@ describe("type expression parser", () => {
     });
   });
 
+  test("parses a negative number expression", () => {
+    const expression = createExpression("-5.34");
+
+    expect(parseExpression(expression)).toStrictEqual({
+      kind: TypeKind.NUMBER_LITERAL,
+      value: -5.34
+    });
+  });
+
   test("parses an array expression", () => {
     const expression = createExpression(
       `[1, "string", true, { myobject: 3 }, null]`
@@ -73,7 +82,7 @@ describe("type expression parser", () => {
 
   test("parses an object literal expression", () => {
     const expression = createExpression(`
-      { 
+      {
         title: "mytitle",
         year: 1999,
         'month': 5,

--- a/lib/src/parsers/utilities/expression-parser.ts
+++ b/lib/src/parsers/utilities/expression-parser.ts
@@ -23,17 +23,17 @@ export function parseExpression(expression: Expression): DataExpression {
   } else if (TypeGuards.isStringLiteral(expression)) {
     return stringExpression(expression.getLiteralValue());
   } else if (TypeGuards.isPrefixUnaryExpression(expression)) {
-    if (expression.getOperatorToken() === SyntaxKind.MinusToken) {
-      const operand = expression.getOperand();
-      if (TypeGuards.isNumericLiteral(operand)) {
+    const operand = expression.getOperand();
+    if (!TypeGuards.isNumericLiteral(operand)) {
+      throw new Error("unary operators may only be used with numeric literals");
+    }
+    switch (expression.getOperatorToken()) {
+      case SyntaxKind.MinusToken:
         return numberExpression(-operand.getLiteralValue());
-      } else {
-        throw new Error(
-          "minus prefix operator may only be used with numeric literals"
-        );
-      }
-    } else {
-      throw new Error("unknown prefix operator token");
+      case SyntaxKind.PlusToken:
+        return numberExpression(operand.getLiteralValue());
+      default:
+        throw new Error("unknown prefix operator token");
     }
   } else if (TypeGuards.isNumericLiteral(expression)) {
     return numberExpression(expression.getLiteralValue());

--- a/lib/src/parsers/utilities/expression-parser.ts
+++ b/lib/src/parsers/utilities/expression-parser.ts
@@ -1,4 +1,4 @@
-import { Expression, TypeGuards } from "ts-morph";
+import { Expression, SyntaxKind, TypeGuards } from "ts-morph";
 import {
   arrayExpression,
   booleanExpression,
@@ -22,6 +22,19 @@ export function parseExpression(expression: Expression): DataExpression {
     return booleanExpression(expression.getLiteralValue());
   } else if (TypeGuards.isStringLiteral(expression)) {
     return stringExpression(expression.getLiteralValue());
+  } else if (TypeGuards.isPrefixUnaryExpression(expression)) {
+    if (expression.getOperatorToken() === SyntaxKind.MinusToken) {
+      const operand = expression.getOperand();
+      if (TypeGuards.isNumericLiteral(operand)) {
+        return numberExpression(-operand.getLiteralValue());
+      } else {
+        throw new Error(
+          "minus prefix operator may only be used with numeric literals"
+        );
+      }
+    } else {
+      throw new Error("unknown prefix operator token");
+    }
   } else if (TypeGuards.isNumericLiteral(expression)) {
     return numberExpression(expression.getLiteralValue());
   } else if (TypeGuards.isArrayLiteralExpression(expression)) {
@@ -52,6 +65,6 @@ export function parseExpression(expression: Expression): DataExpression {
       });
     return objectExpression(objectProperties);
   } else {
-    throw new Error("unknown expression type");
+    throw new Error(`unknown expression type: ${expression.getText()}`);
   }
 }


### PR DESCRIPTION
The Spot parser fails to parse negative numbers in `@test` methods.