### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+# Main squad: *Eng Effectiveness* (Tooling)
+# Main slack channel: #eng-effectiveness
+
+# Mainly targeting dependabot PRs with this. Trialing https://pullpanda.com/assigner
+# Please see commit message for more context
+/yarn.lock @airtasker/tooling-pullassigner
+
+# Known knowledgeable users
+# @fwouts
+# @lfportal


### PR DESCRIPTION
Add CODEOWNERS to auto-assign dependabot PRs to the tooling team