### PR TITLE
TT-557 Add CLI command to start contract validation server

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1,7 +1,7 @@
 import { Command, flags } from "@oclif/command";
-import { startValidationServer } from "../../../lib/src/validation-server/server";
-import { parse } from "../../../lib/src/neu/parser";
 import { outputFile } from "../../../lib/src/io/output";
+import { parse } from "../../../lib/src/neu/parser";
+import { runValidationServer } from "../../../lib/src/validation-server/server";
 
 const ARG_API = "spot_contract";
 
@@ -42,6 +42,6 @@ export default class Serve extends Command {
     outputFile(".spot", "raw.json", rawContract, true);
 
     this.log("Starting spot validation server...");
-    startValidationServer(port);
+    runValidationServer(port, this);
   }
 }

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -6,10 +6,10 @@ import { outputFile } from "../../../lib/src/io/output";
 const ARG_API = "spot_contract";
 
 /**
- * oclif command to start the validation server for spot contracts
+ * oclif command to start the spot contract validation server
  */
 export default class Serve extends Command {
-  static description = "Validate a Spot contract";
+  static description = "Start the spot contract validation server";
 
   static examples = ["$ spot serve api.ts"];
 

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1,5 +1,4 @@
 import { Command, flags } from "@oclif/command";
-import { outputFile } from "../../../lib/src/io/output";
 import { parse } from "../../../lib/src/neu/parser";
 import { runValidationServer } from "../../../lib/src/validation-server/server";
 
@@ -38,12 +37,10 @@ export default class Serve extends Command {
 
     try {
       this.log("Generating raw contract...");
-      const rawContract = JSON.stringify(parse(contractPath));
-      this.debug("Outputing raw contract to ./spot");
-      outputFile(".spot", "raw.json", rawContract, true);
+      const contract = parse(contractPath);
 
       this.log("Starting validation server...");
-      await runValidationServer(port, this).defer();
+      await runValidationServer(port, contract, this).defer();
       this.log(`Validation server running on port ${port}`);
     } catch (e) {
       this.error(e, { exit: 1 });

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1,0 +1,36 @@
+import { Command, flags } from "@oclif/command";
+
+const ARG_API = "spot_contract";
+
+/**
+ * oclif command to start the validation server for spot contracts
+ */
+export default class Serve extends Command {
+  static description = "Validate a Spot contract";
+
+  static examples = ["$ spot serve api.ts"];
+
+  static args = [
+    {
+      name: ARG_API,
+      required: true,
+      description: "path to Spot contract",
+      hidden: false
+    }
+  ];
+
+  static flags = {
+    help: flags.help({ char: "h" }),
+    port: flags.string({
+      char: "p",
+      default: "5907",
+      description: "The port where application will be available"
+    })
+  };
+
+  async run() {
+    const { args, flags } = this.parse(Serve);
+    const { port } = flags;
+    this.log("Running spot serve " + args[ARG_API] + " -p " + port);
+  }
+}

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -43,7 +43,5 @@ export default class Serve extends Command {
 
     this.log("Starting spot validation server...");
     startValidationServer(port);
-
-    this.log("Running spot serve " + contractPath + " -p " + port);
   }
 }

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1,4 +1,5 @@
 import { Command, flags } from "@oclif/command";
+import { startValidationServer } from "../../../lib/src/validation-server/server";
 
 const ARG_API = "spot_contract";
 
@@ -21,9 +22,9 @@ export default class Serve extends Command {
 
   static flags = {
     help: flags.help({ char: "h" }),
-    port: flags.string({
+    port: flags.integer({
       char: "p",
-      default: "5907",
+      default: 5907,
       description: "The port where application will be available"
     })
   };
@@ -31,6 +32,8 @@ export default class Serve extends Command {
   async run() {
     const { args, flags } = this.parse(Serve);
     const { port } = flags;
+    // Generate raw contract
+    startValidationServer(port);
     this.log("Running spot serve " + args[ARG_API] + " -p " + port);
   }
 }

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1,5 +1,7 @@
 import { Command, flags } from "@oclif/command";
 import { startValidationServer } from "../../../lib/src/validation-server/server";
+import { parse } from "../../../lib/src/neu/parser";
+import { outputFile } from "../../../lib/src/io/output";
 
 const ARG_API = "spot_contract";
 
@@ -31,9 +33,17 @@ export default class Serve extends Command {
 
   async run() {
     const { args, flags } = this.parse(Serve);
+    const contractPath = args[ARG_API];
     const { port } = flags;
-    // Generate raw contract
+
+    this.log("Generating raw contract...");
+    const rawContract = JSON.stringify(parse(contractPath));
+    this.debug("Outputing raw contract to ./spot");
+    outputFile(".spot", "raw.json", rawContract, true);
+
+    this.log("Starting spot validation server...");
     startValidationServer(port);
-    this.log("Running spot serve " + args[ARG_API] + " -p " + port);
+
+    this.log("Running spot serve " + contractPath + " -p " + port);
   }
 }

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -36,7 +36,7 @@ export default class Serve extends Command {
     const { port } = flags;
 
     try {
-      this.log("Generating raw contract...");
+      this.log("Parsing contract...");
       const contract = parse(contractPath);
 
       this.log("Starting validation server...");

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -36,12 +36,17 @@ export default class Serve extends Command {
     const contractPath = args[ARG_API];
     const { port } = flags;
 
-    this.log("Generating raw contract...");
-    const rawContract = JSON.stringify(parse(contractPath));
-    this.debug("Outputing raw contract to ./spot");
-    outputFile(".spot", "raw.json", rawContract, true);
+    try {
+      this.log("Generating raw contract...");
+      const rawContract = JSON.stringify(parse(contractPath));
+      this.debug("Outputing raw contract to ./spot");
+      outputFile(".spot", "raw.json", rawContract, true);
 
-    this.log("Starting spot validation server...");
-    runValidationServer(port, this);
+      this.log("Starting validation server...");
+      await runValidationServer(port, this).defer();
+      this.log(`Validation server running on port ${port}`);
+    } catch (e) {
+      this.error(e, { exit: 1 });
+    }
   }
 }

--- a/cli/src/commands/validation-server.ts
+++ b/cli/src/commands/validation-server.ts
@@ -7,10 +7,10 @@ const ARG_API = "spot_contract";
 /**
  * oclif command to start the spot contract validation server
  */
-export default class Serve extends Command {
+export default class ValidationServer extends Command {
   static description = "Start the spot contract validation server";
 
-  static examples = ["$ spot serve api.ts"];
+  static examples = ["$ spot validation-server api.ts"];
 
   static args = [
     {
@@ -31,7 +31,7 @@ export default class Serve extends Command {
   };
 
   async run() {
-    const { args, flags } = this.parse(Serve);
+    const { args, flags } = this.parse(ValidationServer);
     const contractPath = args[ARG_API];
     const { port } = flags;
 

--- a/lib/src/mockserver/server.ts
+++ b/lib/src/mockserver/server.ts
@@ -1,6 +1,7 @@
 import cors from "cors";
 import express from "express";
 import { ContractDefinition } from "../models/definitions";
+import { Logger } from "../utilities/logger";
 import { generateData } from "./dummy";
 import { isRequestForEndpoint } from "./matcher";
 import { proxyRequest } from "./proxy";
@@ -71,9 +72,4 @@ export function runMockServer(
     app,
     defer: () => new Promise(resolve => app.listen(port, resolve))
   };
-}
-
-export interface Logger {
-  log(message: string): void;
-  error(message: string): void;
 }

--- a/lib/src/utilities/logger.ts
+++ b/lib/src/utilities/logger.ts
@@ -1,0 +1,4 @@
+export interface Logger {
+  log(message: string): void;
+  error(message: string): void;
+}

--- a/lib/src/validation-server/server.spec.ts
+++ b/lib/src/validation-server/server.spec.ts
@@ -1,14 +1,19 @@
 import request from "supertest";
+import { parse } from "../neu/parser";
 import { runValidationServer } from "./server";
+
+const CONTRACT_PATH = "./lib/src/__examples__/contract.ts";
 
 describe("Server", () => {
   const mockLogger = {
     log: (message: string) => message
   };
 
+  const contract = parse(CONTRACT_PATH);
+
   describe("Run", () => {
     it("/health and return 200", done => {
-      const { app } = runValidationServer(5907, mockLogger);
+      const { app } = runValidationServer(5907, contract, mockLogger);
 
       request(app)
         .get("/health")

--- a/lib/src/validation-server/server.spec.ts
+++ b/lib/src/validation-server/server.spec.ts
@@ -3,24 +3,24 @@ import { parse } from "../neu/parser";
 import { runValidationServer } from "./server";
 
 const CONTRACT_PATH = "./lib/src/__examples__/contract.ts";
+const DUMMY_PORT = 5907;
 
 describe("Server", () => {
   const mockLogger = {
-    log: (message: string) => message
+    log: (message: string) => message,
+    error: (message: string) => message
   };
 
   const contract = parse(CONTRACT_PATH);
 
   describe("Run", () => {
     it("/health and return 200", done => {
-      const { app } = runValidationServer(5907, contract, mockLogger);
+      const { app } = runValidationServer(DUMMY_PORT, contract, mockLogger);
 
       request(app)
         .get("/health")
         .expect(200)
-        .then(_ => {
-          done();
-        });
+        .then(done);
     });
   });
 });

--- a/lib/src/validation-server/server.spec.ts
+++ b/lib/src/validation-server/server.spec.ts
@@ -1,0 +1,21 @@
+import request from "supertest";
+import { runValidationServer } from "./server";
+
+describe("Server", () => {
+  const mockLogger = {
+    log: (message: string) => message
+  };
+
+  describe("Run", () => {
+    it("/health and return 200", done => {
+      const { app } = runValidationServer(5907, mockLogger);
+
+      request(app)
+        .get("/health")
+        .expect(200)
+        .then(_ => {
+          done();
+        });
+    });
+  });
+});

--- a/lib/src/validation-server/server.spec.ts
+++ b/lib/src/validation-server/server.spec.ts
@@ -5,7 +5,7 @@ import { runValidationServer } from "./server";
 const CONTRACT_PATH = "./lib/src/__examples__/contract.ts";
 const DUMMY_PORT = 5907;
 
-describe("Server", () => {
+describe("Validation Server", () => {
   const mockLogger = {
     log: (message: string) => message,
     error: (message: string) => message
@@ -14,13 +14,12 @@ describe("Server", () => {
   const contract = parse(CONTRACT_PATH);
 
   describe("Run", () => {
-    it("/health and return 200", done => {
+    it("/health and return 200", async () => {
       const { app } = runValidationServer(DUMMY_PORT, contract, mockLogger);
 
-      request(app)
+      await request(app)
         .get("/health")
-        .expect(200)
-        .then(done);
+        .expect(200);
     });
   });
 });

--- a/lib/src/validation-server/server.ts
+++ b/lib/src/validation-server/server.ts
@@ -1,0 +1,13 @@
+import express from "express";
+
+export function startValidationServer(port: number) {
+  const app = express();
+
+  app.get("/health", (req, res) => {
+    res.status(200).end();
+  });
+
+  app.listen(port, () => {
+    console.log(`Spot validation server started at http://localhost:${port}`);
+  });
+}

--- a/lib/src/validation-server/server.ts
+++ b/lib/src/validation-server/server.ts
@@ -1,6 +1,6 @@
 import express from "express";
 
-export function startValidationServer(port: number) {
+export function runValidationServer(port: number, logger: Logger) {
   const app = express();
 
   app.get("/health", (req, res) => {
@@ -8,6 +8,10 @@ export function startValidationServer(port: number) {
   });
 
   app.listen(port, () => {
-    console.log(`Spot validation server started at http://localhost:${port}`);
+    logger.log(`Spot validation server started at http://localhost:${port}`);
   });
+}
+
+export interface Logger {
+  log(message: string): void;
 }

--- a/lib/src/validation-server/server.ts
+++ b/lib/src/validation-server/server.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import { Contract } from "../neu/definitions";
+import { Logger } from "../utilities/logger";
 
 export function runValidationServer(
   port: number,
@@ -16,8 +17,4 @@ export function runValidationServer(
     app,
     defer: () => new Promise(resolve => app.listen(port, resolve))
   };
-}
-
-export interface Logger {
-  log(message: string): void;
 }

--- a/lib/src/validation-server/server.ts
+++ b/lib/src/validation-server/server.ts
@@ -1,6 +1,11 @@
 import express from "express";
+import { Contract } from "../neu/definitions";
 
-export function runValidationServer(port: number, logger: Logger) {
+export function runValidationServer(
+  port: number,
+  contract: Contract,
+  logger: Logger
+) {
   const app = express();
 
   app.get("/health", (req, res) => {

--- a/lib/src/validation-server/server.ts
+++ b/lib/src/validation-server/server.ts
@@ -7,9 +7,10 @@ export function runValidationServer(port: number, logger: Logger) {
     res.status(200).end();
   });
 
-  app.listen(port, () => {
-    logger.log(`Spot validation server started at http://localhost:${port}`);
-  });
+  return {
+    app,
+    defer: () => new Promise(resolve => app.listen(port, resolve))
+  };
 }
 
 export interface Logger {


### PR DESCRIPTION
## Description, Motivation, and Context
Initial work on the validation server feature.

* Added a function to create an express server
* The server contains only one endpoint `/health` which always returns 200
* Added a CLI command `spot serve CONTRACT_PATH [-p PORT]`
* The command generates a raw contract and saves it to `.spot/raw.json`

**Please, let me know if you have any suggestions/concerns about:**
* The command name `serve`
* The path to save the raw contract `.spot/raw.json`

I didn't put much thought on those since they are easy to change, and I wanted to hear your opinions.