### PR TITLE
TT-584 Use path instead of url for RecordedRequest on ValidationRequest

### DIFF
--- a/lib/src/validation-server/server.spec.ts
+++ b/lib/src/validation-server/server.spec.ts
@@ -36,7 +36,7 @@ describe("Validation Server", () => {
       const validRequestAndResponse = {
         request: {
           method: "POST",
-          url: "http://spot.com/company/123/users",
+          path: "/company/123/users",
           headers: [{ key: "x-auth-token", value: "helloworld" }],
           body: JSON.stringify({
             data: {
@@ -84,7 +84,7 @@ describe("Validation Server", () => {
       const requestAndResponseWithMismatches = {
         request: {
           method: "POST",
-          url: "http://spot.com/company/123/users",
+          path: "/company/123/users",
           headers: [{ key: "x-auth-token", value: "helloworld" }],
           body: "{}"
         },
@@ -147,7 +147,7 @@ describe("Transformation functions", () => {
       expect(
         recordedRequestToUserInputRequest({
           method: "POST",
-          url: "http://spot.com/path/to/somewhere?hello=world",
+          path: "/path/to/somewhere?hello=world",
           headers: [{ key: "a", value: "b" }, { key: "c", value: "d" }],
           body: JSON.stringify({ data: "body" })
         })

--- a/lib/src/validation-server/server.ts
+++ b/lib/src/validation-server/server.ts
@@ -1,5 +1,4 @@
 import express from "express";
-import url from "url";
 import { Contract } from "../neu/definitions";
 import { ContractMismatcher } from "../neu/verifications/contract-mismatcher";
 import {
@@ -90,10 +89,9 @@ export const headersToUserInputHeader = (
 export const recordedRequestToUserInputRequest = (
   recordedRequest: RecordedRequest
 ): UserInputRequest => {
-  const url = new URL(recordedRequest.url);
   const jsonBody = JSON.parse(recordedRequest.body);
   return {
-    path: url.pathname + url.search,
+    path: recordedRequest.path,
     method: recordedRequest.method,
     headers: headersToUserInputHeader(recordedRequest.headers),
     body: jsonBody

--- a/lib/src/validation-server/spots/validate.ts
+++ b/lib/src/validation-server/spots/validate.ts
@@ -22,7 +22,7 @@ export class Validate {
 
 export interface RecordedRequest {
   method: HttpMethod;
-  url: String;
+  path: String;
   headers: Header[];
   body: String;
 }


### PR DESCRIPTION
## Description, Motivation and Context
Schema and host are not validated by the contract, the only part that matters is the path onwards. This PR updates the validation request to expect a path instead of a url.

## Checklist:
- [x] I've added/updated tests to cover my changes
- [x] I've created an issue associated with this PR
