### PR TITLE
[TT-474] Review linting rules functions logic

### DIFF
--- a/lib/src/linting/rules/no-nullable-fields-within-requests.ts
+++ b/lib/src/linting/rules/no-nullable-fields-within-requests.ts
@@ -12,7 +12,7 @@ import { extractNestedUnionTypes } from "../../utilities/extract-nested-types";
 export const noNullableFieldsWithinRequests: LintingRule = contract => {
   const extractTypes = flow(
     extractRequestType,
-    (t: TypeNode) => extractNestedUnionTypes(t, contract.types),
+    (t: TypeNode) => t && extractNestedUnionTypes(t, contract.types),
     flatten
   );
 

--- a/lib/src/linting/rules/no-omittable-fields-within-responses.ts
+++ b/lib/src/linting/rules/no-omittable-fields-within-responses.ts
@@ -14,7 +14,7 @@ const hasOptionalProperties = (typeNode: TypeNode<ObjectType>) =>
  */
 export const noOmittableFieldsWithinResponses: LintingRule = contract => {
   const extractObjectTypes = (t: TypeNode[]) =>
-    t.map((type: TypeNode) => extractNestedObjectTypes(type, contract.types));
+    t.map((type: TypeNode) => t && extractNestedObjectTypes(type, contract.types));
 
   const extractTypes = flow(
     extractResponseTypes,

--- a/lib/src/linting/rules/no-omittable-fields-within-responses.ts
+++ b/lib/src/linting/rules/no-omittable-fields-within-responses.ts
@@ -14,7 +14,9 @@ const hasOptionalProperties = (typeNode: TypeNode<ObjectType>) =>
  */
 export const noOmittableFieldsWithinResponses: LintingRule = contract => {
   const extractObjectTypes = (t: TypeNode[]) =>
-    t.map((type: TypeNode) => t && extractNestedObjectTypes(type, contract.types));
+    t.map(
+      (type: TypeNode) => t && extractNestedObjectTypes(type, contract.types)
+    );
 
   const extractTypes = flow(
     extractResponseTypes,


### PR DESCRIPTION
This fixing the linting rules logic where `null` can be passed to types extraction functions and cause the app to crash. 