### PR TITLE
feat: indexed access types

### DIFF
--- a/lib/src/__examples__/contract-endpoint.ts
+++ b/lib/src/__examples__/contract-endpoint.ts
@@ -25,7 +25,7 @@ class GetUser {
     @pathParams
     pathParams: {
       /** company identifier */
-      companyId: Company['id'];
+      companyId: Company["id"];
       /** user identifier */
       userId: String;
     },

--- a/lib/src/__examples__/contract-endpoint.ts
+++ b/lib/src/__examples__/contract-endpoint.ts
@@ -10,7 +10,7 @@ import {
   String,
   test
 } from "@airtasker/spot";
-import { ErrorBody, UserBody } from "./models";
+import { Company, ErrorBody, UserBody } from "./models";
 
 /** Retrieves a user in a company */
 @draft
@@ -25,7 +25,7 @@ class GetUser {
     @pathParams
     pathParams: {
       /** company identifier */
-      companyId: String;
+      companyId: Company['id'];
       /** user identifier */
       userId: String;
     },

--- a/lib/src/__examples__/contract.ts
+++ b/lib/src/__examples__/contract.ts
@@ -35,7 +35,7 @@ class CreateUser {
     @pathParams
     pathParams: {
       /** company identifier */
-      companyId: Company['id'];
+      companyId: Company["id"];
     },
     @headers
     headers: {

--- a/lib/src/__examples__/contract.ts
+++ b/lib/src/__examples__/contract.ts
@@ -14,7 +14,7 @@ import {
   test
 } from "@airtasker/spot";
 import "./contract-endpoint";
-import { Address, ErrorBody, UserBody } from "./models";
+import { Address, Company, ErrorBody, UserBody } from "./models";
 
 /** This is the company API. It does cool things */
 @api({ name: "company-api" })
@@ -35,7 +35,7 @@ class CreateUser {
     @pathParams
     pathParams: {
       /** company identifier */
-      companyId: String;
+      companyId: Company['id'];
     },
     @headers
     headers: {

--- a/lib/src/__examples__/models.ts
+++ b/lib/src/__examples__/models.ts
@@ -1,3 +1,8 @@
+export interface Company {
+  /** company id */
+  id: string;
+}
+
 /** User response body */
 export interface UserBody {
   /** data wrapper */

--- a/lib/src/parsers/utilities/type-parser.spec.ts
+++ b/lib/src/parsers/utilities/type-parser.spec.ts
@@ -334,13 +334,30 @@ describe("type node parser", () => {
       });
     });
 
-    // FIXME: add support for nested indexed access types
-    test("throws on nested indexed access type", () => {
-      const typeNode = createTypeNode("AliasedNestedIndexedAccessType");
-
-      expect(() => parseTypeNode(typeNode)).toThrowError(
-        "indexed access type error: nested indexed access type unsupported"
+    test("parses nested interface indexed access type", () => {
+      const typeNode = createTypeNode(
+        "AliasedNestedInterfaceIndexedAccessType"
       );
+
+      expect(parseTypeNode(typeNode)).toStrictEqual({
+        kind: TypeKind.TYPE_REFERENCE,
+        referenceKind: TypeKind.STRING,
+        name: "AliasedNestedInterfaceIndexedAccessType",
+        location: expect.stringMatching(/main\.ts$/)
+      });
+    });
+
+    test("parses nested type literal indexed access type", () => {
+      const typeNode = createTypeNode(
+        "AliasedNestedTypeLiteralIndexedAccessType"
+      );
+
+      expect(parseTypeNode(typeNode)).toStrictEqual({
+        kind: TypeKind.TYPE_REFERENCE,
+        referenceKind: TypeKind.BOOLEAN,
+        name: "AliasedNestedTypeLiteralIndexedAccessType",
+        location: expect.stringMatching(/main\.ts$/)
+      });
     });
   });
 });
@@ -487,9 +504,14 @@ function createTypeNode(...types: string[]): TypeNode {
       age: number;
     }
 
+    interface NestedNestedObjectInterface {
+      b: string;
+    }
+
     interface NestedObjectInterface {
-      a: {
-        b: string;
+      a: NestedNestedObjectInterface;
+      b: {
+        c: boolean;
       }
     }
 
@@ -528,7 +550,8 @@ function createTypeNode(...types: string[]): TypeNode {
     type AliasedCustomPrimitive = Integer;
     type ChainedAlias = AliasedCustomPrimitive;
     type AliasedIndexedAccessType = ObjectInterface['name'];
-    type AliasedNestedIndexedAccessType = NestedObjectInterface['a']['b'];
+    type AliasedNestedInterfaceIndexedAccessType = NestedObjectInterface['a']['b'];
+    type AliasedNestedTypeLiteralIndexedAccessType = NestedObjectInterface['b']['c'];
   `;
   const sourceFile = createSourceFile(
     { path: "main", content },

--- a/lib/src/parsers/utilities/type-parser.spec.ts
+++ b/lib/src/parsers/utilities/type-parser.spec.ts
@@ -332,14 +332,16 @@ describe("type node parser", () => {
         name: "AliasedIndexedAccessType",
         location: expect.stringMatching(/main\.ts$/)
       });
-    })
+    });
 
     // FIXME: add support for nested indexed access types
     test("throws on nested indexed access type", () => {
       const typeNode = createTypeNode("AliasedNestedIndexedAccessType");
 
-      expect(() => parseTypeNode(typeNode)).toThrowError("indexed access type error: nested indexed access type unsupported");
-    })
+      expect(() => parseTypeNode(typeNode)).toThrowError(
+        "indexed access type error: nested indexed access type unsupported"
+      );
+    });
   });
 });
 

--- a/lib/src/parsers/utilities/type-parser.spec.ts
+++ b/lib/src/parsers/utilities/type-parser.spec.ts
@@ -322,6 +322,24 @@ describe("type node parser", () => {
         location: expect.stringMatching(/main\.ts$/)
       });
     });
+
+    test("parses indexed access type", () => {
+      const typeNode = createTypeNode("AliasedIndexedAccessType");
+
+      expect(parseTypeNode(typeNode)).toStrictEqual({
+        kind: TypeKind.TYPE_REFERENCE,
+        referenceKind: TypeKind.STRING,
+        name: "AliasedIndexedAccessType",
+        location: expect.stringMatching(/main\.ts$/)
+      });
+    })
+
+    // FIXME: add support for nested indexed access types
+    test("throws on nested indexed access type", () => {
+      const typeNode = createTypeNode("AliasedNestedIndexedAccessType");
+
+      expect(() => parseTypeNode(typeNode)).toThrowError("indexed access type error: nested indexed access type unsupported");
+    })
   });
 });
 
@@ -467,6 +485,12 @@ function createTypeNode(...types: string[]): TypeNode {
       age: number;
     }
 
+    interface NestedObjectInterface {
+      a: {
+        b: string;
+      }
+    }
+
     /** Complex interface description */
     interface ComplexInterface extends ComplexInterfaceExtension {
       /** Name of person */
@@ -501,6 +525,8 @@ function createTypeNode(...types: string[]): TypeNode {
     type TrueAlias = true;
     type AliasedCustomPrimitive = Integer;
     type ChainedAlias = AliasedCustomPrimitive;
+    type AliasedIndexedAccessType = ObjectInterface['name'];
+    type AliasedNestedIndexedAccessType = NestedObjectInterface['a']['b'];
   `;
   const sourceFile = createSourceFile(
     { path: "main", content },

--- a/lib/src/parsers/utilities/type-parser.ts
+++ b/lib/src/parsers/utilities/type-parser.ts
@@ -3,13 +3,13 @@ import {
   IndexedAccessTypeNode,
   InterfaceDeclaration,
   LiteralTypeNode,
+  StringLiteral,
+  TypeAliasDeclaration,
   TypeGuards,
   TypeLiteralNode,
   TypeNode,
   TypeReferenceNode,
-  UnionTypeNode,
-  TypeAliasDeclaration,
-  StringLiteral
+  UnionTypeNode
 } from "ts-morph";
 import {
   arrayType,

--- a/lib/src/parsers/utilities/type-parser.ts
+++ b/lib/src/parsers/utilities/type-parser.ts
@@ -231,7 +231,9 @@ function parseIndexedAccessType(typeNode: IndexedAccessTypeNode): TypeNode {
 
   if (TypeGuards.isIndexedAccessTypeNode(object)) {
     // FIXME: add support for nested indexed access types
-    throw new Error("indexed access type error: nested indexed access type unsupported");
+    throw new Error(
+      "indexed access type error: nested indexed access type unsupported"
+    );
   }
 
   if (!TypeGuards.isTypeReferenceNode(object)) {
@@ -254,7 +256,9 @@ function parseIndexedAccessType(typeNode: IndexedAccessTypeNode): TypeNode {
     throw new Error("indexed access type error");
   }
 
-  const valueDeclaration = declaration.getPropertyOrThrow(literal.getLiteralText());
+  const valueDeclaration = declaration.getPropertyOrThrow(
+    literal.getLiteralText()
+  );
 
   if (!TypeGuards.isPropertySignature(valueDeclaration)) {
     throw new Error("expected property signature");

--- a/lib/src/parsers/utilities/type-parser.ts
+++ b/lib/src/parsers/utilities/type-parser.ts
@@ -237,23 +237,23 @@ function parseIndexedAccessType(typeNode: IndexedAccessTypeNode): TypeNode {
   }
 
   if (!TypeGuards.isTypeReferenceNode(object)) {
-    throw new Error("indexed access type error");
+    throw new Error("indexed access type error: not a type reference node");
   }
 
   const declaration = getTargetDeclarationFromTypeReference(object);
 
   if (!TypeGuards.isInterfaceDeclaration(declaration)) {
-    throw new Error("indexed access type error");
+    throw new Error("indexed access type error: not an interface declaration");
   }
 
   if (!TypeGuards.isLiteralTypeNode(index)) {
-    throw new Error("indexed access type error");
+    throw new Error("indexed access type error: not a literal type node");
   }
 
   const literal = index.getLiteral();
 
   if (!TypeGuards.isStringLiteral(literal)) {
-    throw new Error("indexed access type error");
+    throw new Error("indexed access type error: not a string literal");
   }
 
   const valueDeclaration = declaration.getPropertyOrThrow(
@@ -261,7 +261,7 @@ function parseIndexedAccessType(typeNode: IndexedAccessTypeNode): TypeNode {
   );
 
   if (!TypeGuards.isPropertySignature(valueDeclaration)) {
-    throw new Error("expected property signature");
+    throw new Error("indexed access type error: expected property signature");
   }
 
   return valueDeclaration.getTypeNodeOrThrow();


### PR DESCRIPTION
allow indexed access type syntax

```ts
interface Company {
  id: string;
}

@request
function request(
  @pathParams
  pathParams: {
    companyId: Company['id']
  }
)
```

---

### note

I haven't implemented nested indexed access type support yet

i.e.

```ts
interface Company {
  data: {
    id: string;
  }
}

@request
function request(
  @pathParams
  pathParams: {
    companyId: Company['data']['id']
  }
)
```