### PR TITLE
Use string based validators for headers and path params

### DIFF
--- a/lib/src/__examples__/contract.ts
+++ b/lib/src/__examples__/contract.ts
@@ -122,7 +122,7 @@ class GetCompany {
     headers: {
       /** Auth Header */
       "x-id": number;
-    },
+    }
   ) {}
 
   /** Successful creation of user */

--- a/lib/src/__examples__/contract.ts
+++ b/lib/src/__examples__/contract.ts
@@ -14,7 +14,7 @@ import {
   test
 } from "@airtasker/spot";
 import "./contract-endpoint";
-import { Address, Company, ErrorBody, UserBody, UserQuery } from "./models";
+import { Address, CompanyBody, ErrorBody, UserBody, UserQuery } from "./models";
 
 /** This is the company API. It does cool things */
 @api({ name: "company-api" })
@@ -102,6 +102,40 @@ class CreateUser {
     }
   })
   successResponseTest() {}
+}
+
+/** Creates a user in a company */
+@endpoint({
+  method: "GET",
+  path: "/company/:companyId",
+  tags: ["Company"]
+})
+class GetCompany {
+  @request
+  request(
+    @pathParams
+    pathParams: {
+      /** company identifier */
+      companyId: String;
+    },
+    @headers
+    headers: {
+      /** Auth Header */
+      "x-id": number;
+    },
+  ) {}
+
+  /** Successful creation of user */
+  @response({ status: 201 })
+  successResponse(
+    @headers
+    headers: {
+      /** Location header */
+      accept: number;
+    },
+    /** User response body */
+    @body body: CompanyBody
+  ) {}
 }
 
 /** User request body */

--- a/lib/src/__examples__/models.ts
+++ b/lib/src/__examples__/models.ts
@@ -21,6 +21,10 @@ export interface UserBody {
   };
 }
 
+export interface CompanyBody {
+  data: Company,
+}
+
 /** Error body */
 export interface ErrorBody {
   /** error name */

--- a/lib/src/__examples__/models.ts
+++ b/lib/src/__examples__/models.ts
@@ -22,7 +22,7 @@ export interface UserBody {
 }
 
 export interface CompanyBody {
-  data: Company,
+  data: Company;
 }
 
 /** Error body */

--- a/lib/src/generators/contract/__snapshots__/json-schema.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/json-schema.spec.ts.snap
@@ -130,6 +130,28 @@ exports[`JSON Schema generator produces valid code: json 1`] = `
     },
     \\"Address\\": {
       \\"type\\": \\"string\\"
+    },
+    \\"CompanyBody\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"data\\": {
+          \\"$ref\\": \\"#/definitions/Company\\"
+        }
+      },
+      \\"required\\": [
+        \\"data\\"
+      ]
+    },
+    \\"Company\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"id\\": {
+          \\"type\\": \\"string\\"
+        }
+      },
+      \\"required\\": [
+        \\"id\\"
+      ]
     }
   }
 }"
@@ -223,5 +245,19 @@ definitions:
     type: string
   Address:
     type: string
+  CompanyBody:
+    type: object
+    properties:
+      data:
+        $ref: '#/definitions/Company'
+    required:
+      - data
+  Company:
+    type: object
+    properties:
+      id:
+        type: string
+    required:
+      - id
 "
 `;

--- a/lib/src/generators/contract/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/openapi2.spec.ts.snap
@@ -164,11 +164,74 @@ exports[`OpenAPI 2 generator produces valid code: json 1`] = `
           }
         }
       }
+    },
+    \\"/company/{companyId}\\": {
+      \\"get\\": {
+        \\"operationId\\": \\"GetCompany\\",
+        \\"description\\": \\"Creates a user in a company\\",
+        \\"tags\\": [
+          \\"Company\\"
+        ],
+        \\"parameters\\": [
+          {
+            \\"in\\": \\"path\\",
+            \\"name\\": \\"companyId\\",
+            \\"description\\": \\"company identifier\\",
+            \\"type\\": \\"string\\",
+            \\"required\\": true
+          },
+          {
+            \\"in\\": \\"header\\",
+            \\"name\\": \\"x-id\\",
+            \\"description\\": \\"Auth Header\\",
+            \\"type\\": \\"number\\",
+            \\"format\\": \\"float\\",
+            \\"required\\": true
+          }
+        ],
+        \\"responses\\": {
+          \\"201\\": {
+            \\"schema\\": {
+              \\"$ref\\": \\"#/definitions/CompanyBody\\"
+            },
+            \\"headers\\": {
+              \\"accept\\": {
+                \\"type\\": \\"number\\",
+                \\"format\\": \\"float\\",
+                \\"description\\": \\"Location header\\"
+              }
+            },
+            \\"description\\": \\"Successful creation of user\\"
+          }
+        }
+      }
     }
   },
   \\"definitions\\": {
     \\"Address\\": {
       \\"type\\": \\"string\\"
+    },
+    \\"Company\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"id\\": {
+          \\"type\\": \\"string\\"
+        }
+      },
+      \\"required\\": [
+        \\"id\\"
+      ]
+    },
+    \\"CompanyBody\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"data\\": {
+          \\"$ref\\": \\"#/definitions/Company\\"
+        }
+      },
+      \\"required\\": [
+        \\"data\\"
+      ]
     },
     \\"CreateUserRequestBody\\": {
       \\"type\\": \\"object\\",
@@ -426,9 +489,51 @@ paths:
             $ref: '#/definitions/ErrorBody'
           headers: {}
           description: ''
+  '/company/{companyId}':
+    get:
+      operationId: GetCompany
+      description: Creates a user in a company
+      tags:
+        - Company
+      parameters:
+        - in: path
+          name: companyId
+          description: company identifier
+          type: string
+          required: true
+        - in: header
+          name: x-id
+          description: Auth Header
+          type: number
+          format: float
+          required: true
+      responses:
+        '201':
+          schema:
+            $ref: '#/definitions/CompanyBody'
+          headers:
+            accept:
+              type: number
+              format: float
+              description: Location header
+          description: Successful creation of user
 definitions:
   Address:
     type: string
+  Company:
+    type: object
+    properties:
+      id:
+        type: string
+    required:
+      - id
+  CompanyBody:
+    type: object
+    properties:
+      data:
+        $ref: '#/definitions/Company'
+    required:
+      - data
   CreateUserRequestBody:
     type: object
     properties:

--- a/lib/src/generators/contract/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/contract/__snapshots__/openapi3.spec.ts.snap
@@ -763,12 +763,86 @@ exports[`OpenAPI 3 generator produces valid code: json 1`] = `
           }
         }
       }
+    },
+    \\"/company/{companyId}\\": {
+      \\"get\\": {
+        \\"operationId\\": \\"GetCompany\\",
+        \\"description\\": \\"Creates a user in a company\\",
+        \\"tags\\": [
+          \\"Company\\"
+        ],
+        \\"parameters\\": [
+          {
+            \\"in\\": \\"path\\",
+            \\"name\\": \\"companyId\\",
+            \\"description\\": \\"company identifier\\",
+            \\"schema\\": {
+              \\"type\\": \\"string\\"
+            },
+            \\"required\\": true
+          },
+          {
+            \\"in\\": \\"header\\",
+            \\"name\\": \\"x-id\\",
+            \\"description\\": \\"Auth Header\\",
+            \\"schema\\": {
+              \\"type\\": \\"number\\",
+              \\"format\\": \\"float\\"
+            },
+            \\"required\\": true
+          }
+        ],
+        \\"responses\\": {
+          \\"201\\": {
+            \\"content\\": {
+              \\"application/json\\": {
+                \\"schema\\": {
+                  \\"$ref\\": \\"#/components/schemas/CompanyBody\\"
+                }
+              }
+            },
+            \\"headers\\": {
+              \\"accept\\": {
+                \\"description\\": \\"Location header\\",
+                \\"required\\": true,
+                \\"schema\\": {
+                  \\"type\\": \\"number\\",
+                  \\"format\\": \\"float\\"
+                }
+              }
+            },
+            \\"description\\": \\"Successful creation of user\\"
+          }
+        }
+      }
     }
   },
   \\"components\\": {
     \\"schemas\\": {
       \\"Address\\": {
         \\"type\\": \\"string\\"
+      },
+      \\"Company\\": {
+        \\"type\\": \\"object\\",
+        \\"properties\\": {
+          \\"id\\": {
+            \\"type\\": \\"string\\"
+          }
+        },
+        \\"required\\": [
+          \\"id\\"
+        ]
+      },
+      \\"CompanyBody\\": {
+        \\"type\\": \\"object\\",
+        \\"properties\\": {
+          \\"data\\": {
+            \\"$ref\\": \\"#/components/schemas/Company\\"
+          }
+        },
+        \\"required\\": [
+          \\"data\\"
+        ]
       },
       \\"CreateUserRequestBody\\": {
         \\"type\\": \\"object\\",
@@ -1048,10 +1122,58 @@ paths:
                 $ref: '#/components/schemas/ErrorBody'
           headers: {}
           description: ''
+  '/company/{companyId}':
+    get:
+      operationId: GetCompany
+      description: Creates a user in a company
+      tags:
+        - Company
+      parameters:
+        - in: path
+          name: companyId
+          description: company identifier
+          schema:
+            type: string
+          required: true
+        - in: header
+          name: x-id
+          description: Auth Header
+          schema:
+            type: number
+            format: float
+          required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompanyBody'
+          headers:
+            accept:
+              description: Location header
+              required: true
+              schema:
+                type: number
+                format: float
+          description: Successful creation of user
 components:
   schemas:
     Address:
       type: string
+    Company:
+      type: object
+      properties:
+        id:
+          type: string
+      required:
+        - id
+    CompanyBody:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/Company'
+      required:
+        - data
     CreateUserRequestBody:
       type: object
       properties:

--- a/lib/src/neu/generators/__snapshots__/json-schema-generator.spec.ts.snap
+++ b/lib/src/neu/generators/__snapshots__/json-schema-generator.spec.ts.snap
@@ -7,6 +7,28 @@ exports[`JSON Schema generator produces valid code: json 1`] = `
     \\"Address\\": {
       \\"type\\": \\"string\\"
     },
+    \\"Company\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"id\\": {
+          \\"type\\": \\"string\\"
+        }
+      },
+      \\"required\\": [
+        \\"id\\"
+      ]
+    },
+    \\"CompanyBody\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"data\\": {
+          \\"$ref\\": \\"#/definitions/Company\\"
+        }
+      },
+      \\"required\\": [
+        \\"data\\"
+      ]
+    },
     \\"CreateUserRequestBody\\": {
       \\"type\\": \\"object\\",
       \\"properties\\": {
@@ -140,6 +162,20 @@ exports[`JSON Schema generator produces valid code: yaml 1`] = `
 definitions:
   Address:
     type: string
+  Company:
+    type: object
+    properties:
+      id:
+        type: string
+    required:
+      - id
+  CompanyBody:
+    type: object
+    properties:
+      data:
+        $ref: '#/definitions/Company'
+    required:
+      - data
   CreateUserRequestBody:
     type: object
     properties:

--- a/lib/src/neu/verifications/contract-mismatcher.spec.ts
+++ b/lib/src/neu/verifications/contract-mismatcher.spec.ts
@@ -138,86 +138,56 @@ describe("contract mismatch finder", () => {
 
   test("a request header mismatch found, missing required header", () => {
     const request = {
-      path: "/company/5/users",
-      method: "POST",
+      path: "/company/5",
+      method: "GET",
       headers: {},
-      body: {
-        data: {
-          firstName: "Maple",
-          lastName: "Syrup",
-          age: 1.0,
-          email: "maple.syrup@airtasker.com",
-          address: "Doggo bed"
-        }
-      },
+      body: {},
       queryParams: ""
     };
     const response = {
-      headers: { Location: "testLocation" },
+      headers: { accept: "1" },
       statusCode: 201,
       body: {
         data: {
-          firstName: "Maple",
-          lastName: "Syrup",
-          profile: { private: false, messageOptions: { newsletter: false } }
+          id: "5"
         }
       }
     };
     const result = mismatcher.findMismatch(request, response);
     expect(result.unwrapOrThrow().length).toBe(1);
     expect(result.unwrapOrThrow()[0].message).toBe(
-      "{} does not conform to the request contract headers on path: /company/:companyId/users:POST"
+      "{} does not conform to the request contract headers on path: /company/:companyId:GET"
     );
   });
 
   test("a request header mismatch found, wrong header value type", () => {
     const request = {
-      path: "/company/5/users",
-      method: "POST",
-      headers: { "x-auth-token": 1 },
-      body: {
-        data: {
-          firstName: "Maple",
-          lastName: "Syrup",
-          age: 1.0,
-          email: "maple.syrup@airtasker.com",
-          address: "Doggo bed"
-        }
-      },
+      path: "/company/5",
+      method: "GET",
+      headers: { "x-id": "NaN" },
+      body: {},
       queryParams: ""
     };
     const response = {
-      headers: { Location: "testLocation" },
+      headers: { accept: "1" },
       statusCode: 201,
       body: {
         data: {
-          firstName: "Maple",
-          lastName: "Syrup",
-          profile: { private: false, messageOptions: { newsletter: false } }
+          id: "5"
         }
       }
     };
     const result = mismatcher.findMismatch(request, response);
     expect(result.unwrapOrThrow().length).toBe(1);
-    expect(result.unwrapOrThrow()[0].message).toBe(
-      "1: #/type should be string"
-    );
+    expect(result.unwrapOrThrow()[0].message).toBe('"x-id" should be float');
   });
 
   test("a response header mismatch found, missing required header", () => {
     const request = {
-      path: "/company/5/users",
-      method: "POST",
-      headers: { "x-auth-token": "test-correct" },
-      body: {
-        data: {
-          firstName: "Maple",
-          lastName: "Syrup",
-          age: 1.0,
-          email: "maple.syrup@airtasker.com",
-          address: "Doggo bed"
-        }
-      },
+      path: "/company/5",
+      method: "GET",
+      headers: { "x-id": "5" },
+      body: {},
       queryParams: ""
     };
     const response = {
@@ -225,51 +195,37 @@ describe("contract mismatch finder", () => {
       statusCode: 201,
       body: {
         data: {
-          firstName: "Maple",
-          lastName: "Syrup",
-          profile: { private: false, messageOptions: { newsletter: false } }
+          id: "5"
         }
       }
     };
     const result = mismatcher.findMismatch(request, response);
     expect(result.unwrapOrThrow().length).toBe(1);
     expect(result.unwrapOrThrow()[0].message).toBe(
-      "Missing response header of Location on /company/:companyId/users:POST"
+      "Missing response header of accept on /company/:companyId:GET"
     );
   });
 
   test("a response header mismatch found, wrong header value type", () => {
     const request = {
-      path: "/company/5/users",
-      method: "POST",
-      headers: { "x-auth-token": "test-correct" },
-      body: {
-        data: {
-          firstName: "Maple",
-          lastName: "Syrup",
-          age: 1.0,
-          email: "maple.syrup@airtasker.com",
-          address: "Doggo bed"
-        }
-      },
+      path: "/company/5",
+      method: "GET",
+      headers: { "x-id": "5" },
+      body: {},
       queryParams: ""
     };
     const response = {
-      headers: { Location: 123 },
+      headers: { accept: "NaN" },
       statusCode: 201,
       body: {
         data: {
-          firstName: "Maple",
-          lastName: "Syrup",
-          profile: { private: false, messageOptions: { newsletter: false } }
+          id: "5"
         }
       }
     };
     const result = mismatcher.findMismatch(request, response);
     expect(result.unwrapOrThrow().length).toBe(1);
-    expect(result.unwrapOrThrow()[0].message).toBe(
-      "123: #/type should be string"
-    );
+    expect(result.unwrapOrThrow()[0].message).toBe('"accept" should be float');
   });
 
   test("having an extra response header that's not defined in the contract is not a mismatch", () => {

--- a/lib/src/neu/verifications/contract-mismatcher.ts
+++ b/lib/src/neu/verifications/contract-mismatcher.ts
@@ -149,7 +149,7 @@ export class ContractMismatcher {
         const result = this.findMismatchOnStringContent(
           {
             name: userInputHeaderKey,
-            value: userInputRequest.headers[userInputHeaderKey] as string
+            value: userInputRequest.headers[userInputHeaderKey]
           },
           contractHeaderType.unwrap()
         );
@@ -211,9 +211,7 @@ export class ContractMismatcher {
       const result = this.findMismatchOnStringContent(
         {
           name: matchingHeaderNameOnUserInput,
-          value: userInputResponse.headers[
-            matchingHeaderNameOnUserInput
-          ] as string
+          value: userInputResponse.headers[matchingHeaderNameOnUserInput]
         },
         contractHeaderType
       );

--- a/lib/src/neu/verifications/contract-mismatcher.ts
+++ b/lib/src/neu/verifications/contract-mismatcher.ts
@@ -146,8 +146,11 @@ export class ContractMismatcher {
           return accumulator;
         }
 
-        const result = this.findMismatchOnContent(
-          userInputRequest.headers[userInputHeaderKey],
+        const result = this.findMismatchOnStringContent(
+          {
+            name: userInputHeaderKey,
+            value: userInputRequest.headers[userInputHeaderKey] as string
+          },
           contractHeaderType.unwrap()
         );
 
@@ -205,8 +208,13 @@ export class ContractMismatcher {
         return accumulator;
       }
 
-      const result = this.findMismatchOnContent(
-        userInputResponse.headers[matchingHeaderNameOnUserInput],
+      const result = this.findMismatchOnStringContent(
+        {
+          name: matchingHeaderNameOnUserInput,
+          value: userInputResponse.headers[
+            matchingHeaderNameOnUserInput
+          ] as string
+        },
         contractHeaderType
       );
 
@@ -284,8 +292,8 @@ export class ContractMismatcher {
 
         const contractPathParamType = contractPathParam.type;
 
-        const result = this.findMismatchOnContent(
-          userPathArray[i],
+        const result = this.findMismatchOnStringContent(
+          { name: contractPathParam.name, value: userPathArray[i] },
           contractPathParamType
         );
 
@@ -306,13 +314,8 @@ export class ContractMismatcher {
     const requestBodyTypeOnContract = this.getRequestBodyTypeOnContractEndpoint(
       endpoint
     );
-    const mismatches: Mismatch[] = [];
     if (requestBodyTypeOnContract.isErr()) {
-      const mismatch = new Mismatch(
-        requestBodyTypeOnContract.unwrapErr().message
-      );
-      mismatches.push(mismatch);
-      return ok(mismatches);
+      return ok([]);
     }
     return this.findMismatchOnContent(
       userInputRequest.body,

--- a/lib/src/neu/verifications/user-input-models.ts
+++ b/lib/src/neu/verifications/user-input-models.ts
@@ -15,7 +15,7 @@ export interface UserInputResponse {
 export type UserInput = UserInputRequest | UserInputResponse;
 
 export interface UserInputHeader {
-  [key: string]: unknown;
+  [key: string]: string;
 }
 export type UserInputBody = unknown;
 

--- a/lib/src/parsers/parser.spec.ts
+++ b/lib/src/parsers/parser.spec.ts
@@ -4,8 +4,8 @@ describe("parser", () => {
   test("parses all information", () => {
     const result = parse("./lib/src/__examples__/contract.ts");
     expect(result.api).not.toBeUndefined();
-    expect(result.endpoints).toHaveLength(2);
-    expect(result.types).toHaveLength(8);
+    expect(result.endpoints).toHaveLength(3);
+    expect(result.types).toHaveLength(10);
   });
 
   test("follows recursive imports and exports", () => {


### PR DESCRIPTION
## Description, Motivation and Context

This revisits the validation logic that ensures path parameters and headers are valid according to a given contract. It leverages string validators as these kinds of inputs are strings (according to HTTP standards).

## Checklist:

- [x] I've added/updated tests to cover my changes
- [] I've created an issue associated with this PR
