### PR TITLE
[TT-554] Rename 'ampersandEscaped' to 'space' for query params array config

### DIFF
--- a/lib/src/models/types/parameter-serialization-strategies.ts
+++ b/lib/src/models/types/parameter-serialization-strategies.ts
@@ -7,11 +7,7 @@ export interface QueryParamSerializationStrategy {
 }
 
 /** Supported serialization strategies for arrays in query parameters */
-export type QueryParamArrayStrategy =
-  | "ampersand"
-  | "ampersandEscaped"
-  | "comma"
-  | "pipe";
+export type QueryParamArrayStrategy = "ampersand" | "space" | "comma" | "pipe";
 
 /**
  * Transform a parameter serialization strategy for array into
@@ -31,7 +27,7 @@ export function makeParamSerializationRulesForArray(
         style: "form"
       };
     }
-    case "ampersandEscaped": {
+    case "space": {
       return {
         explode: false,
         style: "spaceDelimited"

--- a/lib/src/neu/definitions.ts
+++ b/lib/src/neu/definitions.ts
@@ -78,15 +78,11 @@ export interface Body {
  * Supported serialization strategies for arrays in query parameters
  *
  *    "ampersand": ?id=3&id=4&id=5
- *    "ampersandEscaped": ?id=3%204%205
+ *    "space": ?id=3%204%205
  *    "comma": ?id=3,4,5
  *    "pipe": ?id=3|4|5
  */
-export type QueryParamArrayStrategy =
-  | "ampersand"
-  | "ampersandEscaped"
-  | "comma"
-  | "pipe";
+export type QueryParamArrayStrategy = "ampersand" | "space" | "comma" | "pipe";
 
 /** Supported HTTP methods */
 export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";

--- a/lib/src/neu/parsers/parser-helpers.ts
+++ b/lib/src/neu/parsers/parser-helpers.ts
@@ -352,7 +352,7 @@ export function isQueryParamArrayStrategy(
 ): strategy is QueryParamArrayStrategy {
   switch (strategy) {
     case "ampersand":
-    case "ampersandEscaped":
+    case "space":
     case "comma":
     case "pipe":
       return true;


### PR DESCRIPTION
## Description, Motivation and Context
The 'ampersandEscaped' case for query param array strategy was added by mistake, it should be named 'space'
