### PR TITLE
TT-528 Add spot contract for the validation endpoint

### DIFF
--- a/lib/src/validation-server/spots/api.ts
+++ b/lib/src/validation-server/spots/api.ts
@@ -1,6 +1,7 @@
 import { api } from "../../lib";
 
 import "./health";
+import "./validate";
 
 @api({
   name: "Validation API"

--- a/lib/src/validation-server/spots/utils.ts
+++ b/lib/src/validation-server/spots/utils.ts
@@ -1,0 +1,8 @@
+import { String } from "../../lib";
+
+export interface UnprocessableEntityError {
+  error_code: String;
+  error_messages: String[];
+}
+
+export type Headers = String[];

--- a/lib/src/validation-server/spots/utils.ts
+++ b/lib/src/validation-server/spots/utils.ts
@@ -9,4 +9,7 @@ export interface UnprocessableEntityError extends BaseError {
   type: "unprocessable_entity";
 }
 
-export type Headers = String[];
+export interface Header {
+  key: String;
+  value: String;
+}

--- a/lib/src/validation-server/spots/utils.ts
+++ b/lib/src/validation-server/spots/utils.ts
@@ -1,8 +1,12 @@
 import { String } from "../../lib";
 
-export interface UnprocessableEntityError {
+export interface BaseError {
   error_code: String;
   error_messages: String[];
+}
+
+export interface UnprocessableEntityError extends BaseError {
+  type: "unprocessable_entity";
 }
 
 export type Headers = String[];

--- a/lib/src/validation-server/spots/validate.ts
+++ b/lib/src/validation-server/spots/validate.ts
@@ -1,6 +1,6 @@
 import { body, endpoint, Integer, request, response, String } from "../../lib";
 import { HttpMethod } from "../../models/http";
-import { Headers, UnprocessableEntityError } from "./utils";
+import { Header, UnprocessableEntityError } from "./utils";
 
 @endpoint({
   method: "POST",
@@ -21,14 +21,12 @@ export interface ValidateRequest {
   request: {
     method: HttpMethod;
     path: String;
-    headers: Headers;
+    headers: Header[];
     body: String;
   };
   response: {
-    status: {
-      code: Integer;
-    };
-    headers: Headers;
+    status: Integer;
+    headers: Header[];
     body: String;
   };
 }

--- a/lib/src/validation-server/spots/validate.ts
+++ b/lib/src/validation-server/spots/validate.ts
@@ -1,0 +1,38 @@
+import { body, endpoint, Integer, request, response, String } from "../../lib";
+import { HttpMethod } from "../../models/http";
+import { Headers, UnprocessableEntityError } from "./utils";
+
+@endpoint({
+  method: "POST",
+  path: "/validate"
+})
+export class Validate {
+  @request
+  request(@body body: ValidateRequest) {}
+
+  @response({ status: 200 })
+  response(@body body: ValidateResponse) {}
+
+  @response({ status: 422 })
+  unprocessableEntityError(@body body: UnprocessableEntityError) {}
+}
+
+export interface ValidateRequest {
+  request: {
+    method: HttpMethod;
+    path: String;
+    headers: Headers;
+    body: String;
+  };
+  response: {
+    status: {
+      code: Integer;
+    };
+    headers: Headers;
+    body: String;
+  };
+}
+
+export interface ValidateResponse {
+  mismatches: String[];
+}


### PR DESCRIPTION
Hi, this PR is adding the spot contract for the validation server's `validation` endpoint. This is the endpoint we'll use to confirm that a pair of response and request matches an endpoint definition in the contract.

I have an initial draft of the validate endpoint and I wanted to get some early feedback on the interface

I wrote some reasoning on my choices below, please let me know if you think there is a better way:

**Headers** type
- Using a String[] for the Headers type since Spot doesn't seem to support indexed types
- An example of how we would use it:
```
request: {
  headers: ["Auth-Token: 123", "Content-Type: text/html; charset=UTF-8"]
}
```

**UnprocessableEntityError /  BaseError**
- Following a pattern that we're using on other places, an interface with `error_code`, `error_messages`, and `type`

**ValidateRequest.request.body** type
- Not sure what's the best type to use here. I left it as a String, we can throw a 422 if the value is an invalid JSON