### PR TITLE
[TT-416] Add a new linting rule to prevent null types in request body

### DIFF
--- a/lib/src/linting/rules.ts
+++ b/lib/src/linting/rules.ts
@@ -8,13 +8,13 @@ import { noOmittableFieldsWithinResponses } from "./rules/no-omittable-fields-wi
 import { oneSuccessResponsePerEndpoint } from "./rules/one-success-response-per-endpoint";
 
 export const availableRules = {
+  "has-discriminator": hasDiscriminator,
   "has-request-payload": hasRequestPayload,
   "has-response-payload": hasResponsePayload,
-  "has-discriminator": hasDiscriminator,
   "no-nested-types-within-unions": noNestedTypesWithinUnions,
   "no-nullable-arrays": noNullableArrays,
-  "no-omittable-fields-within-responses": noOmittableFieldsWithinResponses,
   "no-nullable-fields-within-requests": noNullableFieldsWithinRequests,
+  "no-omittable-fields-within-responses": noOmittableFieldsWithinResponses,
   "one-success-response-per-endpoint": oneSuccessResponsePerEndpoint
 };
 

--- a/lib/src/linting/rules.ts
+++ b/lib/src/linting/rules.ts
@@ -3,6 +3,7 @@ import { hasRequestPayload } from "./rules/has-request-payload";
 import { hasResponsePayload } from "./rules/has-response-payload";
 import { noNestedTypesWithinUnions } from "./rules/no-nested-types-within-unions";
 import { noNullableArrays } from "./rules/no-nullable-arrays";
+import { noNullableFieldsWithinRequests } from "./rules/no-nullable-fields-within-requests";
 import { noOmittableFieldsWithinResponses } from "./rules/no-omittable-fields-within-responses";
 import { oneSuccessResponsePerEndpoint } from "./rules/one-success-response-per-endpoint";
 
@@ -13,6 +14,7 @@ export const availableRules = {
   "no-nested-types-within-unions": noNestedTypesWithinUnions,
   "no-nullable-arrays": noNullableArrays,
   "no-omittable-fields-within-responses": noOmittableFieldsWithinResponses,
+  "no-nullable-fields-within-requests": noNullableFieldsWithinRequests,
   "one-success-response-per-endpoint": oneSuccessResponsePerEndpoint
 };
 

--- a/lib/src/linting/rules/no-nullable-fields-within-requests.spec.ts
+++ b/lib/src/linting/rules/no-nullable-fields-within-requests.spec.ts
@@ -40,7 +40,7 @@ describe("rule: no nullable fields within request body", () => {
           }),
           responses: []
         }),
-        // Endpoint with reference type in response payload
+        // Endpoint with reference type in request payload
         fakeLocatable<EndpointNode>({
           name: fakeLocatable("createUser"),
           method: fakeLocatable<HttpMethod>("POST"),
@@ -52,13 +52,7 @@ describe("rule: no nullable fields within request body", () => {
               type: objectType([
                 {
                   name: "data",
-                  type: objectType([
-                    {
-                      name: "slug",
-                      type: STRING,
-                      optional: true
-                    }
-                  ]),
+                  type: referenceType("requestBody201", "", TypeKind.OBJECT),
                   optional: false
                 }
               ])
@@ -69,7 +63,7 @@ describe("rule: no nullable fields within request body", () => {
       ],
       types: [
         {
-          name: "responseBody201",
+          name: "requestBody201",
           type: objectType([
             {
               name: "slug",
@@ -89,7 +83,7 @@ describe("rule: no nullable fields within request body", () => {
         name: fakeLocatable("example-api")
       }),
       endpoints: [
-        // Endpoint with response payload
+        // Endpoint with request payload
         fakeLocatable<EndpointNode>({
           name: fakeLocatable("listUsers"),
           method: fakeLocatable<HttpMethod>("GET"),
@@ -126,7 +120,7 @@ describe("rule: no nullable fields within request body", () => {
         name: fakeLocatable("example-api")
       }),
       endpoints: [
-        // Endpoint with response payload
+        // Endpoint with request payload
         fakeLocatable<EndpointNode>({
           name: fakeLocatable("listUsers"),
           method: fakeLocatable<HttpMethod>("GET"),
@@ -169,7 +163,7 @@ describe("rule: no nullable fields within request body", () => {
         name: fakeLocatable("example-api")
       }),
       endpoints: [
-        // Endpoint with response payload
+        // Endpoint with request payload
         fakeLocatable<EndpointNode>({
           name: fakeLocatable("listUsers"),
           method: fakeLocatable<HttpMethod>("GET"),

--- a/lib/src/linting/rules/no-nullable-fields-within-requests.spec.ts
+++ b/lib/src/linting/rules/no-nullable-fields-within-requests.spec.ts
@@ -1,0 +1,207 @@
+import { HttpMethod } from "../../models/http";
+import {
+  ApiNode,
+  BodyNode,
+  EndpointNode,
+  RequestNode
+} from "../../models/nodes";
+import {
+  INT32,
+  NULL,
+  objectType,
+  referenceType,
+  STRING,
+  TypeKind,
+  unionType
+} from "../../models/types";
+import { fakeLocatable } from "../../spec-helpers/fake-locatable";
+import { noNullableFieldsWithinRequests } from "./no-nullable-fields-within-requests";
+
+describe("rule: no nullable fields within request body", () => {
+  test("valid for correct usage", () => {
+    const errors = noNullableFieldsWithinRequests({
+      api: fakeLocatable<ApiNode>({
+        name: fakeLocatable("example-api")
+      }),
+      endpoints: [
+        // Endpoint with response payload
+        fakeLocatable<EndpointNode>({
+          name: fakeLocatable("listUsers"),
+          method: fakeLocatable<HttpMethod>("GET"),
+          path: fakeLocatable("/users"),
+          isDraft: false,
+          tests: [],
+          request: fakeLocatable<RequestNode>({
+            body: fakeLocatable<BodyNode>({
+              type: {
+                kind: TypeKind.STRING
+              }
+            })
+          }),
+          responses: []
+        }),
+        // Endpoint with reference type in response payload
+        fakeLocatable<EndpointNode>({
+          name: fakeLocatable("createUser"),
+          method: fakeLocatable<HttpMethod>("POST"),
+          path: fakeLocatable("/users"),
+          isDraft: false,
+          tests: [],
+          request: fakeLocatable<RequestNode>({
+            body: fakeLocatable<BodyNode>({
+              type: objectType([
+                {
+                  name: "data",
+                  type: objectType([
+                    {
+                      name: "slug",
+                      type: STRING,
+                      optional: true
+                    }
+                  ]),
+                  optional: false
+                }
+              ])
+            })
+          }),
+          responses: []
+        })
+      ],
+      types: [
+        {
+          name: "responseBody201",
+          type: objectType([
+            {
+              name: "slug",
+              type: STRING,
+              optional: true
+            }
+          ])
+        }
+      ]
+    });
+    expect(errors).toEqual([]);
+  });
+
+  test("rejects a request body object when a field is nullable instead of omittable", () => {
+    const errors = noNullableFieldsWithinRequests({
+      api: fakeLocatable<ApiNode>({
+        name: fakeLocatable("example-api")
+      }),
+      endpoints: [
+        // Endpoint with response payload
+        fakeLocatable<EndpointNode>({
+          name: fakeLocatable("listUsers"),
+          method: fakeLocatable<HttpMethod>("GET"),
+          path: fakeLocatable("/users"),
+          isDraft: false,
+          tests: [],
+          request: fakeLocatable<RequestNode>({
+            body: fakeLocatable<BodyNode>({
+              type: objectType([
+                {
+                  name: "id",
+                  type: unionType([INT32, NULL]),
+                  optional: false
+                }
+              ])
+            })
+          }),
+          responses: []
+        })
+      ],
+      types: []
+    });
+    expect(errors).toEqual([
+      {
+        message:
+          "The object type `listUsers (request body).id` defines an nullable property. Use omittable instead."
+      }
+    ]);
+  });
+
+  test("rejects a request body object when a field is nullable instead of omittable", () => {
+    const errors = noNullableFieldsWithinRequests({
+      api: fakeLocatable<ApiNode>({
+        name: fakeLocatable("example-api")
+      }),
+      endpoints: [
+        // Endpoint with response payload
+        fakeLocatable<EndpointNode>({
+          name: fakeLocatable("listUsers"),
+          method: fakeLocatable<HttpMethod>("GET"),
+          path: fakeLocatable("/users"),
+          isDraft: false,
+          tests: [],
+          request: fakeLocatable<RequestNode>({
+            body: fakeLocatable<BodyNode>({
+              type: objectType([
+                {
+                  name: "data",
+                  type: objectType([
+                    {
+                      name: "slug",
+                      type: unionType([STRING, NULL]),
+                      optional: false
+                    }
+                  ]),
+                  optional: false
+                }
+              ])
+            })
+          }),
+          responses: []
+        })
+      ],
+      types: []
+    });
+    expect(errors).toEqual([
+      {
+        message:
+          "The object type `listUsers (request body).data.slug` defines an nullable property. Use omittable instead."
+      }
+    ]);
+  });
+
+  test("rejects a request body object with a reference when a field is nullable instead of omittable", () => {
+    const errors = noNullableFieldsWithinRequests({
+      api: fakeLocatable<ApiNode>({
+        name: fakeLocatable("example-api")
+      }),
+      endpoints: [
+        // Endpoint with response payload
+        fakeLocatable<EndpointNode>({
+          name: fakeLocatable("listUsers"),
+          method: fakeLocatable<HttpMethod>("GET"),
+          path: fakeLocatable("/users"),
+          isDraft: false,
+          tests: [],
+          request: fakeLocatable<RequestNode>({
+            body: fakeLocatable<BodyNode>({
+              type: referenceType("listUserRequestBody", "", TypeKind.OBJECT)
+            })
+          }),
+          responses: []
+        })
+      ],
+      types: [
+        {
+          name: "listUserRequestBody",
+          type: objectType([
+            {
+              name: "slug",
+              type: unionType([STRING, NULL]),
+              optional: true
+            }
+          ])
+        }
+      ]
+    });
+    expect(errors).toEqual([
+      {
+        message:
+          "The object type `listUsers (request body).slug` defines an nullable property. Use omittable instead."
+      }
+    ]);
+  });
+});

--- a/lib/src/linting/rules/no-nullable-fields-within-requests.spec.ts
+++ b/lib/src/linting/rules/no-nullable-fields-within-requests.spec.ts
@@ -24,7 +24,7 @@ describe("rule: no nullable fields within request body", () => {
         name: fakeLocatable("example-api")
       }),
       endpoints: [
-        // Endpoint with response payload
+        // Endpoint with inline request payload
         fakeLocatable<EndpointNode>({
           name: fakeLocatable("listUsers"),
           method: fakeLocatable<HttpMethod>("GET"),
@@ -109,50 +109,7 @@ describe("rule: no nullable fields within request body", () => {
     expect(errors).toEqual([
       {
         message:
-          "The object type `listUsers (request body).id` defines an nullable property. Use omittable instead."
-      }
-    ]);
-  });
-
-  test("rejects a request body object when a field is nullable instead of omittable", () => {
-    const errors = noNullableFieldsWithinRequests({
-      api: fakeLocatable<ApiNode>({
-        name: fakeLocatable("example-api")
-      }),
-      endpoints: [
-        // Endpoint with request payload
-        fakeLocatable<EndpointNode>({
-          name: fakeLocatable("listUsers"),
-          method: fakeLocatable<HttpMethod>("GET"),
-          path: fakeLocatable("/users"),
-          isDraft: false,
-          tests: [],
-          request: fakeLocatable<RequestNode>({
-            body: fakeLocatable<BodyNode>({
-              type: objectType([
-                {
-                  name: "data",
-                  type: objectType([
-                    {
-                      name: "slug",
-                      type: unionType([STRING, NULL]),
-                      optional: false
-                    }
-                  ]),
-                  optional: false
-                }
-              ])
-            })
-          }),
-          responses: []
-        })
-      ],
-      types: []
-    });
-    expect(errors).toEqual([
-      {
-        message:
-          "The object type `listUsers (request body).data.slug` defines an nullable property. Use omittable instead."
+          "The object type `listUsers (request body).id` defines a nullable property. Use omittable instead."
       }
     ]);
   });
@@ -194,7 +151,7 @@ describe("rule: no nullable fields within request body", () => {
     expect(errors).toEqual([
       {
         message:
-          "The object type `listUsers (request body).slug` defines an nullable property. Use omittable instead."
+          "The object type `listUsers (request body).slug` defines a nullable property. Use omittable instead."
       }
     ]);
   });

--- a/lib/src/linting/rules/no-nullable-fields-within-requests.ts
+++ b/lib/src/linting/rules/no-nullable-fields-within-requests.ts
@@ -1,0 +1,27 @@
+import { flatten, flow } from "lodash";
+import { LintingRule } from "../rule";
+
+import { TypeNode } from "../../models/nodes";
+import { isNullType, UnionType } from "../../models/types";
+import { extractRequestType } from "../../utilities/extract-endpoint-types";
+import { extractNestedUnionTypes } from "../../utilities/extract-nested-types";
+
+/**
+ * Checks optional fields at any level in requests are not nullable
+ */
+export const noNullableFieldsWithinRequests: LintingRule = contract => {
+  const extractTypes = flow(
+    extractRequestType,
+    (t: TypeNode) => extractNestedUnionTypes(t, contract.types),
+    flatten
+  );
+
+  const types = flatten(contract.endpoints.map(extractTypes));
+
+  const filterNullable = (t: TypeNode<UnionType>) =>
+    t.type.types.find(possibleType => isNullType(possibleType));
+
+  return types.filter(filterNullable).map(typeNode => ({
+    message: `The object type \`${typeNode.name}\` defines an nullable property. Use omittable instead.`
+  }));
+};

--- a/lib/src/linting/rules/no-nullable-fields-within-requests.ts
+++ b/lib/src/linting/rules/no-nullable-fields-within-requests.ts
@@ -18,10 +18,10 @@ export const noNullableFieldsWithinRequests: LintingRule = contract => {
 
   const types = flatten(contract.endpoints.map(extractTypes));
 
-  const filterNullable = (t: TypeNode<UnionType>) =>
+  const nullablePredicate = (t: TypeNode<UnionType>) =>
     t.type.types.find(possibleType => isNullType(possibleType));
 
-  return types.filter(filterNullable).map(typeNode => ({
-    message: `The object type \`${typeNode.name}\` defines an nullable property. Use omittable instead.`
+  return types.filter(nullablePredicate).map(typeNode => ({
+    message: `The object type \`${typeNode.name}\` defines a nullable property. Use omittable instead.`
   }));
 };

--- a/lib/src/models/types/index.ts
+++ b/lib/src/models/types/index.ts
@@ -13,7 +13,12 @@ import {
   PrimitiveLiteral,
   StringLiteral
 } from "./primitive-literals";
-import { FloatType, PrimitiveType, StringType, NullType } from "./primitive-types";
+import {
+  FloatType,
+  NullType,
+  PrimitiveType,
+  StringType
+} from "./primitive-types";
 import { ReferenceType, UnionType } from "./special-types";
 
 export * from "./custom-primitive-types";

--- a/lib/src/models/types/index.ts
+++ b/lib/src/models/types/index.ts
@@ -13,7 +13,7 @@ import {
   PrimitiveLiteral,
   StringLiteral
 } from "./primitive-literals";
-import { FloatType, PrimitiveType, StringType } from "./primitive-types";
+import { FloatType, PrimitiveType, StringType, NullType } from "./primitive-types";
 import { ReferenceType, UnionType } from "./special-types";
 
 export * from "./custom-primitive-types";
@@ -62,4 +62,8 @@ export function isUnionType(type: DataType): type is UnionType {
 
 export function isReferenceType(type: DataType): type is ReferenceType {
   return type.kind === TypeKind.TYPE_REFERENCE;
+}
+
+export function isNullType(type: DataType): type is NullType {
+  return type.kind === TypeKind.NULL;
 }


### PR DESCRIPTION
This PR adds a linting rule to prevent null types from being used in request body objects. As per 
The API guidelines, omittable fields should be used instead. 

