### PR TITLE
Indexed access type parity

### DIFF
--- a/lib/src/neu/parsers/__spec-examples__/types.ts
+++ b/lib/src/neu/parsers/__spec-examples__/types.ts
@@ -41,6 +41,7 @@ interface TypeInterface {
   indexedAccess: IndexedAccess["root"];
   indexedAccessNested: IndexedAccess["child"]["nested"]["secondNest"];
   indexedIndexedAccess: IndexedAccess["indexed"]["root"];
+  indexedAccessInline: { root: boolean }["root"];
   enum: Enum;
   enumConstant: Enum.A;
   map: Map<string, boolean>;

--- a/lib/src/neu/parsers/__spec-examples__/types.ts
+++ b/lib/src/neu/parsers/__spec-examples__/types.ts
@@ -38,6 +38,9 @@ interface TypeInterface {
   alias: Alias;
   interface: Interface;
   interfaceExtends: InterfaceExtends;
+  indexedAccess: IndexedAccess["root"];
+  indexedAccessNested: IndexedAccess["child"]["nested"]["secondNest"];
+  indexedIndexedAccess: IndexedAccess["indexed"]["root"];
   enum: Enum;
   enumConstant: Enum.A;
   map: Map<string, boolean>;
@@ -57,6 +60,20 @@ interface InterfaceExtends extends Interface {
 
 interface InterfaceWithIndexSignature {
   [index: string]: boolean;
+}
+
+interface IndexedAccess {
+  root: boolean;
+  child: {
+    nested: {
+      secondNest: boolean;
+    };
+  };
+  indexed: IndexedIndexedAccess;
+}
+
+interface IndexedIndexedAccess {
+  root: boolean;
 }
 
 enum Enum {

--- a/lib/src/neu/parsers/type-parser.spec.ts
+++ b/lib/src/neu/parsers/type-parser.spec.ts
@@ -350,6 +350,36 @@ describe("type parser", () => {
     });
   });
 
+  test("parses indexed accessing", () => {
+    const type = interphace
+      .getPropertyOrThrow("indexedAccess")
+      .getTypeNodeOrThrow();
+
+    expect(parseType(type, typeTable, lociTable).unwrapOrThrow()).toStrictEqual(
+      { kind: "boolean" }
+    );
+  });
+
+  test("parses nested indexed accessing", () => {
+    const type = interphace
+      .getPropertyOrThrow("indexedAccessNested")
+      .getTypeNodeOrThrow();
+
+    expect(parseType(type, typeTable, lociTable).unwrapOrThrow()).toStrictEqual(
+      { kind: "boolean" }
+    );
+  });
+
+  test("parses indexed indexed accessing", () => {
+    const type = interphace
+      .getPropertyOrThrow("indexedIndexedAccess")
+      .getTypeNodeOrThrow();
+
+    expect(parseType(type, typeTable, lociTable).unwrapOrThrow()).toStrictEqual(
+      { kind: "boolean" }
+    );
+  });
+
   test("fails to parse enums", () => {
     const type = interphace.getPropertyOrThrow("enum").getTypeNodeOrThrow();
 

--- a/lib/src/neu/parsers/type-parser.spec.ts
+++ b/lib/src/neu/parsers/type-parser.spec.ts
@@ -380,6 +380,16 @@ describe("type parser", () => {
     );
   });
 
+  test("fails to parse inlined indexed accessing", () => {
+    const type = interphace
+      .getPropertyOrThrow("indexedAccessInline")
+      .getTypeNodeOrThrow();
+
+    expect(
+      parseType(type, typeTable, lociTable).unwrapErrOrThrow()
+    ).toBeInstanceOf(TypeNotAllowedError);
+  });
+
   test("fails to parse enums", () => {
     const type = interphace.getPropertyOrThrow("enum").getTypeNodeOrThrow();
 


### PR DESCRIPTION
Brings the newer raw parser's type parser to feature parity with the old type parser. This adds the final indexed access type parsing that was introduced recently.