### PR TITLE
Include draft flag

### DIFF
--- a/cli/src/commands/test.ts
+++ b/cli/src/commands/test.ts
@@ -29,6 +29,9 @@ export default class Test extends Command {
   static flags = {
     help: flags.help({ char: "h" }),
     debug: flags.boolean({ description: "Enable debug logs" }),
+    includeDraft: flags.boolean({
+      description: "Include draft endpoint tests"
+    }),
     url: flags.string({
       required: true,
       char: "u",
@@ -46,7 +49,13 @@ export default class Test extends Command {
 
   async run() {
     const { args, flags } = this.parse(Test);
-    const { url: baseUrl, stateUrl: baseStateUrl, testFilter, debug } = flags;
+    const {
+      url: baseUrl,
+      stateUrl: baseStateUrl,
+      testFilter,
+      debug,
+      includeDraft
+    } = flags;
     const { definition } = safeParse.call(this, args[ARG_API]);
 
     const testRunnerConfig = {
@@ -57,7 +66,8 @@ export default class Test extends Command {
       debugMode: debug
     };
     const testConfig = {
-      testFilter: testFilter ? parseTestFilter(testFilter) : undefined
+      testFilter: testFilter ? parseTestFilter(testFilter) : undefined,
+      includeDraft
     };
 
     const testRunner = new TestRunner(testRunnerConfig);

--- a/lib/src/testing/__examples__/draft-and-nondraft-endpoint.ts
+++ b/lib/src/testing/__examples__/draft-and-nondraft-endpoint.ts
@@ -39,6 +39,22 @@ class CreateCompany {
   successResponseTest() {}
 }
 
+@endpoint({
+  method: "GET",
+  path: "/companies"
+})
+class GetCompany {
+  @response({ status: 200 })
+  successResponse(@body body: CompanyBody) {}
+
+  @test({
+    response: {
+      status: 200
+    }
+  })
+  successResponseTest() {}
+}
+
 interface CreateCompanyRequestBody {
   name: String;
   private: boolean;

--- a/lib/src/testing/common.ts
+++ b/lib/src/testing/common.ts
@@ -1,5 +1,6 @@
 export interface TestConfig {
   testFilter?: TestFilter;
+  includeDraft: boolean;
 }
 
 export interface TestFilter {

--- a/lib/src/testing/test-runner.spec.ts
+++ b/lib/src/testing/test-runner.spec.ts
@@ -147,7 +147,7 @@ describe("test runner", () => {
     expect(result).toBe(true);
   });
 
-  test("draft endpoint excluded", async () => {
+  test("non draft endpoints are still tested when draft not included", async () => {
     const contract = parseAndCleanse(
       `${testExamplesBasePath}/draft-and-nondraft-endpoint.ts`
     );
@@ -176,7 +176,7 @@ describe("test runner", () => {
     expect(result).toBe(true);
   });
 
-  test("draft endpoint included", async () => {
+  test("passing draft endpoint passes the test when included", async () => {
     const contract = parseAndCleanse(
       `${testExamplesBasePath}/draft-endpoint.ts`
     );
@@ -196,7 +196,7 @@ describe("test runner", () => {
     expect(result).toBe(true);
   });
 
-  test("draft endpoint included - response body mismatch", async () => {
+  test("failing draft endpoint fails the test when included", async () => {
     const contract = parseAndCleanse(
       `${testExamplesBasePath}/draft-endpoint.ts`
     );
@@ -205,7 +205,7 @@ describe("test runner", () => {
       .post("/state/initialize")
       .reply(200)
       .post("/companies", { name: "My Company", private: true })
-      .reply(201, { notname: "My Company" })
+      .reply(201, { THIS_IS_OBVIOUSLY_WRONG: "My Company" })
       .post("/state/teardown")
       .reply(200);
 
@@ -216,23 +216,22 @@ describe("test runner", () => {
     expect(result).toBe(false);
   });
 
-  test("draft endpoint excluded - response body mismatch", async () => {
+  test("failing draft endpoint doesn't fail the test when not included", async () => {
     const contract = parseAndCleanse(
       `${testExamplesBasePath}/draft-endpoint.ts`
     );
 
-    const scope = nock(baseUrl)
+    nock(baseUrl)
       .post("/state/initialize")
       .reply(200)
       .post("/companies", { name: "My Company", private: true })
-      .reply(201, { notname: "My Company" })
+      .reply(201, { THIS_IS_OBVIOUSLY_WRONG: "My Company" })
       .post("/state/teardown")
       .reply(200);
 
     const result = await testRunner.test(contract, {
       includeDraft: false
     });
-    expect(scope.isDone()).toBe(false);
     expect(result).toBe(true);
   });
 

--- a/lib/src/testing/test-runner.spec.ts
+++ b/lib/src/testing/test-runner.spec.ts
@@ -149,7 +149,7 @@ describe("test runner", () => {
 
   test("draft endpoint", async () => {
     const contract = parseAndCleanse(
-      `${testExamplesBasePath}/draft-endpoint.ts`
+      `${testExamplesBasePath}/draft-and-nondraft-endpoint.ts`
     );
 
     const scopeDraft = nock(baseUrl)
@@ -173,6 +173,26 @@ describe("test runner", () => {
     expect(tearDownScope.isDone()).toBe(true);
     expect(scopeDraft.isDone()).toBe(false);
     expect(scopeNotDraft.isDone()).toBe(true);
+    expect(result).toBe(true);
+  });
+
+  test("include draft", async () => {
+    const contract = parseAndCleanse(
+      `${testExamplesBasePath}/draft-endpoint.ts`
+    );
+
+    const scopeDraft = nock(baseUrl)
+      .post("/state/initialize")
+      .reply(200)
+      .post("/companies", { name: "My Company", private: true })
+      .reply(201, { name: "My Company" })
+      .post("/state/teardown")
+      .reply(200);
+
+    const result = await testRunner.test(contract, {
+      includeDraft: true
+    });
+    expect(scopeDraft.isDone()).toBe(true);
     expect(result).toBe(true);
   });
 
@@ -202,6 +222,7 @@ describe("test runner", () => {
       .reply(200);
 
     const result = await testRunner.test(contract, {
+      includeDraft: false,
       testFilter: { endpoint: "CreateCompany", test: "badRequestTest" }
     });
 

--- a/lib/src/testing/test-runner.spec.ts
+++ b/lib/src/testing/test-runner.spec.ts
@@ -147,7 +147,7 @@ describe("test runner", () => {
     expect(result).toBe(true);
   });
 
-  test("draft endpoint", async () => {
+  test("draft endpoint excluded", async () => {
     const contract = parseAndCleanse(
       `${testExamplesBasePath}/draft-and-nondraft-endpoint.ts`
     );
@@ -176,7 +176,7 @@ describe("test runner", () => {
     expect(result).toBe(true);
   });
 
-  test("include draft", async () => {
+  test("draft endpoint included", async () => {
     const contract = parseAndCleanse(
       `${testExamplesBasePath}/draft-endpoint.ts`
     );
@@ -193,6 +193,46 @@ describe("test runner", () => {
       includeDraft: true
     });
     expect(scopeDraft.isDone()).toBe(true);
+    expect(result).toBe(true);
+  });
+
+  test("draft endpoint included - response body mismatch", async () => {
+    const contract = parseAndCleanse(
+      `${testExamplesBasePath}/draft-endpoint.ts`
+    );
+
+    const scope = nock(baseUrl)
+      .post("/state/initialize")
+      .reply(200)
+      .post("/companies", { name: "My Company", private: true })
+      .reply(201, { notname: "My Company" })
+      .post("/state/teardown")
+      .reply(200);
+
+    const result = await testRunner.test(contract, {
+      includeDraft: true
+    });
+    expect(scope.isDone()).toBe(true);
+    expect(result).toBe(false);
+  });
+
+  test("draft endpoint excluded - response body mismatch", async () => {
+    const contract = parseAndCleanse(
+      `${testExamplesBasePath}/draft-endpoint.ts`
+    );
+
+    const scope = nock(baseUrl)
+      .post("/state/initialize")
+      .reply(200)
+      .post("/companies", { name: "My Company", private: true })
+      .reply(201, { notname: "My Company" })
+      .post("/state/teardown")
+      .reply(200);
+
+    const result = await testRunner.test(contract, {
+      includeDraft: false
+    });
+    expect(scope.isDone()).toBe(false);
     expect(result).toBe(true);
   });
 

--- a/lib/src/testing/test-runner.ts
+++ b/lib/src/testing/test-runner.ts
@@ -36,7 +36,7 @@ export class TestRunner {
    */
   async test(
     definition: ContractDefinition,
-    config?: TestConfig
+    config: TestConfig = { includeDraft: false }
   ): Promise<boolean> {
     const testSuiteStartTime = TestTimer.startTime();
 
@@ -44,13 +44,13 @@ export class TestRunner {
 
     for (const endpoint of definition.endpoints) {
       for (const test of endpoint.tests) {
-        if (endpoint.isDraft) {
+        if (endpoint.isDraft && !config.includeDraft) {
           this.logger.warn(
             `Draft endpoint test ${endpoint.name}:${test.name} skipped`
           );
           continue;
         }
-        if (config && config.testFilter) {
+        if (config.testFilter) {
           if (
             config.testFilter.endpoint !== endpoint.name ||
             (config.testFilter.test && config.testFilter.test !== test.name)


### PR DESCRIPTION
Adds `--includeDraft` flag to the test runner CLI that allows to include draft endpoint tests during development. Documentation not included.