### PR TITLE
has-discriminator linting rule port to neu namespace

### DIFF
--- a/lib/src/neu/http.ts
+++ b/lib/src/neu/http.ts
@@ -152,7 +152,7 @@ function isParamObjectPropertyTypeSafe(
 }
 
 /**
- * Check if a type is safe for use as an parameter's array element type.
+ * Check if a type is safe for use as a parameter's array element type.
  *
  * @param type type to check
  * @param typeTable type lookup table

--- a/lib/src/neu/linting/rule.ts
+++ b/lib/src/neu/linting/rule.ts
@@ -1,0 +1,11 @@
+import { Contract } from "../definitions";
+
+/**
+ * A linting rule is a function that returns a list of violations, which will
+ * be empty when the rule is complied with.
+ */
+export type LintingRule = (contract: Contract) => LintingRuleViolation[];
+
+export interface LintingRuleViolation {
+  message: string;
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/has-discriminator/contract-with-union-violations-in-each-component.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-discriminator/contract-with-union-violations-in-each-component.ts
@@ -1,0 +1,97 @@
+import {
+  api,
+  body,
+  defaultResponse,
+  endpoint,
+  Float,
+  headers,
+  pathParams,
+  queryParams,
+  request,
+  response,
+  String
+} from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "POST",
+  path: "/companies/:companyId/users"
+})
+class Endpoint {
+  @request
+  request(
+    @headers
+    headers: {
+      header: String | Float;
+    },
+    @pathParams
+    pathParams: {
+      companyId: String | Float;
+    },
+    @queryParams
+    queryParams: {
+      query: String | Float;
+    },
+    @body
+    body: RequestBody
+  ) {}
+
+  @response({ status: 200 })
+  successResponse(
+    @headers
+    headers: {
+      header: String | Float;
+    },
+    @body body: SuccessBody
+  ) {}
+
+  @defaultResponse
+  defaultResponse(
+    @headers
+    headers: {
+      header: String | Float;
+    },
+    @body body: ErrorBody
+  ) {}
+}
+
+interface RequestBody {
+  requestUnion: RequestA | RequestB;
+}
+
+interface RequestA {
+  type: "a";
+  requestA: String;
+}
+
+interface RequestB {
+  requestB: String;
+}
+
+interface SuccessBody {
+  successUnion: SuccessA | SuccessB;
+}
+
+interface SuccessA {
+  type: "a";
+  successA: String;
+}
+
+interface SuccessB {
+  successB: String;
+}
+
+interface ErrorBody {
+  errorUnion: ErrorA | ErrorB;
+}
+
+interface ErrorA {
+  type: "a";
+  errorA: String;
+}
+
+interface ErrorB {
+  errorB: String;
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/has-discriminator/multiple-homogeneous-primitive-type-or-null-union.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-discriminator/multiple-homogeneous-primitive-type-or-null-union.ts
@@ -1,4 +1,4 @@
-import { api, body, endpoint, response, String } from "@airtasker/spot";
+import { api, body, endpoint, response } from "@airtasker/spot";
 
 @api({ name: "contract" })
 class Contract {}
@@ -13,5 +13,5 @@ class Endpoint {
 }
 
 interface Body {
-  union: "a" | "b" | "c";
+  union: "a" | "b" | "c" | null;
 }

--- a/lib/src/neu/linting/rules/__spec-examples__/has-discriminator/object-union-with-discriminator.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-discriminator/object-union-with-discriminator.ts
@@ -1,0 +1,27 @@
+import { api, body, endpoint, response, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  union: TypeA | TypeB;
+}
+
+interface TypeA {
+  type: "a";
+  a: String;
+}
+
+interface TypeB {
+  type: "b";
+  b: String;
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/has-discriminator/object-union-with-no-discriminator.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-discriminator/object-union-with-no-discriminator.ts
@@ -1,0 +1,26 @@
+import { api, body, endpoint, response, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  union: TypeA | TypeB;
+}
+
+interface TypeA {
+  type: "a";
+  a: String;
+}
+
+interface TypeB {
+  b: String;
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/has-discriminator/single-type-or-null-union.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-discriminator/single-type-or-null-union.ts
@@ -1,0 +1,17 @@
+import { api, body, endpoint, response, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  union: String | null;
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/has-discriminator/string-literal-union.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-discriminator/string-literal-union.ts
@@ -1,0 +1,17 @@
+import { api, body, endpoint, response, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  union: "a" | "b" | "c";
+}

--- a/lib/src/neu/linting/rules/has-discriminator.spec.ts
+++ b/lib/src/neu/linting/rules/has-discriminator.spec.ts
@@ -1,0 +1,78 @@
+import { createProjectFromExistingSourceFile } from "../../../spec-helpers/helper";
+import { parseContract } from "../../parsers/contract-parser";
+import { hasDiscriminator } from "./has-discriminator";
+
+describe("has-discriminator linter rule", () => {
+  test("returns no violations for contract containing object unions with a discriminator", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/has-discriminator/object-union-with-discriminator.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    expect(hasDiscriminator(contract)).toHaveLength(0);
+  });
+
+  test("returns no violations for contract containing single type and null unions", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/has-discriminator/single-type-or-null-union.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    expect(hasDiscriminator(contract)).toHaveLength(0);
+  });
+
+  test("returns no violations for contract containing string literal unions", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/has-discriminator/string-literal-union.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    expect(hasDiscriminator(contract)).toHaveLength(0);
+  });
+
+  test("returns a violation for contract containing object unions with no discriminator", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/has-discriminator/object-union-with-no-discriminator.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    expect(hasDiscriminator(contract)).toHaveLength(1);
+  });
+
+  test("returns violations for every component of a contract", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/has-discriminator/contract-with-union-violations-in-each-component.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    const result = hasDiscriminator(contract);
+    expect(result).toHaveLength(8);
+    const messages = result.map(v => v.message);
+    expect(messages).toContain(
+      "Endpoint (Endpoint) request header (header) contains a union type with no discriminator: #/"
+    );
+    expect(messages).toContain(
+      "Endpoint (Endpoint) request path parameter (companyId) contains a union type with no discriminator: #/"
+    );
+    expect(messages).toContain(
+      "Endpoint (Endpoint) request query parameter (query) contains a union type with no discriminator: #/"
+    );
+    expect(messages).toContain(
+      "Endpoint (Endpoint) request body contains a union type with no discriminator: #/requestUnion"
+    );
+    expect(messages).toContain(
+      "Endpoint (Endpoint) response (200) header (header) contains a union type with no discriminator: #/"
+    );
+    expect(messages).toContain(
+      "Endpoint (Endpoint) response (200) body contains a union type with no discriminator: #/successUnion"
+    );
+    expect(messages).toContain(
+      "Endpoint (Endpoint) response (default) body contains a union type with no discriminator: #/errorUnion"
+    );
+  });
+});

--- a/lib/src/neu/linting/rules/has-discriminator.spec.ts
+++ b/lib/src/neu/linting/rules/has-discriminator.spec.ts
@@ -23,9 +23,9 @@ describe("has-discriminator linter rule", () => {
     expect(hasDiscriminator(contract)).toHaveLength(0);
   });
 
-  test("returns no violations for contract containing string literal unions", () => {
+  test("returns no violations for contract containing unions with multiple homogeneous primitive type and null unions", () => {
     const file = createProjectFromExistingSourceFile(
-      `${__dirname}/__spec-examples__/has-discriminator/string-literal-union.ts`
+      `${__dirname}/__spec-examples__/has-discriminator/multiple-homogeneous-primitive-type-or-null-union.ts`
     ).file;
 
     const { contract } = parseContract(file).unwrapOrThrow();

--- a/lib/src/neu/parsers/__spec-examples__/types.ts
+++ b/lib/src/neu/parsers/__spec-examples__/types.ts
@@ -37,6 +37,10 @@ interface TypeInterface {
   Array: Array<{ a: boolean }>;
   union: boolean | Date | null;
   unionDiscriminated: DiscriminatedUnionElementA | DiscriminatedUnionElementB;
+  unionDiscriminatedNullable:
+    | DiscriminatedUnionElementA
+    | DiscriminatedUnionElementB
+    | null;
   alias: Alias;
   interface: Interface;
   interfaceExtends: InterfaceExtends;

--- a/lib/src/neu/parsers/__spec-examples__/types.ts
+++ b/lib/src/neu/parsers/__spec-examples__/types.ts
@@ -34,7 +34,9 @@ interface TypeInterface {
     propertyB?: boolean;
   };
   array: boolean[];
+  Array: Array<{ a: boolean }>;
   union: boolean | Date | null;
+  unionDiscriminated: DiscriminatedUnionElementA | DiscriminatedUnionElementB;
   alias: Alias;
   interface: Interface;
   interfaceExtends: InterfaceExtends;
@@ -47,6 +49,16 @@ interface TypeInterface {
   map: Map<string, boolean>;
   indexSignature: { [index: string]: boolean };
   interfaceWithIndexSignature: InterfaceWithIndexSignature;
+}
+
+interface DiscriminatedUnionElementA {
+  type: "a";
+  a: string;
+}
+
+interface DiscriminatedUnionElementB {
+  type: "b";
+  b: string;
 }
 
 type Alias = string;

--- a/lib/src/neu/parsers/type-parser.spec.ts
+++ b/lib/src/neu/parsers/type-parser.spec.ts
@@ -252,11 +252,35 @@ describe("type parser", () => {
     );
   });
 
+  test("parses complex Array", () => {
+    const type = interphace.getPropertyOrThrow("Array").getTypeNodeOrThrow();
+
+    expect(parseType(type, typeTable, lociTable).unwrapOrThrow()).toStrictEqual(
+      {
+        kind: TypeKind.ARRAY,
+        elementType: {
+          kind: TypeKind.OBJECT,
+          properties: [
+            {
+              description: undefined,
+              name: "a",
+              optional: false,
+              type: {
+                kind: TypeKind.BOOLEAN
+              }
+            }
+          ]
+        }
+      }
+    );
+  });
+
   test("parses unions", () => {
     const type = interphace.getPropertyOrThrow("union").getTypeNodeOrThrow();
 
     expect(parseType(type, typeTable, lociTable).unwrapOrThrow()).toStrictEqual(
       {
+        discriminator: undefined,
         kind: TypeKind.UNION,
         types: [
           {
@@ -267,6 +291,29 @@ describe("type parser", () => {
           },
           {
             kind: TypeKind.NULL
+          }
+        ]
+      }
+    );
+  });
+
+  test("parses discriminated unions", () => {
+    const type = interphace
+      .getPropertyOrThrow("unionDiscriminated")
+      .getTypeNodeOrThrow();
+
+    expect(parseType(type, typeTable, lociTable).unwrapOrThrow()).toStrictEqual(
+      {
+        discriminator: "type",
+        kind: TypeKind.UNION,
+        types: [
+          {
+            kind: TypeKind.REFERENCE,
+            name: "DiscriminatedUnionElementA"
+          },
+          {
+            kind: TypeKind.REFERENCE,
+            name: "DiscriminatedUnionElementB"
           }
         ]
       }

--- a/lib/src/neu/parsers/type-parser.spec.ts
+++ b/lib/src/neu/parsers/type-parser.spec.ts
@@ -320,6 +320,32 @@ describe("type parser", () => {
     );
   });
 
+  test("parses nullable discriminated unions", () => {
+    const type = interphace
+      .getPropertyOrThrow("unionDiscriminatedNullable")
+      .getTypeNodeOrThrow();
+
+    expect(parseType(type, typeTable, lociTable).unwrapOrThrow()).toStrictEqual(
+      {
+        discriminator: "type",
+        kind: TypeKind.UNION,
+        types: [
+          {
+            kind: TypeKind.REFERENCE,
+            name: "DiscriminatedUnionElementA"
+          },
+          {
+            kind: TypeKind.REFERENCE,
+            name: "DiscriminatedUnionElementB"
+          },
+          {
+            kind: TypeKind.NULL
+          }
+        ]
+      }
+    );
+  });
+
   test("parses type aliases", () => {
     const type = interphace.getPropertyOrThrow("alias").getTypeNodeOrThrow();
 

--- a/lib/src/neu/parsers/type-parser.ts
+++ b/lib/src/neu/parsers/type-parser.ts
@@ -28,6 +28,7 @@ import {
   FloatLiteralType,
   floatType,
   FloatType,
+  inferDiscriminator,
   int32Type,
   Int32Type,
   int64Type,
@@ -46,8 +47,7 @@ import {
   Type,
   TypeKind,
   TypeTable,
-  unionType,
-  inferDiscriminator
+  unionType
 } from "../types";
 import { err, ok, Result } from "../util";
 import { getJsDoc, getPropertyName } from "./parser-helpers";

--- a/lib/src/neu/types.ts
+++ b/lib/src/neu/types.ts
@@ -355,7 +355,7 @@ export function inferDiscriminator(
   types: Type[],
   typeTable: TypeTable
 ): string | undefined {
-  const conreteRootTypes = types.reduce<ConcreteType[]>((acc, type) => {
+  const concreteRootTypes = types.reduce<ConcreteType[]>((acc, type) => {
     return acc.concat(...possibleRootTypes(type, typeTable));
   }, []);
 
@@ -364,7 +364,7 @@ export function inferDiscriminator(
     Array<{ value: string; type: Type }>
   >();
 
-  for (const type of conreteRootTypes) {
+  for (const type of concreteRootTypes) {
     if (!isObjectType(type)) {
       // Only objects will have discriminator properties
       return;


### PR DESCRIPTION
This PR ports the has-discriminator linting rule to the neu namespace to use the new version of the contract definitions. As it is the first linting rule to be ported, some extra setup files are also included.