### PR TITLE
TT-567 Add a spot contract to validation-server's health check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
+      - run: yarn build
       - run: ./bin/run validate ./lib/src/validation-server/spots/api.ts
 
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,21 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
       - run: yarn lint:check
 
+  validate-contracts:
+    <<: *job_configuration
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+      - run: yarn install
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+      - run: ./bin/run validate ./lib/src/validation-server/spots/api.ts
+
   publish:
     <<: *job_configuration
     steps:
@@ -88,6 +103,10 @@ workflows:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - lint-check:
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      - validate-contracts:
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/lib/src/validation-server/spots/api.ts
+++ b/lib/src/validation-server/spots/api.ts
@@ -1,0 +1,8 @@
+import { api } from "../../lib";
+
+import "./health";
+
+@api({
+  name: "Validation API"
+})
+class ValidationApi {}

--- a/lib/src/validation-server/spots/health.ts
+++ b/lib/src/validation-server/spots/health.ts
@@ -1,7 +1,7 @@
 import { endpoint, request, response } from "../../lib";
 
 @endpoint({
-  method: "POST",
+  method: "GET",
   path: "/health"
 })
 export class HealthCheck {

--- a/lib/src/validation-server/spots/health.ts
+++ b/lib/src/validation-server/spots/health.ts
@@ -1,0 +1,13 @@
+import { endpoint, request, response } from "../../lib";
+
+@endpoint({
+  method: "POST",
+  path: "/health"
+})
+export class HealthCheck {
+  @request
+  request() {}
+
+  @response({ status: 200 })
+  response() {}
+}


### PR DESCRIPTION
## Description, Motivation and Context
Adding spot contracts to the validation-server. The only endpoint we currently have is the health check endpoint, so I'm adding an @endpoint for it.

I also added another CircleCI job to validate the contract, so we can be confident that a pull-request is not breaking it.