### PR TITLE
Added verifications to raw parser

### DIFF
--- a/cli/src/commands/generate.ts
+++ b/cli/src/commands/generate.ts
@@ -100,13 +100,12 @@ export default class Generate extends Command {
       this.exit(1);
     }
 
-    const contract = safeParse.call(this, contractPath).definition;
-
-    // TODO: unhack this
     const generatedFiles =
       generator === "raw"
         ? { "*.json": JSON.stringify(parse(contractPath)) }
-        : generators[generator][language](contract);
+        : generators[generator][language](
+            safeParse.call(this, contractPath).definition
+          );
     for (let [relativePath, content] of Object.entries(generatedFiles)) {
       if (relativePath.indexOf("*") !== -1) {
         relativePath = relativePath.replace(/\*/g, contractFilename);

--- a/lib/src/neu/errors.ts
+++ b/lib/src/neu/errors.ts
@@ -1,5 +1,3 @@
-import { Project } from "ts-morph";
-
 export class ParserError extends Error {
   readonly locations: Array<{ file: string; position: number }>;
 
@@ -15,7 +13,3 @@ export class ParserError extends Error {
 
 export class OptionalNotAllowedError extends ParserError {}
 export class TypeNotAllowedError extends ParserError {}
-
-interface PrintOpts {
-  surroundingLines: number;
-}

--- a/lib/src/neu/http.ts
+++ b/lib/src/neu/http.ts
@@ -1,0 +1,192 @@
+import assertNever from "assert-never";
+import { dereferenceType, Type, TypeKind, TypeTable } from "./types";
+
+/**
+ * Check if a type is safe for use as a path parameter.
+ *
+ * @param type type to check
+ * @param typeTable type lookup table
+ */
+export function isPathParamTypeSafe(type: Type, typeTable: TypeTable): boolean {
+  switch (type.kind) {
+    case TypeKind.BOOLEAN:
+    case TypeKind.BOOLEAN_LITERAL:
+    case TypeKind.STRING:
+    case TypeKind.STRING_LITERAL:
+    case TypeKind.FLOAT:
+    case TypeKind.DOUBLE:
+    case TypeKind.FLOAT_LITERAL:
+    case TypeKind.INT32:
+    case TypeKind.INT64:
+    case TypeKind.INT_LITERAL:
+    case TypeKind.DATE:
+    case TypeKind.DATE_TIME:
+      return true;
+    case TypeKind.NULL:
+    case TypeKind.OBJECT:
+      return false;
+    case TypeKind.ARRAY:
+      return isParamArrayElementTypeSafe(type.elementType, typeTable);
+    case TypeKind.UNION:
+      return type.types.every(t => isPathParamTypeSafe(t, typeTable));
+    case TypeKind.REFERENCE:
+      return isPathParamTypeSafe(dereferenceType(type, typeTable), typeTable);
+    default:
+      throw assertNever(type);
+  }
+}
+
+/**
+ * Check if a type is safe for use as a query parameter.
+ *
+ * @param type type to check
+ * @param typeTable type lookup table
+ */
+export function isQueryParamTypeSafe(
+  type: Type,
+  typeTable: TypeTable
+): boolean {
+  switch (type.kind) {
+    case TypeKind.BOOLEAN:
+    case TypeKind.BOOLEAN_LITERAL:
+    case TypeKind.STRING:
+    case TypeKind.STRING_LITERAL:
+    case TypeKind.FLOAT:
+    case TypeKind.DOUBLE:
+    case TypeKind.FLOAT_LITERAL:
+    case TypeKind.INT32:
+    case TypeKind.INT64:
+    case TypeKind.INT_LITERAL:
+    case TypeKind.DATE:
+    case TypeKind.DATE_TIME:
+      return true;
+    case TypeKind.NULL:
+      return false;
+    case TypeKind.ARRAY:
+      return isParamArrayElementTypeSafe(type.elementType, typeTable);
+    case TypeKind.OBJECT:
+      return type.properties.every(p =>
+        isParamObjectPropertyTypeSafe(p.type, typeTable)
+      );
+    case TypeKind.UNION:
+      return type.types.every(t => isQueryParamTypeSafe(t, typeTable));
+    case TypeKind.REFERENCE:
+      return isQueryParamTypeSafe(dereferenceType(type, typeTable), typeTable);
+    default:
+      throw assertNever(type);
+  }
+}
+
+/**
+ * Check if a type is safe for use as a header type.
+ *
+ * @param type type to check
+ * @param typeTable type lookup table
+ */
+export function isHeaderTypeSafe(type: Type, typeTable: TypeTable): boolean {
+  switch (type.kind) {
+    case TypeKind.STRING:
+    case TypeKind.STRING_LITERAL:
+    case TypeKind.FLOAT:
+    case TypeKind.DOUBLE:
+    case TypeKind.FLOAT_LITERAL:
+    case TypeKind.INT32:
+    case TypeKind.INT64:
+    case TypeKind.INT_LITERAL:
+    case TypeKind.DATE:
+    case TypeKind.DATE_TIME:
+      return true;
+    case TypeKind.NULL:
+    case TypeKind.BOOLEAN:
+    case TypeKind.BOOLEAN_LITERAL:
+    case TypeKind.ARRAY:
+    case TypeKind.OBJECT:
+      return false;
+    case TypeKind.UNION:
+      return type.types.every(t => isHeaderTypeSafe(t, typeTable));
+    case TypeKind.REFERENCE:
+      return isHeaderTypeSafe(dereferenceType(type, typeTable), typeTable);
+    default:
+      throw assertNever(type);
+  }
+}
+
+/**
+ * Check if a type is safe for use as an parameter's object property type.
+ *
+ * @param type type to check
+ * @param typeTable type lookup table
+ */
+function isParamObjectPropertyTypeSafe(
+  type: Type,
+  typeTable: TypeTable
+): boolean {
+  switch (type.kind) {
+    case TypeKind.BOOLEAN:
+    case TypeKind.BOOLEAN_LITERAL:
+    case TypeKind.STRING:
+    case TypeKind.STRING_LITERAL:
+    case TypeKind.FLOAT:
+    case TypeKind.DOUBLE:
+    case TypeKind.FLOAT_LITERAL:
+    case TypeKind.INT32:
+    case TypeKind.INT64:
+    case TypeKind.INT_LITERAL:
+    case TypeKind.DATE:
+    case TypeKind.DATE_TIME:
+      return true;
+    case TypeKind.NULL:
+    case TypeKind.ARRAY:
+    case TypeKind.OBJECT:
+      return false;
+    case TypeKind.UNION:
+      return type.types.every(t => isParamObjectPropertyTypeSafe(t, typeTable));
+    case TypeKind.REFERENCE:
+      return isParamObjectPropertyTypeSafe(
+        dereferenceType(type, typeTable),
+        typeTable
+      );
+    default:
+      throw assertNever(type);
+  }
+}
+
+/**
+ * Check if a type is safe for use as an parameter's array element type.
+ *
+ * @param type type to check
+ * @param typeTable type lookup table
+ */
+function isParamArrayElementTypeSafe(
+  type: Type,
+  typeTable: TypeTable
+): boolean {
+  switch (type.kind) {
+    case TypeKind.BOOLEAN:
+    case TypeKind.BOOLEAN_LITERAL:
+    case TypeKind.STRING:
+    case TypeKind.STRING_LITERAL:
+    case TypeKind.FLOAT:
+    case TypeKind.DOUBLE:
+    case TypeKind.FLOAT_LITERAL:
+    case TypeKind.INT32:
+    case TypeKind.INT64:
+    case TypeKind.INT_LITERAL:
+    case TypeKind.DATE:
+    case TypeKind.DATE_TIME:
+      return true;
+    case TypeKind.NULL:
+    case TypeKind.ARRAY:
+    case TypeKind.OBJECT:
+      return false;
+    case TypeKind.UNION:
+      return type.types.every(t => isParamArrayElementTypeSafe(t, typeTable));
+    case TypeKind.REFERENCE:
+      return isParamArrayElementTypeSafe(
+        dereferenceType(type, typeTable),
+        typeTable
+      );
+    default:
+      throw assertNever(type);
+  }
+}

--- a/lib/src/neu/parser.ts
+++ b/lib/src/neu/parser.ts
@@ -15,6 +15,7 @@ export function parse(sourcePath: string): Contract {
 
   const result = parseContract(sourceFile);
 
+  // TODO: print human readable errors
   if (result.isErr()) throw result.unwrapErr();
 
   return result.unwrap().contract;

--- a/lib/src/neu/parsers/__spec-examples__/contracts/duplicate-endpoint-name-contract-dependency.ts
+++ b/lib/src/neu/parsers/__spec-examples__/contracts/duplicate-endpoint-name-contract-dependency.ts
@@ -1,0 +1,4 @@
+import { endpoint } from "@airtasker/spot";
+
+@endpoint({ method: "GET", path: "/anotherpath" })
+class GetEndpoint {}

--- a/lib/src/neu/parsers/__spec-examples__/contracts/duplicate-endpoint-name-contract.ts
+++ b/lib/src/neu/parsers/__spec-examples__/contracts/duplicate-endpoint-name-contract.ts
@@ -1,0 +1,9 @@
+import { api, endpoint } from "@airtasker/spot";
+import "./duplicate-endpoint-name-contract-dependency";
+
+/** contract description */
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({ method: "GET", path: "/path" })
+class GetEndpoint {}

--- a/lib/src/neu/parsers/__spec-examples__/contracts/empty-api-name-contract.ts
+++ b/lib/src/neu/parsers/__spec-examples__/contracts/empty-api-name-contract.ts
@@ -1,0 +1,4 @@
+import { api } from "@airtasker/spot";
+
+@api({ name: "  " })
+class Contract {}

--- a/lib/src/neu/parsers/__spec-examples__/contracts/illegal-api-name-contract.ts
+++ b/lib/src/neu/parsers/__spec-examples__/contracts/illegal-api-name-contract.ts
@@ -1,0 +1,4 @@
+import { api } from "@airtasker/spot";
+
+@api({ name: "contract$!%" })
+class Contract {}

--- a/lib/src/neu/parsers/__spec-examples__/endpoint.ts
+++ b/lib/src/neu/parsers/__spec-examples__/endpoint.ts
@@ -60,3 +60,64 @@ class EndpointClass {
   path: "/path"
 })
 class MinimalEndpointClass {}
+
+@endpoint({
+  method: "GET",
+  path: "/path",
+  tags: ["  "]
+})
+class EndpointWithEmptyTag {}
+
+@endpoint({
+  method: "GET",
+  path: "/path",
+  tags: ["tag", "tag"]
+})
+class EndpointWithDuplicateTag {}
+
+@endpoint({
+  method: "GET",
+  path: "/path/:dynamic/path/:dynamic"
+})
+class EndpointWithDuplicateDynamicPathComponent {}
+
+@endpoint({
+  method: "GET",
+  path: "/path/:dynamic/path/:nested"
+})
+class EndpointWithMissingPathParam {
+  @request
+  request(@pathParams
+  pathParams: {
+    dynamic: string;
+  }) {}
+}
+
+@endpoint({
+  method: "GET",
+  path: "/path/:dynamic"
+})
+class EndpointWithExtraPathParam {
+  @request
+  request(@pathParams
+  pathParams: {
+    dynamic: string;
+    nested: string;
+  }) {}
+}
+
+@endpoint({
+  method: "GET",
+  path: "/path"
+})
+class EndpointWithDuplicateResponseStatus {
+  @response({
+    status: 200
+  })
+  responseOne() {}
+
+  @response({
+    status: 200
+  })
+  responseTwo() {}
+}

--- a/lib/src/neu/parsers/__spec-examples__/headers.ts
+++ b/lib/src/neu/parsers/__spec-examples__/headers.ts
@@ -1,4 +1,4 @@
-import { headers } from "@airtasker/spot";
+import { headers, Int64 } from "@airtasker/spot";
 
 class HeadersClass {
   headersMethod(
@@ -10,10 +10,22 @@ class HeadersClass {
       property: string;
       /** property description */
       "property-with-description": string;
-      optionalProperty?: string;
+      optionalProperty?: Int64;
     },
     @headers
     nonObjectHeaders: string,
+    @headers
+    headersWithIllegalPropertyName: {
+      "illegal-field-name-header%$": string;
+    },
+    @headers
+    headersWithEmptyPropertyName: {
+      "": string;
+    },
+    @headers
+    headersWithIllegalType: {
+      property: boolean;
+    },
     @headers
     optionalHeaders?: {
       property: string;

--- a/lib/src/neu/parsers/__spec-examples__/path-params.ts
+++ b/lib/src/neu/parsers/__spec-examples__/path-params.ts
@@ -10,6 +10,7 @@ class PathParamsClass {
       property: string;
       /** property description */
       "property-with-description": string;
+      arrayProperty: string[];
     },
     @pathParams
     pathParamsWithOptionalProperty: {
@@ -17,6 +18,22 @@ class PathParamsClass {
     },
     @pathParams
     nonObjectPathParams: string,
+    @pathParams
+    pathParamsWithIllegalPropertyName: {
+      "illegal-property-name-%$": string;
+    },
+    @pathParams
+    pathParamsWithEmptyPropertyName: {
+      "": string;
+    },
+    @pathParams
+    pathParamsWithIllegalPropertyType: {
+      property: { prop: string };
+    },
+    @pathParams
+    pathParamsWithIllegalPropertyArrayType: {
+      property: null[];
+    },
     @pathParams
     optionalPathParams?: {
       property: string;

--- a/lib/src/neu/parsers/__spec-examples__/query-params.ts
+++ b/lib/src/neu/parsers/__spec-examples__/query-params.ts
@@ -11,9 +11,37 @@ class QueryParamsClass {
       /** property description */
       "property-with-description": string;
       optionalProperty?: string;
+      objectProperty: {
+        objectProp: string;
+      };
+      arrayProperty: string[];
     },
     @queryParams
     nonObjectQueryParams: string,
+    @queryParams
+    queryParamsWithIllegalPropertyName: {
+      "illegal-property-name-%$": string;
+    },
+    @queryParams
+    queryParamsWithEmptyPropertyName: {
+      "": string;
+    },
+    @queryParams
+    queryParamsWithIllegalPropertyType: {
+      property: null;
+    },
+    @queryParams
+    queryParamsWithIllegalPropertyArrayType: {
+      property: null[];
+    },
+    @queryParams
+    queryParamsWithIllegalPropertyObjectType: {
+      property: {
+        illegalNesting: {
+          property: string;
+        };
+      };
+    },
     @queryParams
     optionalQueryParams?: {
       property: string;

--- a/lib/src/neu/parsers/__spec-examples__/security-header.ts
+++ b/lib/src/neu/parsers/__spec-examples__/security-header.ts
@@ -9,4 +9,13 @@ class SecurityHeaderClass {
 
   @securityHeader
   "optional-security-header"?: string;
+
+  @securityHeader
+  "illegal-field-name-security-header%$": string;
+
+  @securityHeader
+  "": string;
+
+  @securityHeader
+  "not-string-security-header": number;
 }

--- a/lib/src/neu/parsers/contract-parser.spec.ts
+++ b/lib/src/neu/parsers/contract-parser.spec.ts
@@ -1,4 +1,5 @@
 import { createProjectFromExistingSourceFile } from "../../spec-helpers/helper";
+import { ParserError } from "../errors";
 import { parseContract } from "./contract-parser";
 
 describe("contract parser", () => {
@@ -71,5 +72,35 @@ describe("contract parser", () => {
     expect(() => parseContract(file)).toThrowError(
       "expected a decorator @api to be used once, found 0 usages"
     );
+  });
+
+  test("fails to parse file containing @api decorated class with an empty api name", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/contracts/empty-api-name-contract.ts`
+    ).file;
+
+    const result = parseContract(file).unwrapErrOrThrow();
+
+    expect(result).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse file containing @api decorated class with an api name containing illegal characters", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/contracts/illegal-api-name-contract.ts`
+    ).file;
+
+    const result = parseContract(file).unwrapErrOrThrow();
+
+    expect(result).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse contract containing duplicate endpoint names", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/contracts/duplicate-endpoint-name-contract.ts`
+    ).file;
+
+    const result = parseContract(file).unwrapErrOrThrow();
+
+    expect(result).toBeInstanceOf(ParserError);
   });
 });

--- a/lib/src/neu/parsers/endpoint-parser.spec.ts
+++ b/lib/src/neu/parsers/endpoint-parser.spec.ts
@@ -1,8 +1,8 @@
 import { createProjectFromExistingSourceFile } from "../../spec-helpers/helper";
+import { ParserError } from "../errors";
 import { LociTable } from "../locations";
 import { TypeKind, TypeTable } from "../types";
 import { parseEndpoint } from "./endpoint-parser";
-import { ParserError } from "../errors";
 
 describe("endpoint parser", () => {
   const exampleFile = createProjectFromExistingSourceFile(

--- a/lib/src/neu/parsers/endpoint-parser.spec.ts
+++ b/lib/src/neu/parsers/endpoint-parser.spec.ts
@@ -2,6 +2,7 @@ import { createProjectFromExistingSourceFile } from "../../spec-helpers/helper";
 import { LociTable } from "../locations";
 import { TypeKind, TypeTable } from "../types";
 import { parseEndpoint } from "./endpoint-parser";
+import { ParserError } from "../errors";
 
 describe("endpoint parser", () => {
   const exampleFile = createProjectFromExistingSourceFile(
@@ -108,6 +109,66 @@ describe("endpoint parser", () => {
       responses: [],
       tags: []
     });
+  });
+
+  test("fails to parse endpoint with empty tag", () => {
+    const err = parseEndpoint(
+      exampleFile.getClassOrThrow("EndpointWithEmptyTag"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse endpoint with duplicate tag", () => {
+    const err = parseEndpoint(
+      exampleFile.getClassOrThrow("EndpointWithDuplicateTag"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse endpoint with duplicate dynamic path component", () => {
+    const err = parseEndpoint(
+      exampleFile.getClassOrThrow("EndpointWithDuplicateDynamicPathComponent"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse endpoint with missing path param", () => {
+    const err = parseEndpoint(
+      exampleFile.getClassOrThrow("EndpointWithMissingPathParam"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse endpoint with extra path param", () => {
+    const err = parseEndpoint(
+      exampleFile.getClassOrThrow("EndpointWithExtraPathParam"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse endpoint with duplicate response status", () => {
+    const err = parseEndpoint(
+      exampleFile.getClassOrThrow("EndpointWithDuplicateResponseStatus"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
   });
 
   test("fails to parse non-@endpoint decorated class", () => {

--- a/lib/src/neu/parsers/endpoint-parser.ts
+++ b/lib/src/neu/parsers/endpoint-parser.ts
@@ -86,14 +86,14 @@ export function parseEndpoint(
   // Check request path params cover the path dynamic components
   const pathParamsInPath = getDynamicPathComponents(path);
   const pathParamsInRequest = request
-    ? request.pathParams.map(pp => pp.name)
+    ? request.pathParams.map(pathParam => pathParam.name)
     : [];
 
   const exclusivePathParamsInPath = pathParamsInPath.filter(
-    pp => !pathParamsInRequest.includes(pp)
+    pathParam => !pathParamsInRequest.includes(pathParam)
   );
   const exclusivePathParamsInRequest = pathParamsInRequest.filter(
-    pp => !pathParamsInPath.includes(pp)
+    pathParam => !pathParamsInPath.includes(pathParam)
   );
   if (exclusivePathParamsInPath.length !== 0) {
     return err(

--- a/lib/src/neu/parsers/endpoint-parser.ts
+++ b/lib/src/neu/parsers/endpoint-parser.ts
@@ -1,6 +1,10 @@
-import { ClassDeclaration, TypeGuards } from "ts-morph";
+import {
+  ClassDeclaration,
+  ObjectLiteralExpression,
+  TypeGuards
+} from "ts-morph";
 import { EndpointConfig } from "../../syntax/endpoint";
-import { Endpoint } from "../definitions";
+import { Endpoint, Request, Response } from "../definitions";
 import { ParserError } from "../errors";
 import { LociTable } from "../locations";
 import { TypeTable } from "../types";
@@ -28,7 +32,7 @@ export function parseEndpoint(
   const decoratorConfig = getDecoratorConfigOrThrow(decorator);
 
   // Handle name
-  const endpointName = klass.getNameOrThrow();
+  const name = klass.getNameOrThrow();
 
   // Handle method
   const methodProp = getObjLiteralPropOrThrow<EndpointConfig>(
@@ -36,110 +40,238 @@ export function parseEndpoint(
     "method"
   );
   const methodLiteral = getPropValueAsStringOrThrow(methodProp);
-  const methodValue = methodLiteral.getLiteralText();
-  if (!isHttpMethod(methodValue)) {
-    throw new Error(`expected a HttpMethod, got ${methodValue}`);
+  const method = methodLiteral.getLiteralText();
+  if (!isHttpMethod(method)) {
+    throw new Error(`expected a HttpMethod, got ${method}`);
   }
-
-  // Handle path
-  const pathProp = getObjLiteralPropOrThrow<EndpointConfig>(
-    decoratorConfig,
-    "path"
-  );
-  const pathLiteral = getPropValueAsStringOrThrow(pathProp);
 
   // Handle tags
-  const tagsProp = getObjLiteralProp<EndpointConfig>(decoratorConfig, "tags");
-  const tagsLiteral = tagsProp && getPropValueAsArrayOrThrow(tagsProp);
-  const tagsValueLiterals = [];
-  if (tagsLiteral) {
-    for (const elementExpr of tagsLiteral.getElements()) {
-      if (TypeGuards.isStringLiteral(elementExpr)) {
-        tagsValueLiterals.push(elementExpr);
-      } else {
-        return err(
-          new ParserError("tag must be a string", {
-            file: elementExpr.getSourceFile().getFilePath(),
-            position: elementExpr.getPos()
-          })
-        );
-      }
-    }
-  }
+  const tagsResult = extractEndpointTags(decoratorConfig);
+  if (tagsResult.isErr()) return tagsResult;
+  const tags = tagsResult.unwrap();
 
   // Handle jsdoc
   const descriptionDoc = getJsDoc(klass);
+  const description = descriptionDoc && descriptionDoc.getComment();
 
   // Handle request
   const requestMethod = getMethodWithDecorator(klass, "request");
-  let request;
-  if (requestMethod) {
-    const requestResult = parseRequest(requestMethod, typeTable, lociTable, {
-      endpointName
-    });
-    if (requestResult.isErr()) return requestResult;
-    request = requestResult.unwrap();
-  }
+  const requestResult = requestMethod
+    ? parseRequest(requestMethod, typeTable, lociTable)
+    : ok(undefined);
+  if (requestResult.isErr()) return requestResult;
+  const request = requestResult.unwrap();
 
   // Handle responses
-  const responseMethods = klass
-    .getMethods()
-    .filter(m => m.getDecorator("response") !== undefined);
-  const responses = [];
-  for (const method of responseMethods) {
-    const responseResult = parseResponse(method, typeTable, lociTable);
-    if (responseResult.isErr()) return responseResult;
-    responses.push(responseResult.unwrap());
-  }
-  // TODO: find duplicate response statuses
+  const responsesResult = extractEndpointResponses(klass, typeTable, lociTable);
+  if (responsesResult.isErr()) return responsesResult;
+  const responses = responsesResult.unwrap();
 
   // Handle default response
   const defaultResponseMethod = getMethodWithDecorator(
     klass,
     "defaultResponse"
   );
-  let defaultResponse;
-  if (defaultResponseMethod) {
-    const defaultResponseResult = parseDefaultResponse(
-      defaultResponseMethod,
-      typeTable,
-      lociTable
+  const defaultResponseResult = defaultResponseMethod
+    ? parseDefaultResponse(defaultResponseMethod, typeTable, lociTable)
+    : ok(undefined);
+  if (defaultResponseResult.isErr()) return defaultResponseResult;
+  const defaultResponse = defaultResponseResult.unwrap();
+
+  // Handle path
+  const pathResult = extractEndpointPath(decoratorConfig);
+  if (pathResult.isErr()) return pathResult;
+  const path = pathResult.unwrap();
+
+  // Check request path params cover the path dynamic components
+  const pathParamsInPath = getDynamicPathComponents(path);
+  const pathParamsInRequest = request
+    ? request.pathParams.map(pp => pp.name)
+    : [];
+
+  const exclusivePathParamsInPath = pathParamsInPath.filter(
+    pp => !pathParamsInRequest.includes(pp)
+  );
+  const exclusivePathParamsInRequest = pathParamsInRequest.filter(
+    pp => !pathParamsInPath.includes(pp)
+  );
+  if (exclusivePathParamsInPath.length !== 0) {
+    return err(
+      new ParserError(
+        `endpoint path dynamic components must have a corresponding path param defined in @request. Violating path components: ${exclusivePathParamsInPath.join(
+          ", "
+        )}`,
+        {
+          file: klass.getSourceFile().getFilePath(),
+          position: klass.getPos()
+        }
+      )
     );
-    if (defaultResponseResult.isErr()) return defaultResponseResult;
-    defaultResponse = defaultResponseResult.unwrap();
+  }
+  if (exclusivePathParamsInRequest.length !== 0) {
+    return err(
+      new ParserError(
+        `endpoint request path params must have a corresponding dynamic path component defined in @endpoint. Violating path params: ${exclusivePathParamsInRequest.join(
+          ", "
+        )}`,
+        {
+          file: klass.getSourceFile().getFilePath(),
+          position: klass.getPos()
+        }
+      )
+    );
   }
 
   // Add location data
-  lociTable.addMorphNode(LociTable.endpointClassKey(endpointName), klass);
-  lociTable.addMorphNode(
-    LociTable.endpointDecoratorKey(endpointName),
-    decorator
-  );
-  lociTable.addMorphNode(LociTable.endpointMethodKey(endpointName), methodProp);
-  lociTable.addMorphNode(LociTable.endpointPathKey(endpointName), pathProp);
-  if (descriptionDoc) {
-    lociTable.addMorphNode(
-      LociTable.endpointDescriptionKey(endpointName),
-      descriptionDoc
-    );
-  }
-  if (tagsProp) {
-    lociTable.addMorphNode(LociTable.endpointTagsKey(endpointName), tagsProp);
-    tagsValueLiterals.forEach(tagLiteral => {
-      lociTable.addMorphNode(
-        LociTable.endpointTagKey(endpointName, tagLiteral.getLiteralText()),
-        tagLiteral
-      );
-    });
-  }
+  lociTable.addMorphNode(LociTable.endpointClassKey(name), klass);
+  lociTable.addMorphNode(LociTable.endpointDecoratorKey(name), decorator);
+  lociTable.addMorphNode(LociTable.endpointMethodKey(name), methodProp);
+
   return ok({
-    name: endpointName,
-    description: descriptionDoc && descriptionDoc.getComment(),
-    tags: tagsValueLiterals.map(tvl => tvl.getLiteralText()), // TODO: sort tags
-    method: methodValue,
-    path: pathLiteral.getLiteralText(),
+    name,
+    description,
+    tags,
+    method,
+    path,
     request,
-    responses: responses.sort((a, b) => (b.status > a.status ? -1 : 1)),
+    responses,
     defaultResponse
   });
+}
+
+function extractEndpointTags(
+  decoratorConfig: ObjectLiteralExpression
+): Result<string[], ParserError> {
+  const tagsProp = getObjLiteralProp<EndpointConfig>(decoratorConfig, "tags");
+  if (tagsProp === undefined) return ok([]);
+
+  const tagsLiteral = getPropValueAsArrayOrThrow(tagsProp);
+  const tags: string[] = [];
+
+  for (const elementExpr of tagsLiteral.getElements()) {
+    // Sanity check, typesafety should prevent any non-string tags
+    if (!TypeGuards.isStringLiteral(elementExpr)) {
+      return err(
+        new ParserError("endpoint tag must be a string", {
+          file: elementExpr.getSourceFile().getFilePath(),
+          position: elementExpr.getPos()
+        })
+      );
+    }
+    const tag = elementExpr.getLiteralText().trim();
+    if (tag.length === 0) {
+      return err(
+        new ParserError("endpoint tag cannot be blank", {
+          file: elementExpr.getSourceFile().getFilePath(),
+          position: elementExpr.getPos()
+        })
+      );
+    }
+    if (!/^[\w\s-]*$/.test(tag)) {
+      return err(
+        new ParserError(
+          "endpoint tag may only contain alphanumeric, space, underscore and hyphen characters",
+          {
+            file: elementExpr.getSourceFile().getFilePath(),
+            position: elementExpr.getPos()
+          }
+        )
+      );
+    }
+    tags.push(tag);
+  }
+
+  const duplicateTags = [
+    ...new Set(tags.filter((tag, index) => tags.indexOf(tag) !== index))
+  ];
+  if (duplicateTags.length !== 0) {
+    return err(
+      new ParserError(
+        `endpoint tags may not contain duplicates: ${duplicateTags.join(", ")}`,
+        {
+          file: tagsProp.getSourceFile().getFilePath(),
+          position: tagsProp.getPos()
+        }
+      )
+    );
+  }
+
+  return ok(tags.sort((a, b) => (b > a ? -1 : 1)));
+}
+
+function extractEndpointPath(
+  decoratorConfig: ObjectLiteralExpression
+): Result<string, ParserError> {
+  const pathProp = getObjLiteralPropOrThrow<EndpointConfig>(
+    decoratorConfig,
+    "path"
+  );
+  const pathLiteral = getPropValueAsStringOrThrow(pathProp);
+  const path = pathLiteral.getLiteralText();
+  const dynamicComponents = getDynamicPathComponents(path);
+
+  const duplicateDynamicComponents = [
+    ...new Set(
+      dynamicComponents.filter(
+        (component, index) => dynamicComponents.indexOf(component) !== index
+      )
+    )
+  ];
+  if (duplicateDynamicComponents.length !== 0) {
+    return err(
+      new ParserError(
+        "endpoint path dynamic components must have unique names",
+        {
+          file: pathProp.getSourceFile().getFilePath(),
+          position: pathProp.getPos()
+        }
+      )
+    );
+  }
+
+  return ok(path);
+}
+
+function extractEndpointResponses(
+  klass: ClassDeclaration,
+  typeTable: TypeTable,
+  lociTable: LociTable
+): Result<Response[], ParserError> {
+  const responseMethods = klass
+    .getMethods()
+    .filter(m => m.getDecorator("response") !== undefined);
+
+  const responses: Response[] = [];
+  for (const method of responseMethods) {
+    const responseResult = parseResponse(method, typeTable, lociTable);
+    if (responseResult.isErr()) return responseResult;
+    responses.push(responseResult.unwrap());
+  }
+
+  // ensure unique response statsues
+  const statuses = responses.map(r => r.status);
+  const duplicateStatuses = [
+    ...new Set(
+      statuses.filter((status, index) => statuses.indexOf(status) !== index)
+    )
+  ];
+  if (duplicateStatuses.length !== 0) {
+    return err(
+      new ParserError(
+        `endpoint responses must have unique statuses. Duplicates found: ${duplicateStatuses.join(
+          ", "
+        )}`,
+        { file: klass.getSourceFile().getFilePath(), position: klass.getPos() }
+      )
+    );
+  }
+
+  return ok(responses.sort((a, b) => (b.status > a.status ? -1 : 1)));
+}
+
+function getDynamicPathComponents(path: string): string[] {
+  return path
+    .split("/")
+    .filter(component => component.startsWith(":"))
+    .map(component => component.substr(1));
 }

--- a/lib/src/neu/parsers/headers-parser.spec.ts
+++ b/lib/src/neu/parsers/headers-parser.spec.ts
@@ -1,5 +1,5 @@
 import { createProjectFromExistingSourceFile } from "../../spec-helpers/helper";
-import { OptionalNotAllowedError } from "../errors";
+import { OptionalNotAllowedError, ParserError } from "../errors";
 import { LociTable } from "../locations";
 import { TypeKind, TypeTable } from "../types";
 import { parseHeaders } from "./headers-parser";
@@ -31,7 +31,7 @@ describe("headers parser", () => {
       description: undefined,
       name: "optionalProperty",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.INT64
       },
       optional: true
     });
@@ -71,6 +71,36 @@ describe("headers parser", () => {
         lociTable
       ).unwrapErrOrThrow()
     ).toBeInstanceOf(OptionalNotAllowedError);
+  });
+
+  test("fails to parse @headers with param containing illegal characters", () => {
+    const err = parseHeaders(
+      method.getParameterOrThrow("headersWithIllegalPropertyName"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse @headers with an empty param name", () => {
+    const err = parseHeaders(
+      method.getParameterOrThrow("headersWithEmptyPropertyName"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse @headers with an illegal param type", () => {
+    const err = parseHeaders(
+      method.getParameterOrThrow("headersWithIllegalType"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
   });
 
   test("fails to parse non-@headers decorated parameter", () => {

--- a/lib/src/neu/parsers/path-params-parser.ts
+++ b/lib/src/neu/parsers/path-params-parser.ts
@@ -1,8 +1,9 @@
-import { ParameterDeclaration } from "ts-morph";
+import { ParameterDeclaration, PropertySignature } from "ts-morph";
 import { PathParam } from "../definitions";
 import { OptionalNotAllowedError, ParserError } from "../errors";
+import { isPathParamTypeSafe } from "../http";
 import { LociTable } from "../locations";
-import { TypeTable } from "../types";
+import { Type, TypeTable } from "../types";
 import { err, ok, Result } from "../util";
 import {
   getJsDoc,
@@ -25,39 +26,102 @@ export function parsePathParams(
       })
     );
   }
-  const type = getParameterTypeAsTypeLiteralOrThrow(parameter);
+  const pathParamTypeLiteral = getParameterTypeAsTypeLiteralOrThrow(parameter);
 
   const pathParams = [];
-  for (const propertySignature of type.getProperties()) {
-    if (propertySignature.hasQuestionToken()) {
-      return err(
-        new OptionalNotAllowedError(
-          "@pathParams properties cannot be optional",
-          {
-            file: propertySignature.getSourceFile().getFilePath(),
-            position: propertySignature.getQuestionTokenNodeOrThrow().getPos()
-          }
-        )
-      );
-    }
-
-    const typeResult = parseType(
-      propertySignature.getTypeNodeOrThrow(),
+  for (const propertySignature of pathParamTypeLiteral.getProperties()) {
+    const pathParamResult = extractPathParam(
+      propertySignature,
       typeTable,
       lociTable
     );
-    if (typeResult.isErr()) return typeResult;
-    const pDescription = getJsDoc(propertySignature);
-
-    const pathParam = {
-      name: getPropertyName(propertySignature),
-      type: typeResult.unwrap(),
-      description: pDescription && pDescription.getComment()
-    };
-
-    pathParams.push(pathParam);
+    if (pathParamResult.isErr()) return pathParamResult;
+    pathParams.push(pathParamResult.unwrap());
   }
 
-  // TODO: add loci information
   return ok(pathParams.sort((a, b) => (b.name > a.name ? -1 : 1)));
+}
+
+function extractPathParam(
+  propertySignature: PropertySignature,
+  typeTable: TypeTable,
+  lociTable: LociTable
+): Result<PathParam, ParserError> {
+  if (propertySignature.hasQuestionToken()) {
+    return err(
+      new OptionalNotAllowedError("@pathParams property cannot be optional", {
+        file: propertySignature.getSourceFile().getFilePath(),
+        position: propertySignature.getQuestionTokenNodeOrThrow().getPos()
+      })
+    );
+  }
+
+  const nameResult = extractPathParamName(propertySignature);
+  if (nameResult.isErr()) return nameResult;
+  const name = nameResult.unwrap();
+
+  const typeResult = extractPathParamType(
+    propertySignature,
+    typeTable,
+    lociTable
+  );
+  if (typeResult.isErr()) return typeResult;
+  const type = typeResult.unwrap();
+
+  const pDescription = getJsDoc(propertySignature);
+  const description = pDescription && pDescription.getComment();
+
+  return ok({ name, type, description });
+}
+
+function extractPathParamName(
+  propertySignature: PropertySignature
+): Result<string, ParserError> {
+  const name = getPropertyName(propertySignature);
+  if (!/^[\w-]*$/.test(name)) {
+    return err(
+      new ParserError(
+        "@pathParams property name may only contain alphanumeric, underscore and hyphen characters",
+        {
+          file: propertySignature.getSourceFile().getFilePath(),
+          position: propertySignature.getPos()
+        }
+      )
+    );
+  }
+  if (name.length === 0) {
+    return err(
+      new ParserError("@pathParams property name must not be empty", {
+        file: propertySignature.getSourceFile().getFilePath(),
+        position: propertySignature.getPos()
+      })
+    );
+  }
+  return ok(name);
+}
+
+function extractPathParamType(
+  propertySignature: PropertySignature,
+  typeTable: TypeTable,
+  lociTable: LociTable
+): Result<Type, ParserError> {
+  const typeResult = parseType(
+    propertySignature.getTypeNodeOrThrow(),
+    typeTable,
+    lociTable
+  );
+  if (typeResult.isErr()) return typeResult;
+
+  if (!isPathParamTypeSafe(typeResult.unwrap(), typeTable)) {
+    return err(
+      new ParserError(
+        "path parameter type may only be a URL-safe type, or an array of URL-safe types",
+        {
+          file: propertySignature.getSourceFile().getFilePath(),
+          position: propertySignature.getPos()
+        }
+      )
+    );
+  }
+  return typeResult;
 }

--- a/lib/src/neu/parsers/query-params-parser.spec.ts
+++ b/lib/src/neu/parsers/query-params-parser.spec.ts
@@ -1,5 +1,5 @@
 import { createProjectFromExistingSourceFile } from "../../spec-helpers/helper";
-import { OptionalNotAllowedError, TypeNotAllowedError } from "../errors";
+import { OptionalNotAllowedError, ParserError } from "../errors";
 import { LociTable } from "../locations";
 import { TypeKind, TypeTable } from "../types";
 import { parseQueryParams } from "./query-params-parser";
@@ -26,8 +26,37 @@ describe("query params parser", () => {
       typeTable,
       lociTable
     ).unwrapOrThrow();
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(5);
     expect(result[0]).toStrictEqual({
+      description: undefined,
+      name: "arrayProperty",
+      type: {
+        kind: TypeKind.ARRAY,
+        elementType: {
+          kind: TypeKind.STRING
+        }
+      },
+      optional: false
+    });
+    expect(result[1]).toStrictEqual({
+      description: undefined,
+      name: "objectProperty",
+      type: {
+        kind: TypeKind.OBJECT,
+        properties: [
+          {
+            description: undefined,
+            name: "objectProp",
+            optional: false,
+            type: {
+              kind: TypeKind.STRING
+            }
+          }
+        ]
+      },
+      optional: false
+    });
+    expect(result[2]).toStrictEqual({
       description: undefined,
       name: "optionalProperty",
       type: {
@@ -35,7 +64,7 @@ describe("query params parser", () => {
       },
       optional: true
     });
-    expect(result[1]).toStrictEqual({
+    expect(result[3]).toStrictEqual({
       description: undefined,
       name: "property",
       type: {
@@ -43,7 +72,7 @@ describe("query params parser", () => {
       },
       optional: false
     });
-    expect(result[2]).toStrictEqual({
+    expect(result[4]).toStrictEqual({
       description: "property description",
       name: "property-with-description",
       type: {
@@ -71,6 +100,56 @@ describe("query params parser", () => {
         lociTable
       ).unwrapErrOrThrow()
     ).toBeInstanceOf(OptionalNotAllowedError);
+  });
+
+  test("fails to parse @queryParams with param name containing illegal characters", () => {
+    const err = parseQueryParams(
+      method.getParameterOrThrow("queryParamsWithIllegalPropertyName"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse @queryParams with empty param name", () => {
+    const err = parseQueryParams(
+      method.getParameterOrThrow("queryParamsWithEmptyPropertyName"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse @queryParams with an illegal param type", () => {
+    const err = parseQueryParams(
+      method.getParameterOrThrow("queryParamsWithIllegalPropertyType"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse @queryParams with an illegal array param type", () => {
+    const err = parseQueryParams(
+      method.getParameterOrThrow("queryParamsWithIllegalPropertyArrayType"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse @queryParams with an illegal object param type", () => {
+    const err = parseQueryParams(
+      method.getParameterOrThrow("queryParamsWithIllegalPropertyObjectType"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
   });
 
   test("fails to parse non-@queryParams decorated parameter", () => {

--- a/lib/src/neu/parsers/request-parser.spec.ts
+++ b/lib/src/neu/parsers/request-parser.spec.ts
@@ -21,8 +21,7 @@ describe("request parser", () => {
     const result = parseRequest(
       klass.getMethodOrThrow("request"),
       typeTable,
-      lociTable,
-      { endpointName: "endpoint" }
+      lociTable
     ).unwrapOrThrow();
 
     expect(result).toStrictEqual({
@@ -59,8 +58,7 @@ describe("request parser", () => {
     const result = parseRequest(
       klass.getMethodOrThrow("parameterlessRequest"),
       typeTable,
-      lociTable,
-      { endpointName: "endpoint" }
+      lociTable
     ).unwrapOrThrow();
 
     expect(result).toStrictEqual({
@@ -73,9 +71,7 @@ describe("request parser", () => {
 
   test("fails to parse non-@request decorated method", () => {
     expect(() =>
-      parseRequest(klass.getMethodOrThrow("notRequest"), typeTable, lociTable, {
-        endpointName: "endpoint"
-      })
+      parseRequest(klass.getMethodOrThrow("notRequest"), typeTable, lociTable)
     ).toThrowError("Expected to find decorator named 'request'");
   });
 });

--- a/lib/src/neu/parsers/request-parser.ts
+++ b/lib/src/neu/parsers/request-parser.ts
@@ -13,10 +13,7 @@ import { parseQueryParams } from "./query-params-parser";
 export function parseRequest(
   method: MethodDeclaration,
   typeTable: TypeTable,
-  lociTable: LociTable,
-  lociContext: {
-    endpointName: string;
-  }
+  lociTable: LociTable
 ): Result<Request, ParserError> {
   method.getDecoratorOrThrow("request");
   const headersParam = getParamWithDecorator(method, "headers");

--- a/lib/src/neu/parsers/security-header-parser.spec.ts
+++ b/lib/src/neu/parsers/security-header-parser.spec.ts
@@ -1,5 +1,5 @@
 import { createProjectFromExistingSourceFile } from "../../spec-helpers/helper";
-import { OptionalNotAllowedError } from "../errors";
+import { OptionalNotAllowedError, ParserError } from "../errors";
 import { LociTable } from "../locations";
 import { TypeKind, TypeTable } from "../types";
 import { parseSecurityHeader } from "./security-header-parser";
@@ -53,5 +53,35 @@ describe("security header parser", () => {
         lociTable
       )
     ).toThrowError("Expected to find decorator named 'securityHeader'");
+  });
+
+  test("fails to parse @securityHeader decorated property with a field name containing illegal characters", () => {
+    const err = parseSecurityHeader(
+      klass.getPropertyOrThrow(`\"illegal-field-name-security-header%$\"`),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse @securityHeader decorated property with an empty field name", () => {
+    const err = parseSecurityHeader(
+      klass.getPropertyOrThrow(`\"\"`),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse @securityHeader decorated property with a non-string type", () => {
+    const err = parseSecurityHeader(
+      klass.getPropertyOrThrow(`\"not-string-security-header\"`),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
   });
 });

--- a/lib/src/neu/parsers/security-header-parser.ts
+++ b/lib/src/neu/parsers/security-header-parser.ts
@@ -2,7 +2,7 @@ import { PropertyDeclaration } from "ts-morph";
 import { SecurityHeader } from "../definitions";
 import { OptionalNotAllowedError, ParserError } from "../errors";
 import { LociTable } from "../locations";
-import { TypeTable } from "../types";
+import { isStringType, possibleRootTypes, Type, TypeTable } from "../types";
 import { err, ok, Result } from "../util";
 import { getJsDoc, getPropertyName } from "./parser-helpers";
 import { parseType } from "./type-parser";
@@ -25,19 +25,69 @@ export function parseSecurityHeader(
       )
     );
   }
-  const name = getPropertyName(property);
+
+  // Handle name
+  const nameResult = extractName(property);
+  if (nameResult.isErr()) return nameResult;
+  const name = nameResult.unwrap();
+
+  // Handle description
   const descriptionDoc = getJsDoc(property);
+  const description = descriptionDoc && descriptionDoc.getComment();
+
+  // Handle type
+  const typeResult = extractType(property, typeTable, lociTable);
+  if (typeResult.isErr()) return typeResult;
+  const type = typeResult.unwrap();
+
+  return ok({ name, description, type });
+}
+
+function extractName(
+  property: PropertyDeclaration
+): Result<string, ParserError> {
+  const name = getPropertyName(property);
+  if (!/^[\w-]*$/.test(name)) {
+    return err(
+      new ParserError(
+        "@securityHeader field name may only contain alphanumeric, underscore and hyphen characters",
+        {
+          file: property.getSourceFile().getFilePath(),
+          position: property.getPos()
+        }
+      )
+    );
+  }
+  if (name.length === 0) {
+    return err(
+      new ParserError("@securityHeader field name must not be empty", {
+        file: property.getSourceFile().getFilePath(),
+        position: property.getPos()
+      })
+    );
+  }
+  return ok(name);
+}
+
+function extractType(
+  property: PropertyDeclaration,
+  typeTable: TypeTable,
+  lociTable: LociTable
+): Result<Type, ParserError> {
   const typeResult = parseType(
     property.getTypeNodeOrThrow(),
     typeTable,
     lociTable
   );
-
   if (typeResult.isErr()) return typeResult;
-
-  return ok({
-    name,
-    description: descriptionDoc && descriptionDoc.getComment(),
-    type: typeResult.unwrap()
-  });
+  const rootTypes = possibleRootTypes(typeResult.unwrap(), typeTable);
+  if (rootTypes.some(rt => !isStringType(rt))) {
+    return err(
+      new ParserError("@securityHeader type may only be a string type", {
+        file: property.getSourceFile().getFilePath(),
+        position: property.getPos()
+      })
+    );
+  }
+  return typeResult;
 }

--- a/lib/src/neu/types.ts
+++ b/lib/src/neu/types.ts
@@ -37,6 +37,8 @@ export type Type =
   | UnionType
   | ReferenceType;
 
+export type ConcreteRootType = Exclude<Type, UnionType | ReferenceType>;
+
 export interface NullType {
   kind: TypeKind.NULL;
 }
@@ -117,6 +119,8 @@ export interface ReferenceType {
   kind: TypeKind.REFERENCE;
   name: string;
 }
+
+// Type builders
 
 export function nullType(): NullType {
   return {
@@ -233,6 +237,104 @@ export function referenceType(name: string): ReferenceType {
     kind: TypeKind.REFERENCE,
     name
   };
+}
+
+// Type guards
+
+export function isNullType(type: Type): type is NullType {
+  return type.kind === TypeKind.NULL;
+}
+
+export function isBooleanType(type: Type): type is BooleanType {
+  return type.kind === TypeKind.BOOLEAN;
+}
+
+export function isBooleanLiteralType(type: Type): type is BooleanLiteralType {
+  return type.kind === TypeKind.BOOLEAN_LITERAL;
+}
+
+export function isStringType(type: Type): type is StringType {
+  return type.kind === TypeKind.STRING;
+}
+
+export function isStringLiteralType(type: Type): type is StringLiteralType {
+  return type.kind === TypeKind.STRING_LITERAL;
+}
+
+export function isFloatType(type: Type): type is FloatType {
+  return type.kind === TypeKind.FLOAT;
+}
+
+export function isDoubleType(type: Type): type is DoubleType {
+  return type.kind === TypeKind.DOUBLE;
+}
+
+export function isFloatLiteralType(type: Type): type is FloatLiteralType {
+  return type.kind === TypeKind.FLOAT_LITERAL;
+}
+
+export function isInt32Type(type: Type): type is Int32Type {
+  return type.kind === TypeKind.INT32;
+}
+
+export function isInt64Type(type: Type): type is Int64Type {
+  return type.kind === TypeKind.INT64;
+}
+
+export function isIntLiteralType(type: Type): type is IntLiteralType {
+  return type.kind === TypeKind.INT_LITERAL;
+}
+
+export function isDateType(type: Type): type is DateType {
+  return type.kind === TypeKind.DATE;
+}
+
+export function isDateTimeType(type: Type): type is DateTimeType {
+  return type.kind === TypeKind.DATE_TIME;
+}
+
+export function isObjectType(type: Type): type is ObjectType {
+  return type.kind === TypeKind.OBJECT;
+}
+
+export function isArrayType(type: Type): type is ArrayType {
+  return type.kind === TypeKind.ARRAY;
+}
+
+export function isUnionType(type: Type): type is UnionType {
+  return type.kind === TypeKind.UNION;
+}
+
+export function isReferenceType(type: Type): type is ReferenceType {
+  return type.kind === TypeKind.REFERENCE;
+}
+
+// Type helpers
+
+export function possibleRootTypes(
+  type: Type,
+  typeTable: TypeTable
+): ConcreteRootType[] {
+  if (isReferenceType(type)) {
+    return possibleRootTypes(typeTable.getOrError(type.name), typeTable);
+  }
+  if (isUnionType(type)) {
+    return type.types.reduce<ConcreteRootType[]>(
+      (acc, curr) => acc.concat(possibleRootTypes(curr, typeTable)),
+      []
+    );
+  }
+  return [type];
+}
+
+export function dereferenceType(
+  type: Type,
+  typeTable: TypeTable
+): Exclude<Type, ReferenceType> {
+  if (isReferenceType(type)) {
+    return dereferenceType(typeTable.getOrError(type.name), typeTable);
+  }
+  return type;
 }
 
 /**

--- a/lib/src/neu/types.ts
+++ b/lib/src/neu/types.ts
@@ -37,7 +37,10 @@ export type Type =
   | UnionType
   | ReferenceType;
 
-export type ConcreteRootType = Exclude<Type, UnionType | ReferenceType>;
+/**
+ * A concrete type is any type that is not a union of types or reference to a type.
+ */
+export type ConcreteType = Exclude<Type, UnionType | ReferenceType>;
 
 export interface NullType {
   kind: TypeKind.NULL;
@@ -314,12 +317,12 @@ export function isReferenceType(type: Type): type is ReferenceType {
 export function possibleRootTypes(
   type: Type,
   typeTable: TypeTable
-): ConcreteRootType[] {
+): ConcreteType[] {
   if (isReferenceType(type)) {
     return possibleRootTypes(typeTable.getOrError(type.name), typeTable);
   }
   if (isUnionType(type)) {
-    return type.types.reduce<ConcreteRootType[]>(
+    return type.types.reduce<ConcreteType[]>(
       (acc, curr) => acc.concat(possibleRootTypes(curr, typeTable)),
       []
     );


### PR DESCRIPTION
All generator's are first parsed and then verifications are performed against the parsed content. However the raw generator uses a newer parser but currently does not perform the verifications. The raw generator would parse the contract twice (once using the older parser, once using the newer) to temporarily ensure verification is performed. This PR adds the same verifications directly into the newer parser which brings parity to the old and new parsers. As a result the raw generator no longer parses the contract twice.