### PR TITLE
[TT-502] Add lint rule to ensure queryParams are not objects 

### DIFF
--- a/lib/src/linting/rules.ts
+++ b/lib/src/linting/rules.ts
@@ -4,6 +4,7 @@ import { hasResponsePayload } from "./rules/has-response-payload";
 import { noNestedTypesWithinUnions } from "./rules/no-nested-types-within-unions";
 import { noNullableArrays } from "./rules/no-nullable-arrays";
 import { noNullableFieldsWithinRequests } from "./rules/no-nullable-fields-within-requests";
+import { noObjectsInQueryParams } from "./rules/no-objects-in-query-params";
 import { noOmittableFieldsWithinResponses } from "./rules/no-omittable-fields-within-responses";
 import { oneSuccessResponsePerEndpoint } from "./rules/one-success-response-per-endpoint";
 
@@ -14,6 +15,7 @@ export const availableRules = {
   "no-nested-types-within-unions": noNestedTypesWithinUnions,
   "no-nullable-arrays": noNullableArrays,
   "no-nullable-fields-within-requests": noNullableFieldsWithinRequests,
+  "no-objects-in-query-params": noObjectsInQueryParams,
   "no-omittable-fields-within-responses": noOmittableFieldsWithinResponses,
   "one-success-response-per-endpoint": oneSuccessResponsePerEndpoint
 };

--- a/lib/src/linting/rules/no-objects-in-query-params.spec.ts
+++ b/lib/src/linting/rules/no-objects-in-query-params.spec.ts
@@ -109,7 +109,7 @@ describe("rule: no objects in query parameters", () => {
     expect(errors).toEqual([
       {
         message:
-          "The type `somequeryparam` is of type object. Objects are not recommended in query parameters."
+          "The type `somequeryparam` in endpoint listUsers is of type object. Objects are not recommended in query parameters."
       }
     ]);
   });
@@ -155,7 +155,7 @@ describe("rule: no objects in query parameters", () => {
     expect(errors).toEqual([
       {
         message:
-          "The type `somequeryparam` is of type object. Objects are not recommended in query parameters."
+          "The type `somequeryparam` in endpoint listUsers is of type object. Objects are not recommended in query parameters."
       }
     ]);
   });

--- a/lib/src/linting/rules/no-objects-in-query-params.spec.ts
+++ b/lib/src/linting/rules/no-objects-in-query-params.spec.ts
@@ -1,8 +1,8 @@
 import { HttpMethod } from "../../models/http";
 import {
   ApiNode,
-  QueryParamNode,
   EndpointNode,
+  QueryParamNode,
   RequestNode
 } from "../../models/nodes";
 import {

--- a/lib/src/linting/rules/no-objects-in-query-params.spec.ts
+++ b/lib/src/linting/rules/no-objects-in-query-params.spec.ts
@@ -1,0 +1,162 @@
+import { HttpMethod } from "../../models/http";
+import {
+  ApiNode,
+  QueryParamNode,
+  EndpointNode,
+  RequestNode
+} from "../../models/nodes";
+import {
+  INT32,
+  NULL,
+  objectType,
+  referenceType,
+  STRING,
+  TypeKind,
+  unionType
+} from "../../models/types";
+import { fakeLocatable } from "../../spec-helpers/fake-locatable";
+import { noObjectsInQueryParams } from "./no-objects-in-query-params";
+
+describe("rule: no objects in query parameters", () => {
+  test("valid for correct usage", () => {
+    const errors = noObjectsInQueryParams({
+      api: fakeLocatable<ApiNode>({
+        name: fakeLocatable("example-api")
+      }),
+      endpoints: [
+        // Endpoint with inline query parameters
+        fakeLocatable<EndpointNode>({
+          name: fakeLocatable("listUsers"),
+          method: fakeLocatable<HttpMethod>("GET"),
+          path: fakeLocatable("/users"),
+          isDraft: false,
+          tests: [],
+          request: fakeLocatable<RequestNode>({
+            queryParams: fakeLocatable([
+              fakeLocatable<QueryParamNode>({
+                name: fakeLocatable("somequeryparam"),
+                type: {
+                  kind: TypeKind.STRING
+                },
+                optional: true
+              })
+            ])
+          }),
+          responses: []
+        }),
+        // Endpoint with reference type in query parameters
+        fakeLocatable<EndpointNode>({
+          name: fakeLocatable("createUser"),
+          method: fakeLocatable<HttpMethod>("POST"),
+          path: fakeLocatable("/users"),
+          isDraft: false,
+          tests: [],
+          request: fakeLocatable<RequestNode>({
+            queryParams: fakeLocatable([
+              fakeLocatable<QueryParamNode>({
+                name: fakeLocatable("somequeryparam"),
+                type: referenceType("somequeryparam", "", TypeKind.UNION),
+                optional: true
+              })
+            ])
+          }),
+          responses: []
+        })
+      ],
+      types: [
+        {
+          name: "somequeryparam",
+          type: unionType([STRING, INT32])
+        }
+      ]
+    });
+    expect(errors).toEqual([]);
+  });
+
+  test("rejects query parameters of type object", () => {
+    const errors = noObjectsInQueryParams({
+      api: fakeLocatable<ApiNode>({
+        name: fakeLocatable("example-api")
+      }),
+      endpoints: [
+        // Endpoint with request payload
+        fakeLocatable<EndpointNode>({
+          name: fakeLocatable("listUsers"),
+          method: fakeLocatable<HttpMethod>("GET"),
+          path: fakeLocatable("/users"),
+          isDraft: false,
+          tests: [],
+          request: fakeLocatable<RequestNode>({
+            queryParams: fakeLocatable([
+              fakeLocatable<QueryParamNode>({
+                name: fakeLocatable("somequeryparam"),
+                type: objectType([
+                  {
+                    name: "id",
+                    type: unionType([INT32, NULL]),
+                    optional: false
+                  }
+                ]),
+                optional: true
+              })
+            ])
+          }),
+          responses: []
+        })
+      ],
+      types: []
+    });
+    expect(errors).toEqual([
+      {
+        message:
+          "The type `somequeryparam` is of type object. Objects are not recommended in query parameters."
+      }
+    ]);
+  });
+
+  test("rejects query parameters with a reference that points to an object", () => {
+    const errors = noObjectsInQueryParams({
+      api: fakeLocatable<ApiNode>({
+        name: fakeLocatable("example-api")
+      }),
+      endpoints: [
+        // Endpoint with reference type in query parameters
+        fakeLocatable<EndpointNode>({
+          name: fakeLocatable("listUsers"),
+          method: fakeLocatable<HttpMethod>("GET"),
+          path: fakeLocatable("/users"),
+          isDraft: false,
+          tests: [],
+          request: fakeLocatable<RequestNode>({
+            queryParams: fakeLocatable([
+              fakeLocatable<QueryParamNode>({
+                name: fakeLocatable("somequeryparam"),
+                type: referenceType("somequeryparam", "", TypeKind.OBJECT),
+                optional: true
+              })
+            ])
+          }),
+          responses: []
+        })
+      ],
+      types: [
+        {
+          name: "somequeryparam",
+          type: objectType([
+            {
+              name: "slug",
+              type: unionType([STRING, NULL]),
+              optional: true
+            }
+          ])
+        }
+      ]
+    });
+    expect(errors).toEqual([
+      {
+        message:
+          "The type `somequeryparam` is of type object. Objects are not recommended in query parameters."
+      }
+    ]);
+  });
+});

--- a/lib/src/linting/rules/no-objects-in-query-params.spec.ts
+++ b/lib/src/linting/rules/no-objects-in-query-params.spec.ts
@@ -109,7 +109,7 @@ describe("rule: no objects in query parameters", () => {
     expect(errors).toEqual([
       {
         message:
-          "The type `somequeryparam` in endpoint listUsers is of type object. Objects are not recommended in query parameters."
+          "The parameter `somequeryparam` in endpoint listUsers is of type object. Objects are not recommended in query parameters."
       }
     ]);
   });
@@ -155,7 +155,7 @@ describe("rule: no objects in query parameters", () => {
     expect(errors).toEqual([
       {
         message:
-          "The type `somequeryparam` in endpoint listUsers is of type object. Objects are not recommended in query parameters."
+          "The parameter `somequeryparam` in endpoint listUsers is of type object. Objects are not recommended in query parameters."
       }
     ]);
   });

--- a/lib/src/linting/rules/no-objects-in-query-params.ts
+++ b/lib/src/linting/rules/no-objects-in-query-params.ts
@@ -1,10 +1,10 @@
 import { flatten } from "lodash";
 import { LintingRule } from "../rule";
 
-import { TypeNode, EndpointNode } from "../../models/nodes";
+import { Locatable } from "lib/src/models/locatable";
+import { EndpointNode, TypeNode } from "../../models/nodes";
 import { extractQueryParams } from "../../utilities/extract-endpoint-types";
 import { extractNestedObjectTypes } from "../../utilities/extract-nested-types";
-import { Locatable } from "lib/src/models/locatable";
 
 /**
  * Ensure query parameters are not objects
@@ -20,7 +20,7 @@ export const noObjectsInQueryParams: LintingRule = contract => {
       const objectTypes = queryParams.map(extractObjectTypes);
 
       return flatten(objectTypes).map((typeNode: TypeNode) => ({
-        message: `The type \`${typeNode.name}\` in endpoint ${endpoint.value.name.value} is of type object. Objects are not recommended in query parameters.`
+        message: `The parameter \`${typeNode.name}\` in endpoint ${endpoint.value.name.value} is of type object. Objects are not recommended in query parameters.`
       }));
     }
   );

--- a/lib/src/linting/rules/no-objects-in-query-params.ts
+++ b/lib/src/linting/rules/no-objects-in-query-params.ts
@@ -1,22 +1,29 @@
 import { flatten } from "lodash";
 import { LintingRule } from "../rule";
 
-import { TypeNode } from "../../models/nodes";
+import { TypeNode, EndpointNode } from "../../models/nodes";
 import { extractQueryParams } from "../../utilities/extract-endpoint-types";
 import { extractNestedObjectTypes } from "../../utilities/extract-nested-types";
+import { Locatable } from "lib/src/models/locatable";
 
 /**
  * Ensure query parameters are not objects
  */
 export const noObjectsInQueryParams: LintingRule = contract => {
   const extractObjectTypes = (t: TypeNode) =>
-    t && extractNestedObjectTypes(t, contract.types);
+    extractNestedObjectTypes(t, contract.types);
 
-  const objectTypes = flatten(contract.endpoints.map(extractQueryParams)).map(
-    extractObjectTypes
+  const messages = contract.endpoints.map(
+    (endpoint: Locatable<EndpointNode>) => {
+      const queryParams = extractQueryParams(endpoint);
+
+      const objectTypes = queryParams.map(extractObjectTypes);
+
+      return flatten(objectTypes).map((typeNode: TypeNode) => ({
+        message: `The type \`${typeNode.name}\` in endpoint ${endpoint.value.name.value} is of type object. Objects are not recommended in query parameters.`
+      }));
+    }
   );
 
-  return flatten(objectTypes).map((typeNode: TypeNode) => ({
-    message: `The type \`${typeNode.name}\` is of type object. Objects are not recommended in query parameters.`
-  }));
+  return flatten(messages);
 };

--- a/lib/src/linting/rules/no-objects-in-query-params.ts
+++ b/lib/src/linting/rules/no-objects-in-query-params.ts
@@ -1,10 +1,9 @@
-import { flatten } from "lodash";
-import { LintingRule } from "../rule";
-
 import { Locatable } from "lib/src/models/locatable";
+import { flatten } from "lodash";
 import { EndpointNode, TypeNode } from "../../models/nodes";
 import { extractQueryParams } from "../../utilities/extract-endpoint-types";
 import { extractNestedObjectTypes } from "../../utilities/extract-nested-types";
+import { LintingRule } from "../rule";
 
 /**
  * Ensure query parameters are not objects

--- a/lib/src/linting/rules/no-objects-in-query-params.ts
+++ b/lib/src/linting/rules/no-objects-in-query-params.ts
@@ -1,0 +1,22 @@
+import { flatten } from "lodash";
+import { LintingRule } from "../rule";
+
+import { TypeNode } from "../../models/nodes";
+import { extractQueryParams } from "../../utilities/extract-endpoint-types";
+import { extractNestedObjectTypes } from "../../utilities/extract-nested-types";
+
+/**
+ * Ensure query parameters are not objects
+ */
+export const noObjectsInQueryParams: LintingRule = contract => {
+  const extractObjectTypes = (t: TypeNode) =>
+    t && extractNestedObjectTypes(t, contract.types);
+
+  const objectTypes = flatten(contract.endpoints.map(extractQueryParams)).map(
+    extractObjectTypes
+  );
+
+  return flatten(objectTypes).map((typeNode: TypeNode) => ({
+    message: `The type \`${typeNode.name}\` is of type object. Objects are not recommended in query parameters.`
+  }));
+};

--- a/lib/src/utilities/extract-endpoint-types.ts
+++ b/lib/src/utilities/extract-endpoint-types.ts
@@ -42,3 +42,16 @@ export function extractEndpointTypes(
     extractRequestType(endpoint)
   ]);
 }
+
+export function extractQueryParams(
+  endpoint: Locatable<EndpointNode>
+): TypeNode[] {
+  return compact(
+    endpoint.value.request &&
+      endpoint.value.request.value.queryParams &&
+      endpoint.value.request.value.queryParams.value.map(queryParam => ({
+        name: queryParam.value.name.value,
+        type: queryParam.value.type
+      }))
+  );
+}


### PR DESCRIPTION
**Changes** 

As per the [api guidelines](https://github.com/airtasker/api-guidelines/blob/master/guidelines/query-parameters/object.md), this adds a lint rule to ensure there's no object in query parameters definitions. 

This also adds tests to cover the changes.