### PR TITLE
TT-555 Remove unused array serialization strategies space and pipe

### DIFF
--- a/lib/src/models/types/parameter-serialization-strategies.ts
+++ b/lib/src/models/types/parameter-serialization-strategies.ts
@@ -7,7 +7,7 @@ export interface QueryParamSerializationStrategy {
 }
 
 /** Supported serialization strategies for arrays in query parameters */
-export type QueryParamArrayStrategy = "ampersand" | "space" | "comma" | "pipe";
+export type QueryParamArrayStrategy = "ampersand" | "comma";
 
 /**
  * Transform a parameter serialization strategy for array into
@@ -27,22 +27,10 @@ export function makeParamSerializationRulesForArray(
         style: "form"
       };
     }
-    case "space": {
-      return {
-        explode: false,
-        style: "spaceDelimited"
-      };
-    }
     case "comma": {
       return {
         explode: false,
         style: "form"
-      };
-    }
-    case "pipe": {
-      return {
-        explode: false,
-        style: "pipeDelimited"
       };
     }
   }

--- a/lib/src/neu/definitions.ts
+++ b/lib/src/neu/definitions.ts
@@ -78,11 +78,9 @@ export interface Body {
  * Supported serialization strategies for arrays in query parameters
  *
  *    "ampersand": ?id=3&id=4&id=5
- *    "space": ?id=3%204%205
  *    "comma": ?id=3,4,5
- *    "pipe": ?id=3|4|5
  */
-export type QueryParamArrayStrategy = "ampersand" | "space" | "comma" | "pipe";
+export type QueryParamArrayStrategy = "ampersand" | "comma";
 
 /** Supported HTTP methods */
 export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";

--- a/lib/src/neu/parsers/parser-helpers.ts
+++ b/lib/src/neu/parsers/parser-helpers.ts
@@ -352,9 +352,7 @@ export function isQueryParamArrayStrategy(
 ): strategy is QueryParamArrayStrategy {
   switch (strategy) {
     case "ampersand":
-    case "space":
     case "comma":
-    case "pipe":
       return true;
     default:
       return false;


### PR DESCRIPTION
## Description, Motivation and Context
We don't have a use case for the "space" and "pipe" strategies and adding support for them on the contract validators will add extra work. We can always add them later.
