### PR TITLE
Contract mismatcher messages preparation

### DIFF
--- a/lib/src/neu/generators/__snapshots__/json-schema-generator.spec.ts.snap
+++ b/lib/src/neu/generators/__snapshots__/json-schema-generator.spec.ts.snap
@@ -16,7 +16,8 @@ exports[`JSON Schema generator produces valid code: json 1`] = `
       },
       \\"required\\": [
         \\"id\\"
-      ]
+      ],
+      \\"additionalProperties\\": true
     },
     \\"CompanyBody\\": {
       \\"type\\": \\"object\\",
@@ -27,7 +28,8 @@ exports[`JSON Schema generator produces valid code: json 1`] = `
       },
       \\"required\\": [
         \\"data\\"
-      ]
+      ],
+      \\"additionalProperties\\": true
     },
     \\"CreateUserRequestBody\\": {
       \\"type\\": \\"object\\",
@@ -57,12 +59,14 @@ exports[`JSON Schema generator produces valid code: json 1`] = `
             \\"age\\",
             \\"email\\",
             \\"address\\"
-          ]
+          ],
+          \\"additionalProperties\\": true
         }
       },
       \\"required\\": [
         \\"data\\"
-      ]
+      ],
+      \\"additionalProperties\\": true
     },
     \\"Email\\": {
       \\"type\\": \\"string\\"
@@ -83,7 +87,8 @@ exports[`JSON Schema generator produces valid code: json 1`] = `
       \\"required\\": [
         \\"name\\",
         \\"message\\"
-      ]
+      ],
+      \\"additionalProperties\\": true
     },
     \\"MessageOptions\\": {
       \\"type\\": \\"object\\",
@@ -94,7 +99,8 @@ exports[`JSON Schema generator produces valid code: json 1`] = `
       },
       \\"required\\": [
         \\"newsletter\\"
-      ]
+      ],
+      \\"additionalProperties\\": true
     },
     \\"Profile\\": {
       \\"type\\": \\"object\\",
@@ -109,7 +115,8 @@ exports[`JSON Schema generator produces valid code: json 1`] = `
       \\"required\\": [
         \\"private\\",
         \\"messageOptions\\"
-      ]
+      ],
+      \\"additionalProperties\\": true
     },
     \\"UserBody\\": {
       \\"type\\": \\"object\\",
@@ -131,12 +138,14 @@ exports[`JSON Schema generator produces valid code: json 1`] = `
             \\"firstName\\",
             \\"lastName\\",
             \\"profile\\"
-          ]
+          ],
+          \\"additionalProperties\\": true
         }
       },
       \\"required\\": [
         \\"data\\"
-      ]
+      ],
+      \\"additionalProperties\\": true
     },
     \\"UserQuery\\": {
       \\"type\\": \\"object\\",
@@ -151,7 +160,8 @@ exports[`JSON Schema generator produces valid code: json 1`] = `
       \\"required\\": [
         \\"id\\",
         \\"slug\\"
-      ]
+      ],
+      \\"additionalProperties\\": true
     }
   }
 }"
@@ -169,6 +179,7 @@ definitions:
         type: string
     required:
       - id
+    additionalProperties: true
   CompanyBody:
     type: object
     properties:
@@ -176,6 +187,7 @@ definitions:
         $ref: '#/definitions/Company'
     required:
       - data
+    additionalProperties: true
   CreateUserRequestBody:
     type: object
     properties:
@@ -198,8 +210,10 @@ definitions:
           - age
           - email
           - address
+        additionalProperties: true
     required:
       - data
+    additionalProperties: true
   Email:
     type: string
   ErrorBody:
@@ -214,6 +228,7 @@ definitions:
     required:
       - name
       - message
+    additionalProperties: true
   MessageOptions:
     type: object
     properties:
@@ -221,6 +236,7 @@ definitions:
         type: boolean
     required:
       - newsletter
+    additionalProperties: true
   Profile:
     type: object
     properties:
@@ -231,6 +247,7 @@ definitions:
     required:
       - private
       - messageOptions
+    additionalProperties: true
   UserBody:
     type: object
     properties:
@@ -247,8 +264,10 @@ definitions:
           - firstName
           - lastName
           - profile
+        additionalProperties: true
     required:
       - data
+    additionalProperties: true
   UserQuery:
     type: object
     properties:
@@ -259,5 +278,6 @@ definitions:
     required:
       - id
       - slug
+    additionalProperties: true
 "
 `;

--- a/lib/src/neu/generators/json-schema-generator.spec.ts
+++ b/lib/src/neu/generators/json-schema-generator.spec.ts
@@ -32,127 +32,128 @@ describe("JSON Schema generator", () => {
   describe("generates type validator", () => {
     test("null", () => {
       expect(generateJsonSchemaType(nullType())).toMatchInlineSnapshot(`
-Object {
-  "type": "null",
-}
-`);
+        Object {
+          "type": "null",
+        }
+      `);
     });
 
     test("boolean", () => {
       expect(generateJsonSchemaType(booleanType())).toMatchInlineSnapshot(`
-Object {
-  "type": "boolean",
-}
-`);
+        Object {
+          "type": "boolean",
+        }
+      `);
     });
 
     test("boolean literal", () => {
       expect(generateJsonSchemaType(booleanLiteralType(true)))
         .toMatchInlineSnapshot(`
-Object {
-  "const": true,
-  "type": "boolean",
-}
-`);
+        Object {
+          "const": true,
+          "type": "boolean",
+        }
+      `);
       expect(generateJsonSchemaType(booleanLiteralType(false)))
         .toMatchInlineSnapshot(`
-Object {
-  "const": false,
-  "type": "boolean",
-}
-`);
+        Object {
+          "const": false,
+          "type": "boolean",
+        }
+      `);
     });
 
     test("string", () => {
       expect(generateJsonSchemaType(stringType())).toMatchInlineSnapshot(`
-Object {
-  "type": "string",
-}
-`);
+        Object {
+          "type": "string",
+        }
+      `);
     });
 
     test("string literal", () => {
       expect(generateJsonSchemaType(stringLiteralType("some literal")))
         .toMatchInlineSnapshot(`
-Object {
-  "const": "some literal",
-  "type": "string",
-}
-`);
+        Object {
+          "const": "some literal",
+          "type": "string",
+        }
+      `);
     });
 
     test("float", () => {
       expect(generateJsonSchemaType(floatType())).toMatchInlineSnapshot(`
-Object {
-  "type": "number",
-}
-`);
+        Object {
+          "type": "number",
+        }
+      `);
     });
 
     test("number literal", () => {
       expect(generateJsonSchemaType(floatLiteralType(1.5)))
         .toMatchInlineSnapshot(`
-Object {
-  "const": 1.5,
-  "type": "number",
-}
-`);
+        Object {
+          "const": 1.5,
+          "type": "number",
+        }
+      `);
       expect(generateJsonSchemaType(floatLiteralType(-23.1)))
         .toMatchInlineSnapshot(`
-Object {
-  "const": -23.1,
-  "type": "number",
-}
-`);
+        Object {
+          "const": -23.1,
+          "type": "number",
+        }
+      `);
     });
 
     test("int32", () => {
       expect(generateJsonSchemaType(int32Type())).toMatchInlineSnapshot(`
-Object {
-  "type": "integer",
-}
-`);
+        Object {
+          "type": "integer",
+        }
+      `);
     });
 
     test("int64", () => {
       expect(generateJsonSchemaType(int64Type())).toMatchInlineSnapshot(`
-Object {
-  "type": "integer",
-}
-`);
+        Object {
+          "type": "integer",
+        }
+      `);
     });
 
     test("number literal", () => {
       expect(generateJsonSchemaType(intLiteralType(0))).toMatchInlineSnapshot(`
-Object {
-  "const": 0,
-  "type": "integer",
-}
-`);
+        Object {
+          "const": 0,
+          "type": "integer",
+        }
+      `);
       expect(generateJsonSchemaType(intLiteralType(123)))
         .toMatchInlineSnapshot(`
-Object {
-  "const": 123,
-  "type": "integer",
-}
-`);
+        Object {
+          "const": 123,
+          "type": "integer",
+        }
+      `);
       expect(generateJsonSchemaType(intLiteralType(-1000)))
         .toMatchInlineSnapshot(`
-Object {
-  "const": -1000,
-  "type": "integer",
-}
-`);
+        Object {
+          "const": -1000,
+          "type": "integer",
+        }
+      `);
     });
 
     test("object", () => {
       expect(generateJsonSchemaType(objectType([]))).toMatchInlineSnapshot(`
-Object {
-  "properties": Object {},
-  "required": Array [],
-  "type": "object",
-}
-`);
+        Object {
+          "additionalProperties": true,
+          "properties": Object {},
+          "required": Array [],
+          "type": "object",
+        }
+      `);
       expect(
         generateJsonSchemaType(
           objectType([
@@ -164,18 +165,19 @@ Object {
           ])
         )
       ).toMatchInlineSnapshot(`
-Object {
-  "properties": Object {
-    "singleField": Object {
-      "type": "number",
-    },
-  },
-  "required": Array [
-    "singleField",
-  ],
-  "type": "object",
-}
-`);
+        Object {
+          "additionalProperties": true,
+          "properties": Object {
+            "singleField": Object {
+              "type": "number",
+            },
+          },
+          "required": Array [
+            "singleField",
+          ],
+          "type": "object",
+        }
+      `);
       expect(
         generateJsonSchemaType(
           objectType([
@@ -197,37 +199,38 @@ Object {
           ])
         )
       ).toMatchInlineSnapshot(`
-Object {
-  "properties": Object {
-    "field1": Object {
-      "type": "number",
-    },
-    "field2": Object {
-      "type": "string",
-    },
-    "field3": Object {
-      "type": "boolean",
-    },
-  },
-  "required": Array [
-    "field1",
-    "field2",
-  ],
-  "type": "object",
-}
-`);
+        Object {
+          "additionalProperties": true,
+          "properties": Object {
+            "field1": Object {
+              "type": "number",
+            },
+            "field2": Object {
+              "type": "string",
+            },
+            "field3": Object {
+              "type": "boolean",
+            },
+          },
+          "required": Array [
+            "field1",
+            "field2",
+          ],
+          "type": "object",
+        }
+      `);
     });
 
     test("array", () => {
       expect(generateJsonSchemaType(arrayType(stringType())))
         .toMatchInlineSnapshot(`
-Object {
-  "items": Object {
-    "type": "string",
-  },
-  "type": "array",
-}
-`);
+        Object {
+          "items": Object {
+            "type": "string",
+          },
+          "type": "array",
+        }
+      `);
     });
 
     test("union", () => {
@@ -236,29 +239,29 @@ Object {
           unionType([stringType(), floatType(), booleanType()])
         )
       ).toMatchInlineSnapshot(`
-Object {
-  "oneOf": Array [
-    Object {
-      "type": "string",
-    },
-    Object {
-      "type": "number",
-    },
-    Object {
-      "type": "boolean",
-    },
-  ],
-}
-`);
+        Object {
+          "oneOf": Array [
+            Object {
+              "type": "string",
+            },
+            Object {
+              "type": "number",
+            },
+            Object {
+              "type": "boolean",
+            },
+          ],
+        }
+      `);
     });
 
     test("type reference", () => {
       expect(generateJsonSchemaType(referenceType("OtherType")))
         .toMatchInlineSnapshot(`
-Object {
-  "$ref": "#/definitions/OtherType",
-}
-`);
+        Object {
+          "$ref": "#/definitions/OtherType",
+        }
+      `);
     });
   });
 });

--- a/lib/src/neu/generators/json-schema-generator.ts
+++ b/lib/src/neu/generators/json-schema-generator.ts
@@ -35,7 +35,10 @@ function jsonSchemaOfSpotContract(contract: Contract): JsonSchema {
   };
 }
 
-export function generateJsonSchemaType(type: Type): JsonSchemaType {
+export function generateJsonSchemaType(
+  type: Type,
+  objectAdditionalProperties: boolean = true // TODO: expose proper configuration object
+): JsonSchemaType {
   switch (type.kind) {
     case TypeKind.NULL:
       return {
@@ -87,23 +90,32 @@ export function generateJsonSchemaType(type: Type): JsonSchemaType {
           if (!property.optional) {
             acc.required.push(property.name);
           }
-          acc.properties[property.name] = generateJsonSchemaType(property.type);
+          acc.properties[property.name] = generateJsonSchemaType(
+            property.type,
+            objectAdditionalProperties
+          );
           return acc;
         },
         {
           type: "object",
           properties: {},
-          required: []
+          required: [],
+          additionalProperties: objectAdditionalProperties
         }
       );
     case TypeKind.ARRAY:
       return {
         type: "array",
-        items: generateJsonSchemaType(type.elementType)
+        items: generateJsonSchemaType(
+          type.elementType,
+          objectAdditionalProperties
+        )
       };
     case TypeKind.UNION:
       return {
-        oneOf: type.types.map(generateJsonSchemaType)
+        oneOf: type.types.map(t =>
+          generateJsonSchemaType(t, objectAdditionalProperties)
+        )
       };
     case TypeKind.REFERENCE:
       return {

--- a/lib/src/neu/generators/json-schema-generator.ts
+++ b/lib/src/neu/generators/json-schema-generator.ts
@@ -35,6 +35,15 @@ function jsonSchemaOfSpotContract(contract: Contract): JsonSchema {
   };
 }
 
+/**
+ * Generate a JSON Schema type definition. `objectAdditionalProperties` may
+ * be used to configure whether additional properties should be allowed on
+ * object types. This can be useful for data validation purposes where
+ * property validation can be strict or lenient.
+ *
+ * @param type a contract type
+ * @param objectAdditionalProperties whether to allow additional properties for objects
+ */
 export function generateJsonSchemaType(
   type: Type,
   objectAdditionalProperties: boolean = true // TODO: expose proper configuration object

--- a/lib/src/neu/schemas/json-schema.ts
+++ b/lib/src/neu/schemas/json-schema.ts
@@ -22,6 +22,7 @@ export interface JsonSchemaObject {
     [name: string]: JsonSchemaType;
   };
   required?: string[];
+  additionalProperties: boolean;
 }
 
 export interface JsonSchemaArray {

--- a/lib/src/neu/verifications/contract-mismatcher.spec.ts
+++ b/lib/src/neu/verifications/contract-mismatcher.spec.ts
@@ -41,7 +41,12 @@ describe("contract mismatch finder", () => {
     const request = {
       path: "/company/5/users",
       method: "POST",
-      headers: { "x-auth-token": "token" },
+      headers: [
+        {
+          name: "x-auth-token",
+          value: "token"
+        }
+      ],
       body: {
         data: {
           firstName: "Maple",
@@ -53,7 +58,7 @@ describe("contract mismatch finder", () => {
       }
     };
     const response = {
-      headers: { Location: "testLocation" },
+      headers: [{ name: "Location", value: "testLocation" }],
       statusCode: 201,
       body: {
         data: {
@@ -71,7 +76,7 @@ describe("contract mismatch finder", () => {
     const request = {
       path: "/company/5/users",
       method: "POST",
-      headers: { "x-auth-token": "token" },
+      headers: [{ name: "x-auth-token", value: "token" }],
       body: {
         data: {
           firstName: "Maple",
@@ -82,7 +87,7 @@ describe("contract mismatch finder", () => {
       }
     };
     const response = {
-      headers: { Location: "testLocation" },
+      headers: [{ name: "Location", value: "testLocation" }],
       statusCode: 201,
       body: {
         data: {
@@ -100,7 +105,7 @@ describe("contract mismatch finder", () => {
     const request = {
       path: "/compan/5/users",
       method: "POST",
-      headers: { "x-auth-token": "token" },
+      headers: [{ name: "x-auth-token", value: "token" }],
       body: {
         data: {
           firstName: "Maple",
@@ -111,7 +116,7 @@ describe("contract mismatch finder", () => {
       }
     };
     const response = {
-      headers: { Location: "testLocation" },
+      headers: [{ name: "Location", value: "testLocation" }],
       statusCode: 201,
       body: {
         data: {
@@ -132,7 +137,7 @@ describe("contract mismatch finder", () => {
     const request = {
       path: "/some/prefix/company/5/users",
       method: "POST",
-      headers: { "x-auth-token": "token" },
+      headers: [{ name: "x-auth-token", value: "token" }],
       body: {
         data: {
           firstName: "Maple",
@@ -143,7 +148,7 @@ describe("contract mismatch finder", () => {
       }
     };
     const response = {
-      headers: { Location: "testLocation" },
+      headers: [{ name: "Location", value: "testLocation" }],
       statusCode: 201,
       body: {
         data: {
@@ -165,7 +170,7 @@ describe("contract mismatch finder", () => {
     const request = {
       path: "/company/true/users",
       method: "POST",
-      headers: { "x-auth-token": "token" },
+      headers: [{ name: "x-auth-token", value: "token" }],
       body: {
         data: {
           firstName: "Maple",
@@ -176,7 +181,7 @@ describe("contract mismatch finder", () => {
       }
     };
     const response = {
-      headers: { Location: "testLocation" },
+      headers: [{ name: "Location", value: "testLocation" }],
       statusCode: 201,
       body: {
         data: {
@@ -197,11 +202,11 @@ describe("contract mismatch finder", () => {
     const request = {
       path: "/company/5",
       method: "GET",
-      headers: {},
+      headers: [],
       body: {}
     };
     const response = {
-      headers: { accept: "1" },
+      headers: [{ name: "accept", value: "1" }],
       statusCode: 201,
       body: {
         data: {
@@ -220,11 +225,11 @@ describe("contract mismatch finder", () => {
     const request = {
       path: "/company/5",
       method: "GET",
-      headers: { "x-id": "NaN" },
+      headers: [{ name: "x-id", value: "NaN" }],
       body: {}
     };
     const response = {
-      headers: { accept: "1" },
+      headers: [{ name: "accept", value: "1" }],
       statusCode: 201,
       body: {
         data: {
@@ -241,11 +246,11 @@ describe("contract mismatch finder", () => {
     const request = {
       path: "/company/5",
       method: "GET",
-      headers: { "x-id": "5" },
+      headers: [{ name: "x-id", value: "5" }],
       body: {}
     };
     const response = {
-      headers: {},
+      headers: [],
       statusCode: 201,
       body: {
         data: {
@@ -264,11 +269,11 @@ describe("contract mismatch finder", () => {
     const request = {
       path: "/company/5",
       method: "GET",
-      headers: { "x-id": "5" },
+      headers: [{ name: "x-id", value: "5" }],
       body: {}
     };
     const response = {
-      headers: { accept: "NaN" },
+      headers: [{ name: "accept", value: "NaN" }],
       statusCode: 201,
       body: {
         data: {
@@ -285,7 +290,7 @@ describe("contract mismatch finder", () => {
     const request = {
       path: "/company/5/users",
       method: "POST",
-      headers: { "x-auth-token": "token" },
+      headers: [{ name: "x-auth-token", value: "token" }],
       body: {
         data: {
           firstName: "Maple",
@@ -297,7 +302,10 @@ describe("contract mismatch finder", () => {
       }
     };
     const response = {
-      headers: { Location: "testLocation", ExtraHeader: "testExtraHeader" },
+      headers: [
+        { name: "Location", value: "testLocation" },
+        { name: "ExtraHeader", value: "testExtraHeader" }
+      ],
       statusCode: 201,
       body: {
         data: {
@@ -316,7 +324,7 @@ describe("contract mismatch finder", () => {
       const request = {
         path: "/company/0/users?id=query+param+array+pipe",
         method: "POST",
-        headers: { "x-auth-token": "token" },
+        headers: [{ name: "x-auth-token", value: "token" }],
         body: {
           data: {
             firstName: "Maple",
@@ -329,7 +337,7 @@ describe("contract mismatch finder", () => {
       };
 
       const response = {
-        headers: { Location: "testLocation" },
+        headers: [{ name: "Location", value: "testLocation" }],
         statusCode: 201,
         body: {
           data: {
@@ -351,7 +359,7 @@ describe("contract mismatch finder", () => {
       const request = {
         path: "/company/0/users?user[id]=invalid&user[slug]=2",
         method: "POST",
-        headers: { "x-auth-token": "token" },
+        headers: [{ name: "x-auth-token", value: "token" }],
         body: {
           data: {
             firstName: "Maple",
@@ -364,7 +372,7 @@ describe("contract mismatch finder", () => {
       };
 
       const response = {
-        headers: { Location: "testLocation" },
+        headers: [{ name: "Location", value: "testLocation" }],
         statusCode: 201,
         body: {
           data: {
@@ -386,7 +394,7 @@ describe("contract mismatch finder", () => {
       const request = {
         path: "/company/0/users?user[id]=0&user[slug]=2&ids[0]=false&ids[1]=1",
         method: "POST",
-        headers: { "x-auth-token": "token" },
+        headers: [{ name: "x-auth-token", value: "token" }],
         body: {
           data: {
             firstName: "Maple",
@@ -399,7 +407,7 @@ describe("contract mismatch finder", () => {
       };
 
       const response = {
-        headers: { Location: "testLocation" },
+        headers: [{ name: "Location", value: "testLocation" }],
         statusCode: 201,
         body: {
           data: {

--- a/lib/src/neu/verifications/contract-mismatcher.spec.ts
+++ b/lib/src/neu/verifications/contract-mismatcher.spec.ts
@@ -69,7 +69,7 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findMismatch(request, response);
-    expect(result.unwrapOrThrow().length).toBe(0);
+    expect(result.unwrapOrThrow()).toHaveLength(0);
   });
 
   test("a mismatch is found, missing 1 property on request body.", () => {
@@ -98,7 +98,7 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findMismatch(request, response);
-    expect(result.unwrapOrThrow().length).toBe(1);
+    expect(result.unwrapOrThrow()).toHaveLength(1);
   });
 
   test("a mismatch is found, no matching path on the contract", () => {
@@ -127,9 +127,9 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findMismatch(request, response);
-    expect(result.unwrapOrThrow().length).toBe(1);
+    expect(result.unwrapOrThrow()).toHaveLength(1);
     expect(result.unwrapOrThrow()[0].message).toBe(
-      "POST /compan/5/users does not exist under the specified contract."
+      "Endpoint POST /compan/5/users not found."
     );
   });
 
@@ -160,9 +160,9 @@ describe("contract mismatch finder", () => {
     };
     const result = mismatcher.findMismatch(request, response);
     const unwrappedResult = result.unwrapOrThrow();
-    // expect(unwrappedResult.length).toBe(1);
+    expect(unwrappedResult).toHaveLength(1);
     expect(unwrappedResult[0].message).toBe(
-      "POST /some/prefix/company/5/users does not exist under the specified contract."
+      "Endpoint POST /some/prefix/company/5/users not found."
     );
   });
 
@@ -192,7 +192,7 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findMismatch(request, response);
-    expect(result.unwrapOrThrow().length).toBe(1);
+    expect(result.unwrapOrThrow()).toHaveLength(1);
     expect(result.unwrapOrThrow()[0].message).toBe(
       '{"data":{"firstName":"Maple","lastName":"Syrup","email":"maple.syrup@airtasker.com","address":"Doggo bed"}}: #/properties/data/required should have required property \'age\''
     );
@@ -202,8 +202,7 @@ describe("contract mismatch finder", () => {
     const request = {
       path: "/company/5",
       method: "GET",
-      headers: [],
-      body: {}
+      headers: []
     };
     const response = {
       headers: [{ name: "accept", value: "1" }],
@@ -215,9 +214,9 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findMismatch(request, response);
-    expect(result.unwrapOrThrow().length).toBe(1);
+    expect(result.unwrapOrThrow()).toHaveLength(1);
     expect(result.unwrapOrThrow()[0].message).toBe(
-      "{} does not conform to the request contract headers on path: /company/:companyId:GET"
+      'Header "x-id" missing on endpoint'
     );
   });
 
@@ -225,8 +224,7 @@ describe("contract mismatch finder", () => {
     const request = {
       path: "/company/5",
       method: "GET",
-      headers: [{ name: "x-id", value: "NaN" }],
-      body: {}
+      headers: [{ name: "x-id", value: "NaN" }]
     };
     const response = {
       headers: [{ name: "accept", value: "1" }],
@@ -238,7 +236,7 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findMismatch(request, response);
-    expect(result.unwrapOrThrow().length).toBe(1);
+    expect(result.unwrapOrThrow()).toHaveLength(1);
     expect(result.unwrapOrThrow()[0].message).toBe('"x-id" should be float');
   });
 
@@ -246,8 +244,7 @@ describe("contract mismatch finder", () => {
     const request = {
       path: "/company/5",
       method: "GET",
-      headers: [{ name: "x-id", value: "5" }],
-      body: {}
+      headers: [{ name: "x-id", value: "5" }]
     };
     const response = {
       headers: [],
@@ -259,9 +256,9 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findMismatch(request, response);
-    expect(result.unwrapOrThrow().length).toBe(1);
+    expect(result.unwrapOrThrow()).toHaveLength(1);
     expect(result.unwrapOrThrow()[0].message).toBe(
-      "Missing response header of accept on /company/:companyId:GET"
+      'Header "accept" missing on endpoint'
     );
   });
 
@@ -269,8 +266,7 @@ describe("contract mismatch finder", () => {
     const request = {
       path: "/company/5",
       method: "GET",
-      headers: [{ name: "x-id", value: "5" }],
-      body: {}
+      headers: [{ name: "x-id", value: "5" }]
     };
     const response = {
       headers: [{ name: "accept", value: "NaN" }],
@@ -282,7 +278,7 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findMismatch(request, response);
-    expect(result.unwrapOrThrow().length).toBe(1);
+    expect(result.unwrapOrThrow()).toHaveLength(1);
     expect(result.unwrapOrThrow()[0].message).toBe('"accept" should be float');
   });
 
@@ -316,7 +312,7 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findMismatch(request, response);
-    expect(result.unwrapOrThrow().length).toBe(0);
+    expect(result.unwrapOrThrow()).toHaveLength(0);
   });
 
   describe("a mismatch is found, query params do not conform to contract", () => {
@@ -349,7 +345,7 @@ describe("contract mismatch finder", () => {
       };
 
       const result = mismatcher.findMismatch(request, response);
-      expect(result.unwrapOrThrow().length).toBe(1);
+      expect(result.unwrapOrThrow()).toHaveLength(1);
       expect(result.unwrapOrThrow()[0].message).toBe(
         'Query parameter "id" does not exist under the specified endpoint.'
       );
@@ -384,7 +380,7 @@ describe("contract mismatch finder", () => {
       };
 
       const result = mismatcher.findMismatch(request, response);
-      expect(result.unwrapOrThrow().length).toBe(1);
+      expect(result.unwrapOrThrow()).toHaveLength(1);
       expect(result.unwrapOrThrow()[0].message).toBe(
         '".user.id" should be float'
       );
@@ -419,7 +415,7 @@ describe("contract mismatch finder", () => {
       };
 
       const result = mismatcher.findMismatch(request, response);
-      expect(result.unwrapOrThrow().length).toBe(1);
+      expect(result.unwrapOrThrow()).toHaveLength(1);
       expect(result.unwrapOrThrow()[0].message).toBe(
         '"ids[0]" should be float'
       );

--- a/lib/src/neu/verifications/contract-mismatcher.ts
+++ b/lib/src/neu/verifications/contract-mismatcher.ts
@@ -30,78 +30,79 @@ export class ContractMismatcher {
     userInputRequest: UserInputRequest,
     userInputResponse: UserInputResponse
   ): Result<Mismatch[], Error> {
-    const expectedEndpoint = this.getEndpointByRequest(userInputRequest);
+    const mismatches: Mismatch[] = [];
+
+    const expectedEndpointResult = this.getEndpointByRequest(userInputRequest);
     // Return mismatch if endpoint does not exist on the contract.
-    if (expectedEndpoint.isErr()) {
-      return ok([new Mismatch(expectedEndpoint.unwrapErr().message)]);
-    } else {
-      const mismatches: Mismatch[] = [];
-
-      // Header mismatch finding.
-      const mismatchesOnRequestHeader = this.findMismatchOnRequestHeader(
-        expectedEndpoint.unwrap(),
-        userInputRequest
-      );
-
-      if (mismatchesOnRequestHeader.isErr()) {
-        return mismatchesOnRequestHeader;
-      }
-
-      const mismatchesOnResponseHeader = this.findMismatchOnResponseHeader(
-        expectedEndpoint.unwrap(),
-        userInputResponse
-      );
-
-      if (mismatchesOnResponseHeader.isErr()) {
-        return mismatchesOnResponseHeader;
-      }
-
-      mismatches.push(...mismatchesOnRequestHeader.unwrap());
-      mismatches.push(...mismatchesOnResponseHeader.unwrap());
-
-      // Body mismatch finding.
-      const mismatchesOnRequestBody = this.findMismatchOnRequestBody(
-        expectedEndpoint.unwrap(),
-        userInputRequest
-      );
-
-      if (mismatchesOnRequestBody.isErr()) {
-        return mismatchesOnRequestBody;
-      }
-
-      const mismatchesOnResponseBody = this.findMismatchOnResponseBody(
-        expectedEndpoint.unwrap(),
-        userInputResponse
-      );
-
-      if (mismatchesOnResponseBody.isErr()) {
-        return mismatchesOnResponseBody;
-      }
-
-      mismatches.push(...mismatchesOnRequestBody.unwrap());
-      mismatches.push(...mismatchesOnResponseBody.unwrap());
-
-      // Path params mismatch finding
-      const pathParamMismatches = this.findMismatchOnRequestPathParam(
-        expectedEndpoint.unwrap(),
-        userInputRequest
-      );
-      if (pathParamMismatches.isErr()) {
-        return pathParamMismatches;
-      }
-      mismatches.push(...pathParamMismatches.unwrap());
-
-      const queryParamsMismatches = this.findMismatchOnRequestQueryParams(
-        expectedEndpoint.unwrap(),
-        userInputRequest
-      );
-      if (queryParamsMismatches.isErr()) {
-        return pathParamMismatches;
-      }
-      mismatches.push(...queryParamsMismatches.unwrap());
-
-      return ok(mismatches);
+    if (expectedEndpointResult.isErr()) {
+      return ok([new Mismatch(expectedEndpointResult.unwrapErr().message)]);
     }
+    const expectedEndpoint = expectedEndpointResult.unwrap();
+
+    // Header mismatch finding.
+    const mismatchesOnRequestHeader = this.findMismatchOnRequestHeader(
+      expectedEndpoint,
+      userInputRequest
+    );
+
+    if (mismatchesOnRequestHeader.isErr()) {
+      return mismatchesOnRequestHeader;
+    }
+
+    const mismatchesOnResponseHeader = this.findMismatchOnResponseHeader(
+      expectedEndpoint,
+      userInputResponse
+    );
+
+    if (mismatchesOnResponseHeader.isErr()) {
+      return mismatchesOnResponseHeader;
+    }
+
+    mismatches.push(...mismatchesOnRequestHeader.unwrap());
+    mismatches.push(...mismatchesOnResponseHeader.unwrap());
+
+    // Body mismatch finding.
+    const mismatchesOnRequestBody = this.findMismatchOnRequestBody(
+      expectedEndpoint,
+      userInputRequest
+    );
+
+    if (mismatchesOnRequestBody.isErr()) {
+      return mismatchesOnRequestBody;
+    }
+
+    const mismatchesOnResponseBody = this.findMismatchOnResponseBody(
+      expectedEndpoint,
+      userInputResponse
+    );
+
+    if (mismatchesOnResponseBody.isErr()) {
+      return mismatchesOnResponseBody;
+    }
+
+    mismatches.push(...mismatchesOnRequestBody.unwrap());
+    mismatches.push(...mismatchesOnResponseBody.unwrap());
+
+    // Path params mismatch finding
+    const pathParamMismatches = this.findMismatchOnRequestPathParam(
+      expectedEndpoint,
+      userInputRequest
+    );
+    if (pathParamMismatches.isErr()) {
+      return pathParamMismatches;
+    }
+    mismatches.push(...pathParamMismatches.unwrap());
+
+    const queryParamsMismatches = this.findMismatchOnRequestQueryParams(
+      expectedEndpoint,
+      userInputRequest
+    );
+    if (queryParamsMismatches.isErr()) {
+      return pathParamMismatches;
+    }
+    mismatches.push(...queryParamsMismatches.unwrap());
+
+    return ok(mismatches);
   }
 
   private findMismatchOnRequestHeader(
@@ -125,7 +126,7 @@ export class ContractMismatcher {
           `${JSON.stringify(
             userInputRequest.headers
           )} does not conform to the request contract headers on path: ${
-            endpoint.path
+            endpoint.name
           }:${endpoint.method}`
         )
       ]);

--- a/lib/src/neu/verifications/user-input-models.ts
+++ b/lib/src/neu/verifications/user-input-models.ts
@@ -1,12 +1,12 @@
 export interface UserInputRequest {
   path: string;
   method: string;
-  headers: UserInputHeader;
+  headers: UserInputHeader[];
   body?: UserInputBody;
 }
 
 export interface UserInputResponse {
-  headers: UserInputHeader;
+  headers: UserInputHeaders;
   statusCode: number;
   body?: UserInputBody;
 }
@@ -14,8 +14,13 @@ export interface UserInputResponse {
 export type UserInput = UserInputRequest | UserInputResponse;
 
 export interface UserInputHeader {
+  name: string;
+  value: string;
+}
+
+export interface UserInputHeaders {
   [key: string]: string;
 }
 export type UserInputBody = unknown;
 
-export type UserContent = UserInputBody | UserInputHeader;
+export type UserContent = UserInputBody | UserInputHeaders;

--- a/lib/src/neu/verifications/user-input-models.ts
+++ b/lib/src/neu/verifications/user-input-models.ts
@@ -6,21 +6,14 @@ export interface UserInputRequest {
 }
 
 export interface UserInputResponse {
-  headers: UserInputHeaders;
+  headers: UserInputHeader[];
   statusCode: number;
   body?: UserInputBody;
 }
-
-export type UserInput = UserInputRequest | UserInputResponse;
 
 export interface UserInputHeader {
   name: string;
   value: string;
 }
 
-export interface UserInputHeaders {
-  [key: string]: string;
-}
 export type UserInputBody = unknown;
-
-export type UserContent = UserInputBody | UserInputHeaders;

--- a/lib/src/validation-server/server.spec.ts
+++ b/lib/src/validation-server/server.spec.ts
@@ -129,16 +129,13 @@ describe("Validation Server", () => {
 
 describe("Transformation functions", () => {
   describe("headersToUserInputHeader", () => {
-    it("should transform Header[] into UserInputHeader", () => {
+    it("should transform Header[] into UserInputHeader[]", () => {
       expect(
         headersToUserInputHeader([
           { key: "a", value: "b" },
           { key: "c", value: "d" }
         ])
-      ).toEqual({
-        a: "b",
-        c: "d"
-      });
+      ).toEqual([{ name: "a", value: "b" }, { name: "c", value: "d" }]);
     });
   });
 

--- a/lib/src/validation-server/server.spec.ts
+++ b/lib/src/validation-server/server.spec.ts
@@ -151,7 +151,7 @@ describe("Transformation functions", () => {
       ).toEqual({
         path: "/path/to/somewhere?hello=world",
         method: "POST",
-        headers: { a: "b", c: "d" },
+        headers: [{ name: "a", value: "b" }, { name: "c", value: "d" }],
         body: { data: "body" }
       });
     });
@@ -166,7 +166,7 @@ describe("Transformation functions", () => {
           body: JSON.stringify({ data: "body" })
         })
       ).toEqual({
-        headers: { a: "b", c: "d" },
+        headers: [{ name: "a", value: "b" }, { name: "c", value: "d" }],
         statusCode: 200,
         body: { data: "body" }
       });

--- a/lib/src/validation-server/server.ts
+++ b/lib/src/validation-server/server.ts
@@ -2,7 +2,7 @@ import express from "express";
 import { Contract } from "../neu/definitions";
 import { ContractMismatcher } from "../neu/verifications/contract-mismatcher";
 import {
-  UserInputHeader,
+  UserInputHeaders,
   UserInputRequest,
   UserInputResponse
 } from "../neu/verifications/user-input-models";
@@ -75,14 +75,14 @@ const makeInternalServerError = (messages: string[]): InternalServerError => {
 
 export const headersToUserInputHeader = (
   headers: Header[]
-): UserInputHeader => {
+): UserInputHeaders => {
   return headers.reduce(
     (userInputHeader, header, _0, _1) => {
       const newUserInputHeader = userInputHeader;
       newUserInputHeader[header.key] = header.value;
       return newUserInputHeader;
     },
-    {} as UserInputHeader
+    {} as UserInputHeaders
   );
 };
 

--- a/lib/src/validation-server/server.ts
+++ b/lib/src/validation-server/server.ts
@@ -2,7 +2,7 @@ import express from "express";
 import { Contract } from "../neu/definitions";
 import { ContractMismatcher } from "../neu/verifications/contract-mismatcher";
 import {
-  UserInputHeaders,
+  UserInputHeader,
   UserInputRequest,
   UserInputResponse
 } from "../neu/verifications/user-input-models";
@@ -75,15 +75,13 @@ const makeInternalServerError = (messages: string[]): InternalServerError => {
 
 export const headersToUserInputHeader = (
   headers: Header[]
-): UserInputHeaders => {
-  return headers.reduce(
-    (userInputHeader, header, _0, _1) => {
-      const newUserInputHeader = userInputHeader;
-      newUserInputHeader[header.key] = header.value;
-      return newUserInputHeader;
-    },
-    {} as UserInputHeaders
-  );
+): UserInputHeader[] => {
+  return headers.map(header => {
+    return {
+      name: header.key,
+      value: header.value
+    };
+  });
 };
 
 export const recordedRequestToUserInputRequest = (


### PR DESCRIPTION
## Description, Motivation and Context
This PR refactors some of the methods in the `ContractMismatcher` class in preparation for simplifying the addition of extra context into the mismatcher errors.

Notable changes:
- The json schema generator has been updated to explicitly add `additionalProperties` attribute to `object` types. This is the default behaviour of json schema when this attribute is not present. `ContractMismatcher` sets the attribute false to enable strict checking of json bodies when required.
- `UserInputHeaders` has been changed to a stronger interface (not an index signature) to enable code to be more typesafe.
- Header and Body mismatch checking support toggling between `strict` mode. `strict === true` means content must match exactly with no additional headers/body attributes included in the user payload. `strict === true` is enabled for request checking. This will enable strict toggling at the validation-server level or on a per-request basis in the future.

## Checklist:

- [x] I've added/updated tests to cover my changes
- [] I've created an issue associated with this PR
