### PR TITLE
TT-585 Fix path params matcher matching wrong paths

### DIFF
--- a/lib/src/neu/verifications/contract-mismatcher.ts
+++ b/lib/src/neu/verifications/contract-mismatcher.ts
@@ -596,7 +596,7 @@ export class ContractMismatcher {
 
 // Transform /a/:b/c/:d/e -> /^/a/\w+/c/\w+/e$/
 const regexForVariablePath = (path: string): RegExp => {
-  const regexp = path.replace(/:[^\/]+/g, "\\w+");
+  const regexp = path.replace(/:[^\/]+/g, ".+");
   return new RegExp(`^${regexp}$`);
 };
 


### PR DESCRIPTION
## Description, Motivation and Context
The path params matcher was matching wrong paths, for example, `/z/x/w/a/0/c` would match `/a/:b/c`.

This PR fixes this issue by correcting the regexp used for matching, and add tests for a couple of cases.

There are other small changes on this PR:
- Changed the error message when the matcher fails to find an endpoint on the contract matching the request
- Refactored the regexp part of the code
- Removed an unused method

## Checklist:

- [x] I've added/updated tests to cover my changes
- [x] I've created an issue associated with this PR
