### PR TITLE
Add contextual data to validation server error messages

### DIFF
--- a/lib/src/neu/verifications/contract-mismatcher.spec.ts
+++ b/lib/src/neu/verifications/contract-mismatcher.spec.ts
@@ -100,7 +100,7 @@ describe("contract mismatch finder", () => {
     const result = mismatcher.findViolations(request, response);
     expect(result.unwrapOrThrow().violations).toHaveLength(1);
     expect(result.unwrapOrThrow().violations[0].message).toBe(
-      `Request body type mismatch:\n${JSON.stringify(
+      `Request body type disparity:\n${JSON.stringify(
         {
           data: {
             firstName: "Maple",
@@ -220,7 +220,7 @@ describe("contract mismatch finder", () => {
     const result = mismatcher.findViolations(request, response);
     expect(result.unwrapOrThrow().violations).toHaveLength(1);
     expect(result.unwrapOrThrow().violations[0].message).toBe(
-      'Request header "x-id" type mismatch: "x-id" should be float'
+      'Request header "x-id" type disparity: "x-id" should be float'
     );
   });
 
@@ -264,7 +264,7 @@ describe("contract mismatch finder", () => {
     const result = mismatcher.findViolations(request, response);
     expect(result.unwrapOrThrow().violations).toHaveLength(1);
     expect(result.unwrapOrThrow().violations[0].message).toBe(
-      'Response header "accept" type mismatch: "accept" should be float'
+      'Response header "accept" type disparity: "accept" should be float'
     );
   });
 
@@ -368,7 +368,7 @@ describe("contract mismatch finder", () => {
       const result = mismatcher.findViolations(request, response);
       expect(result.unwrapOrThrow().violations).toHaveLength(1);
       expect(result.unwrapOrThrow().violations[0].message).toBe(
-        'Query param "user" type mismatch: ".user.id" should be float'
+        'Query param "user" type disparity: ".user.id" should be float'
       );
     });
 
@@ -403,7 +403,7 @@ describe("contract mismatch finder", () => {
       const result = mismatcher.findViolations(request, response);
       expect(result.unwrapOrThrow().violations).toHaveLength(1);
       expect(result.unwrapOrThrow().violations[0].message).toBe(
-        'Query param "ids" type mismatch: "ids[0]" should be float'
+        'Query param "ids" type disparity: "ids[0]" should be float'
       );
     });
   });

--- a/lib/src/neu/verifications/contract-mismatcher.spec.ts
+++ b/lib/src/neu/verifications/contract-mismatcher.spec.ts
@@ -68,11 +68,11 @@ describe("contract mismatch finder", () => {
         }
       }
     };
-    const result = mismatcher.findMismatch(request, response);
-    expect(result.unwrapOrThrow().mismatches).toHaveLength(0);
+    const result = mismatcher.findViolations(request, response);
+    expect(result.unwrapOrThrow().violations).toHaveLength(0);
   });
 
-  test("a mismatch is found, missing 1 property on request body.", () => {
+  test("a violation is found, missing 1 property on request body.", () => {
     const request = {
       path: "/company/5/users",
       method: "POST",
@@ -97,9 +97,9 @@ describe("contract mismatch finder", () => {
         }
       }
     };
-    const result = mismatcher.findMismatch(request, response);
-    expect(result.unwrapOrThrow().mismatches).toHaveLength(1);
-    expect(result.unwrapOrThrow().mismatches[0].message).toBe(
+    const result = mismatcher.findViolations(request, response);
+    expect(result.unwrapOrThrow().violations).toHaveLength(1);
+    expect(result.unwrapOrThrow().violations[0].message).toBe(
       `Request body type mismatch:\n${JSON.stringify(
         {
           data: {
@@ -111,11 +111,11 @@ describe("contract mismatch finder", () => {
         },
         undefined,
         2
-      )}\n.data should have required property 'age'`
+      )}\n- #.data should have required property 'age'`
     );
   });
 
-  test("a mismatch is found, no matching path on the contract", () => {
+  test("a violation is found, no matching path on the contract", () => {
     const request = {
       path: "/compan/5/users",
       method: "POST",
@@ -140,14 +140,14 @@ describe("contract mismatch finder", () => {
         }
       }
     };
-    const result = mismatcher.findMismatch(request, response);
-    expect(result.unwrapOrThrow().mismatches).toHaveLength(1);
-    expect(result.unwrapOrThrow().mismatches[0].message).toBe(
+    const result = mismatcher.findViolations(request, response);
+    expect(result.unwrapOrThrow().violations).toHaveLength(1);
+    expect(result.unwrapOrThrow().violations[0].message).toBe(
       "Endpoint POST /compan/5/users not found."
     );
   });
 
-  test("a mismatch is found, when path is similar but contains a prefix", () => {
+  test("a violation is found, when path is similar but contains a prefix", () => {
     const request = {
       path: "/some/prefix/company/5/users",
       method: "POST",
@@ -172,15 +172,15 @@ describe("contract mismatch finder", () => {
         }
       }
     };
-    const result = mismatcher.findMismatch(request, response);
+    const result = mismatcher.findViolations(request, response);
     const unwrappedResult = result.unwrapOrThrow();
-    expect(unwrappedResult.mismatches).toHaveLength(1);
-    expect(unwrappedResult.mismatches[0].message).toBe(
+    expect(unwrappedResult.violations).toHaveLength(1);
+    expect(unwrappedResult.violations[0].message).toBe(
       "Endpoint POST /some/prefix/company/5/users not found."
     );
   });
 
-  test("a request header mismatch found, missing required header", () => {
+  test("a request header violation found, missing required header", () => {
     const request = {
       path: "/company/5",
       method: "GET",
@@ -195,14 +195,14 @@ describe("contract mismatch finder", () => {
         }
       }
     };
-    const result = mismatcher.findMismatch(request, response);
-    expect(result.unwrapOrThrow().mismatches).toHaveLength(1);
-    expect(result.unwrapOrThrow().mismatches[0].message).toBe(
+    const result = mismatcher.findViolations(request, response);
+    expect(result.unwrapOrThrow().violations).toHaveLength(1);
+    expect(result.unwrapOrThrow().violations[0].message).toBe(
       'Required request header "x-id" missing'
     );
   });
 
-  test("a request header mismatch found, wrong header value type", () => {
+  test("a request header violation found, wrong header value type", () => {
     const request = {
       path: "/company/5",
       method: "GET",
@@ -217,14 +217,14 @@ describe("contract mismatch finder", () => {
         }
       }
     };
-    const result = mismatcher.findMismatch(request, response);
-    expect(result.unwrapOrThrow().mismatches).toHaveLength(1);
-    expect(result.unwrapOrThrow().mismatches[0].message).toBe(
+    const result = mismatcher.findViolations(request, response);
+    expect(result.unwrapOrThrow().violations).toHaveLength(1);
+    expect(result.unwrapOrThrow().violations[0].message).toBe(
       'Request header "x-id" type mismatch: "x-id" should be float'
     );
   });
 
-  test("a response header mismatch found, missing required header", () => {
+  test("a response header violation found, missing required header", () => {
     const request = {
       path: "/company/5",
       method: "GET",
@@ -239,14 +239,14 @@ describe("contract mismatch finder", () => {
         }
       }
     };
-    const result = mismatcher.findMismatch(request, response);
-    expect(result.unwrapOrThrow().mismatches).toHaveLength(1);
-    expect(result.unwrapOrThrow().mismatches[0].message).toBe(
+    const result = mismatcher.findViolations(request, response);
+    expect(result.unwrapOrThrow().violations).toHaveLength(1);
+    expect(result.unwrapOrThrow().violations[0].message).toBe(
       'Required response header "accept" missing'
     );
   });
 
-  test("a response header mismatch found, wrong header value type", () => {
+  test("a response header violation found, wrong header value type", () => {
     const request = {
       path: "/company/5",
       method: "GET",
@@ -261,14 +261,14 @@ describe("contract mismatch finder", () => {
         }
       }
     };
-    const result = mismatcher.findMismatch(request, response);
-    expect(result.unwrapOrThrow().mismatches).toHaveLength(1);
-    expect(result.unwrapOrThrow().mismatches[0].message).toBe(
+    const result = mismatcher.findViolations(request, response);
+    expect(result.unwrapOrThrow().violations).toHaveLength(1);
+    expect(result.unwrapOrThrow().violations[0].message).toBe(
       'Response header "accept" type mismatch: "accept" should be float'
     );
   });
 
-  test("having an extra response header that's not defined in the contract is not a mismatch", () => {
+  test("having an extra response header that's not defined in the contract is not a violation", () => {
     const request = {
       path: "/company/5/users",
       method: "POST",
@@ -297,11 +297,11 @@ describe("contract mismatch finder", () => {
         }
       }
     };
-    const result = mismatcher.findMismatch(request, response);
-    expect(result.unwrapOrThrow().mismatches).toHaveLength(0);
+    const result = mismatcher.findViolations(request, response);
+    expect(result.unwrapOrThrow().violations).toHaveLength(0);
   });
 
-  describe("a mismatch is found, query params do not conform to contract", () => {
+  describe("a violation is found, query params do not conform to contract", () => {
     test("query param does not exist under endpoint", () => {
       const request = {
         path: "/company/0/users?id=query+param+array+pipe",
@@ -330,9 +330,9 @@ describe("contract mismatch finder", () => {
         }
       };
 
-      const result = mismatcher.findMismatch(request, response);
-      expect(result.unwrapOrThrow().mismatches).toHaveLength(1);
-      expect(result.unwrapOrThrow().mismatches[0].message).toBe(
+      const result = mismatcher.findViolations(request, response);
+      expect(result.unwrapOrThrow().violations).toHaveLength(1);
+      expect(result.unwrapOrThrow().violations[0].message).toBe(
         'Query param "id" not defined in contract request query params'
       );
     });
@@ -365,9 +365,9 @@ describe("contract mismatch finder", () => {
         }
       };
 
-      const result = mismatcher.findMismatch(request, response);
-      expect(result.unwrapOrThrow().mismatches).toHaveLength(1);
-      expect(result.unwrapOrThrow().mismatches[0].message).toBe(
+      const result = mismatcher.findViolations(request, response);
+      expect(result.unwrapOrThrow().violations).toHaveLength(1);
+      expect(result.unwrapOrThrow().violations[0].message).toBe(
         'Query param "user" type mismatch: ".user.id" should be float'
       );
     });
@@ -400,9 +400,9 @@ describe("contract mismatch finder", () => {
         }
       };
 
-      const result = mismatcher.findMismatch(request, response);
-      expect(result.unwrapOrThrow().mismatches).toHaveLength(1);
-      expect(result.unwrapOrThrow().mismatches[0].message).toBe(
+      const result = mismatcher.findViolations(request, response);
+      expect(result.unwrapOrThrow().violations).toHaveLength(1);
+      expect(result.unwrapOrThrow().violations[0].message).toBe(
         'Query param "ids" type mismatch: "ids[0]" should be float'
       );
     });

--- a/lib/src/neu/verifications/contract-mismatcher.ts
+++ b/lib/src/neu/verifications/contract-mismatcher.ts
@@ -116,7 +116,8 @@ export class ContractMismatcher {
             requestHeaderTypeMismatch(
               `Request header "${m.header}" type mismatch: ${m.mismatches.join(
                 ", "
-              )}`
+              )}`,
+              m.mismatches
             )
           );
           return;
@@ -154,7 +155,8 @@ export class ContractMismatcher {
             responseHeaderTypeMismatch(
               `Response header "${m.header}" type mismatch: ${m.mismatches.join(
                 ", "
-              )}`
+              )}`,
+              m.mismatches
             )
           );
           return;
@@ -184,7 +186,8 @@ export class ContractMismatcher {
             requestBodyTypeMismatch(
               `Request body type mismatch:\n${m.data}\n${m.mismatches
                 .map(mismatch => `- ${mismatch}`)
-                .join("\n")}`
+                .join("\n")}`,
+              m.mismatches
             )
           );
           return;
@@ -213,7 +216,8 @@ export class ContractMismatcher {
             responseBodyTypeMismatch(
               `Response body type mismatch:\n${m.data}\n${m.mismatches
                 .map(mismatch => `- ${mismatch}`)
-                .join("\n")}`
+                .join("\n")}`,
+              m.mismatches
             )
           );
           return;
@@ -237,7 +241,8 @@ export class ContractMismatcher {
             pathParamTypeMismatch(
               `Path param "${m.pathParam}" type mismatch: ${m.mismatches.join(
                 ", "
-              )}`
+              )}`,
+              m.mismatches
             )
           );
           return;
@@ -275,7 +280,8 @@ export class ContractMismatcher {
             queryParamTypeMismatch(
               `Query param "${m.queryParam}" type mismatch: ${m.mismatches.join(
                 ", "
-              )}`
+              )}`,
+              m.mismatches
             )
           );
           return;

--- a/lib/src/neu/verifications/mismatches.ts
+++ b/lib/src/neu/verifications/mismatches.ts
@@ -1,0 +1,138 @@
+/**
+ * Mismatches are used by the contract mismatcher to report on mismatches
+ * between data and different components of a contract. They are not intended
+ * to produce human friendly messages as they may not contain a sufficient
+ * amount of contextual information.
+ */
+
+export enum MismatchKind {
+  REQUIRED_HEADER_MISSING = "required_header_missing",
+  UNDEFINED_HEADER = "undefined_header",
+  HEADER_TYPE_DISPARITY = "header_type_disparity",
+  PATH_PARAM_TYPE_DISPARITY = "path_param_type_disparity",
+  REQUIRED_QUERY_PARAM_MISSING = "required_query_param_missing",
+  UNDEFINED_QUERY_PARAM = "undefined_query_param",
+  QUERY_PARAM_TYPE_DISPARITY = "query_param_type_disparity",
+  UNDEFINED_BODY = "undefined_body",
+  BODY_TYPE_DISPARITY = "body_type_disparity"
+}
+
+export interface RequiredHeaderMissingMismatch {
+  kind: MismatchKind.REQUIRED_HEADER_MISSING;
+  header: string;
+}
+
+export interface UndefinedHeaderMismatch {
+  kind: MismatchKind.UNDEFINED_HEADER;
+  header: string;
+}
+
+export interface HeaderTypeDisparityMismatch {
+  kind: MismatchKind.HEADER_TYPE_DISPARITY;
+  header: string;
+  typeDisparities: string[];
+}
+
+export interface PathParamTypeDisparityMismatch {
+  kind: MismatchKind.PATH_PARAM_TYPE_DISPARITY;
+  pathParam: string;
+  typeDisparities: string[];
+}
+
+export interface RequiredQueryParamMissingMismatch {
+  kind: MismatchKind.REQUIRED_QUERY_PARAM_MISSING;
+  queryParam: string;
+}
+
+export interface UndefinedQueryParamMismatch {
+  kind: MismatchKind.UNDEFINED_QUERY_PARAM;
+  queryParam: string;
+}
+
+export interface QueryParamTypeDisparityMismatch {
+  kind: MismatchKind.QUERY_PARAM_TYPE_DISPARITY;
+  queryParam: string;
+  typeDisparities: string[];
+}
+
+export interface UndefinedBodyMismatch {
+  kind: MismatchKind.UNDEFINED_BODY;
+}
+
+export interface BodyTypeDisparityMismatch {
+  kind: MismatchKind.BODY_TYPE_DISPARITY;
+  data: string;
+  typeDisparities: string[];
+}
+
+export function requiredHeaderMissingMismatch(
+  header: string
+): RequiredHeaderMissingMismatch {
+  return { kind: MismatchKind.REQUIRED_HEADER_MISSING, header };
+}
+
+export function undefinedHeaderMismatch(
+  header: string
+): UndefinedHeaderMismatch {
+  return { kind: MismatchKind.UNDEFINED_HEADER, header };
+}
+
+export function headerTypeDisparityMismatch(
+  header: string,
+  typeDisparities: string[]
+): HeaderTypeDisparityMismatch {
+  return {
+    kind: MismatchKind.HEADER_TYPE_DISPARITY,
+    header,
+    typeDisparities
+  };
+}
+
+export function pathParamTypeDisparityMismatch(
+  pathParam: string,
+  typeDisparities: string[]
+): PathParamTypeDisparityMismatch {
+  return {
+    kind: MismatchKind.PATH_PARAM_TYPE_DISPARITY,
+    pathParam,
+    typeDisparities
+  };
+}
+
+export function requiredQueryParamMissingMismatch(
+  queryParam: string
+): RequiredQueryParamMissingMismatch {
+  return { kind: MismatchKind.REQUIRED_QUERY_PARAM_MISSING, queryParam };
+}
+
+export function undefinedQueryParamMismatch(
+  queryParam: string
+): UndefinedQueryParamMismatch {
+  return { kind: MismatchKind.UNDEFINED_QUERY_PARAM, queryParam };
+}
+
+export function queryParamTypeDisparityMismatch(
+  queryParam: string,
+  typeDisparities: string[]
+): QueryParamTypeDisparityMismatch {
+  return {
+    kind: MismatchKind.QUERY_PARAM_TYPE_DISPARITY,
+    queryParam,
+    typeDisparities
+  };
+}
+
+export function undefinedBodyMismatch(): UndefinedBodyMismatch {
+  return { kind: MismatchKind.UNDEFINED_BODY };
+}
+
+export function bodyTypeDisparityMismatch(
+  data: string,
+  typeDisparities: string[]
+): BodyTypeDisparityMismatch {
+  return {
+    kind: MismatchKind.BODY_TYPE_DISPARITY,
+    data,
+    typeDisparities
+  };
+}

--- a/lib/src/neu/verifications/violations.ts
+++ b/lib/src/neu/verifications/violations.ts
@@ -52,18 +52,24 @@ export function undefinedRequestHeader(
 }
 
 export function requestHeaderTypeMismatch(
-  message: string
+  message: string,
+  typeViolations: string[]
 ): RequestHeaderTypeMismatch {
   return {
     type: "request_header_type_mismatch",
-    message
+    message,
+    type_violations: typeViolations
   };
 }
 
-export function pathParamTypeMismatch(message: string): PathParamTypeMismatch {
+export function pathParamTypeMismatch(
+  message: string,
+  typeViolations: string[]
+): PathParamTypeMismatch {
   return {
     type: "path_param_type_mismatch",
-    message
+    message,
+    type_violations: typeViolations
   };
 }
 
@@ -84,11 +90,13 @@ export function undefinedQueryParam(message: string): UndefinedQueryParam {
 }
 
 export function queryParamTypeMismatch(
-  message: string
+  message: string,
+  typeViolations: string[]
 ): QueryParamTypeMismatch {
   return {
     type: "query_param_type_mismatch",
-    message
+    message,
+    type_violations: typeViolations
   };
 }
 
@@ -100,11 +108,13 @@ export function undefinedRequestBody(message: string): UndefinedRequestBody {
 }
 
 export function requestBodyTypeMismatch(
-  message: string
+  message: string,
+  typeViolations: string[]
 ): RequestBodyTypeMismatch {
   return {
     type: "request_body_type_mismatch",
-    message
+    message,
+    type_violations: typeViolations
   };
 }
 
@@ -127,11 +137,13 @@ export function undefinedResponseHeader(
 }
 
 export function responseHeaderTypeMismatch(
-  message: string
+  message: string,
+  typeViolations: string[]
 ): ResponseHeaderTypeMismatch {
   return {
     type: "response_header_type_mismatch",
-    message
+    message,
+    type_violations: typeViolations
   };
 }
 
@@ -143,10 +155,12 @@ export function undefinedResponseBody(message: string): UndefinedResponseBody {
 }
 
 export function responseBodyTypeMismatch(
-  message: string
+  message: string,
+  typeViolations: string[]
 ): ResponseBodyTypeMismatch {
   return {
     type: "response_body_type_mismatch",
-    message
+    message,
+    type_violations: typeViolations
   };
 }

--- a/lib/src/neu/verifications/violations.ts
+++ b/lib/src/neu/verifications/violations.ts
@@ -1,166 +1,149 @@
+/**
+ * Violations are used as part of the validation server payload to
+ * express contract violations.
+ */
+
 import {
-  PathParamTypeMismatch,
-  QueryParamTypeMismatch,
-  RequestBodyTypeMismatch,
-  RequestHeaderTypeMismatch,
-  RequiredQueryParamMissing,
-  RequiredRequestHeaderMissing,
-  RequiredResponseHeaderMissing,
-  ResponseBodyTypeMismatch,
-  ResponseHeaderTypeMismatch,
-  UndefinedEndpoint,
-  UndefinedEndpointResponse,
-  UndefinedQueryParam,
-  UndefinedRequestBody,
-  UndefinedRequestHeader,
-  UndefinedResponseBody,
-  UndefinedResponseHeader
+  PathParamTypeDisparityViolation,
+  QueryParamTypeDisparityViolation,
+  RequestBodyTypeDisparityViolation,
+  RequestHeaderTypeDisparityViolation,
+  RequiredQueryParamMissingViolation,
+  RequiredRequestHeaderMissingViolation,
+  RequiredResponseHeaderMissingViolation,
+  ResponseBodyTypeDisparityViolation,
+  ResponseHeaderTypeDisparityViolation,
+  UndefinedEndpointResponseViolation,
+  UndefinedEndpointViolation,
+  UndefinedQueryParamViolation,
+  UndefinedRequestBodyViolation,
+  UndefinedRequestHeaderViolation,
+  UndefinedResponseBodyViolation,
+  UndefinedResponseHeaderViolation
 } from "../../validation-server/spots/validate";
 
-export function undefinedEndpoint(message: string): UndefinedEndpoint {
-  return {
-    type: "undefined_endpoint",
-    message
-  };
-}
-
-export function undefinedEndpointResponse(
+export function undefinedEndpointViolation(
   message: string
-): UndefinedEndpointResponse {
-  return {
-    type: "undefined_endpoint_response",
-    message
-  };
+): UndefinedEndpointViolation {
+  return { type: "undefined_endpoint", message };
 }
 
-export function requiredRequestHeaderMissing(
+export function undefinedEndpointResponseViolation(
   message: string
-): RequiredRequestHeaderMissing {
-  return {
-    type: "required_request_header_missing",
-    message
-  };
+): UndefinedEndpointResponseViolation {
+  return { type: "undefined_endpoint_response", message };
 }
 
-export function undefinedRequestHeader(
+export function requiredRequestHeaderMissingViolation(
   message: string
-): UndefinedRequestHeader {
-  return {
-    type: "undefined_request_header",
-    message
-  };
+): RequiredRequestHeaderMissingViolation {
+  return { type: "required_request_header_missing", message };
 }
 
-export function requestHeaderTypeMismatch(
-  message: string,
-  typeViolations: string[]
-): RequestHeaderTypeMismatch {
-  return {
-    type: "request_header_type_mismatch",
-    message,
-    type_violations: typeViolations
-  };
-}
-
-export function pathParamTypeMismatch(
-  message: string,
-  typeViolations: string[]
-): PathParamTypeMismatch {
-  return {
-    type: "path_param_type_mismatch",
-    message,
-    type_violations: typeViolations
-  };
-}
-
-export function requiredQueryParamMissing(
+export function undefinedRequestHeaderViolation(
   message: string
-): RequiredQueryParamMissing {
-  return {
-    type: "required_query_param_missing",
-    message
-  };
+): UndefinedRequestHeaderViolation {
+  return { type: "undefined_request_header", message };
 }
 
-export function undefinedQueryParam(message: string): UndefinedQueryParam {
-  return {
-    type: "undefined_query_param",
-    message
-  };
-}
-
-export function queryParamTypeMismatch(
+export function requestHeaderTypeDisparityViolation(
   message: string,
-  typeViolations: string[]
-): QueryParamTypeMismatch {
+  typeDisparities: string[]
+): RequestHeaderTypeDisparityViolation {
   return {
-    type: "query_param_type_mismatch",
+    type: "request_header_type_disparity",
     message,
-    type_violations: typeViolations
+    type_disparities: typeDisparities
   };
 }
 
-export function undefinedRequestBody(message: string): UndefinedRequestBody {
-  return {
-    type: "undefined_request_body",
-    message
-  };
-}
-
-export function requestBodyTypeMismatch(
+export function pathParamTypeDisparityViolation(
   message: string,
-  typeViolations: string[]
-): RequestBodyTypeMismatch {
+  typeDisparities: string[]
+): PathParamTypeDisparityViolation {
   return {
-    type: "request_body_type_mismatch",
+    type: "path_param_type_disparity",
     message,
-    type_violations: typeViolations
+    type_disparities: typeDisparities
   };
 }
 
-export function requiredResponseHeaderMissing(
+export function requiredQueryParamMissingViolation(
   message: string
-): RequiredResponseHeaderMissing {
-  return {
-    type: "required_response_header_missing",
-    message
-  };
+): RequiredQueryParamMissingViolation {
+  return { type: "required_query_param_missing", message };
 }
 
-export function undefinedResponseHeader(
+export function undefinedQueryParamViolation(
   message: string
-): UndefinedResponseHeader {
-  return {
-    type: "undefined_response_header",
-    message
-  };
+): UndefinedQueryParamViolation {
+  return { type: "undefined_query_param", message };
 }
 
-export function responseHeaderTypeMismatch(
+export function queryParamTypeDisparityViolation(
   message: string,
-  typeViolations: string[]
-): ResponseHeaderTypeMismatch {
+  typeDisparities: string[]
+): QueryParamTypeDisparityViolation {
   return {
-    type: "response_header_type_mismatch",
+    type: "query_param_type_disparity",
     message,
-    type_violations: typeViolations
+    type_disparities: typeDisparities
   };
 }
 
-export function undefinedResponseBody(message: string): UndefinedResponseBody {
-  return {
-    type: "undefined_response_body",
-    message
-  };
+export function undefinedRequestBodyViolation(
+  message: string
+): UndefinedRequestBodyViolation {
+  return { type: "undefined_request_body", message };
 }
 
-export function responseBodyTypeMismatch(
+export function requestBodyTypeDisparityViolation(
   message: string,
-  typeViolations: string[]
-): ResponseBodyTypeMismatch {
+  typeDisparities: string[]
+): RequestBodyTypeDisparityViolation {
   return {
-    type: "response_body_type_mismatch",
+    type: "request_body_type_disparity",
     message,
-    type_violations: typeViolations
+    type_disparities: typeDisparities
+  };
+}
+
+export function requiredResponseHeaderMissingViolation(
+  message: string
+): RequiredResponseHeaderMissingViolation {
+  return { type: "required_response_header_missing", message };
+}
+
+export function undefinedResponseHeaderViolation(
+  message: string
+): UndefinedResponseHeaderViolation {
+  return { type: "undefined_response_header", message };
+}
+
+export function responseHeaderTypeDisparityViolation(
+  message: string,
+  typeDisparities: string[]
+): ResponseHeaderTypeDisparityViolation {
+  return {
+    type: "response_header_type_disparity",
+    message,
+    type_disparities: typeDisparities
+  };
+}
+
+export function undefinedResponseBodyViolation(
+  message: string
+): UndefinedResponseBodyViolation {
+  return { type: "undefined_response_body", message };
+}
+
+export function responseBodyTypeDisparityViolation(
+  message: string,
+  typeDisparities: string[]
+): ResponseBodyTypeDisparityViolation {
+  return {
+    type: "response_body_type_disparity",
+    message,
+    type_disparities: typeDisparities
   };
 }

--- a/lib/src/neu/verifications/violations.ts
+++ b/lib/src/neu/verifications/violations.ts
@@ -1,0 +1,152 @@
+import {
+  PathParamTypeMismatch,
+  QueryParamTypeMismatch,
+  RequestBodyTypeMismatch,
+  RequestHeaderTypeMismatch,
+  RequiredQueryParamMissing,
+  RequiredRequestHeaderMissing,
+  RequiredResponseHeaderMissing,
+  ResponseBodyTypeMismatch,
+  ResponseHeaderTypeMismatch,
+  UndefinedEndpoint,
+  UndefinedEndpointResponse,
+  UndefinedQueryParam,
+  UndefinedRequestBody,
+  UndefinedRequestHeader,
+  UndefinedResponseBody,
+  UndefinedResponseHeader
+} from "../../validation-server/spots/validate";
+
+export function undefinedEndpoint(message: string): UndefinedEndpoint {
+  return {
+    type: "undefined_endpoint",
+    message
+  };
+}
+
+export function undefinedEndpointResponse(
+  message: string
+): UndefinedEndpointResponse {
+  return {
+    type: "undefined_endpoint_response",
+    message
+  };
+}
+
+export function requiredRequestHeaderMissing(
+  message: string
+): RequiredRequestHeaderMissing {
+  return {
+    type: "required_request_header_missing",
+    message
+  };
+}
+
+export function undefinedRequestHeader(
+  message: string
+): UndefinedRequestHeader {
+  return {
+    type: "undefined_request_header",
+    message
+  };
+}
+
+export function requestHeaderTypeMismatch(
+  message: string
+): RequestHeaderTypeMismatch {
+  return {
+    type: "request_header_type_mismatch",
+    message
+  };
+}
+
+export function pathParamTypeMismatch(message: string): PathParamTypeMismatch {
+  return {
+    type: "path_param_type_mismatch",
+    message
+  };
+}
+
+export function requiredQueryParamMissing(
+  message: string
+): RequiredQueryParamMissing {
+  return {
+    type: "required_query_param_missing",
+    message
+  };
+}
+
+export function undefinedQueryParam(message: string): UndefinedQueryParam {
+  return {
+    type: "undefined_query_param",
+    message
+  };
+}
+
+export function queryParamTypeMismatch(
+  message: string
+): QueryParamTypeMismatch {
+  return {
+    type: "query_param_type_mismatch",
+    message
+  };
+}
+
+export function undefinedRequestBody(message: string): UndefinedRequestBody {
+  return {
+    type: "undefined_request_body",
+    message
+  };
+}
+
+export function requestBodyTypeMismatch(
+  message: string
+): RequestBodyTypeMismatch {
+  return {
+    type: "request_body_type_mismatch",
+    message
+  };
+}
+
+export function requiredResponseHeaderMissing(
+  message: string
+): RequiredResponseHeaderMissing {
+  return {
+    type: "required_response_header_missing",
+    message
+  };
+}
+
+export function undefinedResponseHeader(
+  message: string
+): UndefinedResponseHeader {
+  return {
+    type: "undefined_response_header",
+    message
+  };
+}
+
+export function responseHeaderTypeMismatch(
+  message: string
+): ResponseHeaderTypeMismatch {
+  return {
+    type: "response_header_type_mismatch",
+    message
+  };
+}
+
+export function undefinedResponseBody(message: string): UndefinedResponseBody {
+  return {
+    type: "undefined_response_body",
+    message
+  };
+}
+
+export function responseBodyTypeMismatch(
+  message: string
+): ResponseBodyTypeMismatch {
+  return {
+    type: "response_body_type_mismatch",
+    message
+  };
+}

--- a/lib/src/validation-server/server.spec.ts
+++ b/lib/src/validation-server/server.spec.ts
@@ -106,12 +106,17 @@ describe("Validation Server", () => {
             {
               type: "request_body_type_mismatch",
               message:
-                "Request body type mismatch:\n{}\n- # should have required property 'data'"
+                "Request body type mismatch:\n{}\n- # should have required property 'data'",
+              type_violations: ["# should have required property 'data'"]
             },
             {
               type: "response_body_type_mismatch",
               message:
-                "Response body type mismatch:\n{}\n- # should have required property 'name'\n- # should have required property 'message'"
+                "Response body type mismatch:\n{}\n- # should have required property 'name'\n- # should have required property 'message'",
+              type_violations: [
+                "# should have required property 'name'",
+                "# should have required property 'message'"
+              ]
             }
           ]);
           expect(response.body.endpoint).toEqual("CreateUser");

--- a/lib/src/validation-server/server.spec.ts
+++ b/lib/src/validation-server/server.spec.ts
@@ -104,16 +104,16 @@ describe("Validation Server", () => {
         .then(response => {
           expect(response.body.violations).toEqual([
             {
-              type: "request_body_type_mismatch",
+              type: "request_body_type_disparity",
               message:
-                "Request body type mismatch:\n{}\n- # should have required property 'data'",
-              type_violations: ["# should have required property 'data'"]
+                "Request body type disparity:\n{}\n- # should have required property 'data'",
+              type_disparities: ["# should have required property 'data'"]
             },
             {
-              type: "response_body_type_mismatch",
+              type: "response_body_type_disparity",
               message:
-                "Response body type mismatch:\n{}\n- # should have required property 'name'\n- # should have required property 'message'",
-              type_violations: [
+                "Response body type disparity:\n{}\n- # should have required property 'name'\n- # should have required property 'message'",
+              type_disparities: [
                 "# should have required property 'name'",
                 "# should have required property 'message'"
               ]

--- a/lib/src/validation-server/server.ts
+++ b/lib/src/validation-server/server.ts
@@ -10,7 +10,8 @@ import { InternalServerError } from "./spots/utils";
 import {
   RecordedRequest,
   RecordedResponse,
-  ValidateRequest
+  ValidateRequest,
+  ValidateResponse
 } from "./spots/validate";
 
 export function runValidationServer(
@@ -39,7 +40,7 @@ export function runValidationServer(
 
       const contractValidator = new ContractMismatcher(contract);
 
-      const validatorResult = contractValidator.findMismatch(
+      const validatorResult = contractValidator.findViolations(
         userInputRequest,
         userInputResponse
       );
@@ -50,16 +51,16 @@ export function runValidationServer(
         return;
       }
 
-      const { mismatches, context } = validatorResult.unwrap();
-      const messages = mismatches.map(mismatch => mismatch.message);
-      res.json({
+      const { violations, context } = validatorResult.unwrap();
+      const responseBody: ValidateResponse = {
         interaction: {
           request: body.request,
           response: body.response
         },
         endpoint: context.endpoint,
-        mismatches: messages
-      });
+        violations
+      };
+      res.json(responseBody);
     } catch (error) {
       res.status(500).send(makeInternalServerError([error.message]));
     }

--- a/lib/src/validation-server/spots/utils.ts
+++ b/lib/src/validation-server/spots/utils.ts
@@ -14,6 +14,6 @@ export interface InternalServerError extends BaseError {
 }
 
 export interface Header {
-  key: String;
+  name: String;
   value: String;
 }

--- a/lib/src/validation-server/spots/validate.ts
+++ b/lib/src/validation-server/spots/validate.ts
@@ -39,5 +39,7 @@ export interface ValidateRequest {
 }
 
 export interface ValidateResponse {
+  interaction: ValidateRequest;
+  endpoint: String;
   mismatches: String[];
 }

--- a/lib/src/validation-server/spots/validate.ts
+++ b/lib/src/validation-server/spots/validate.ts
@@ -45,103 +45,103 @@ export interface ValidateResponse {
 }
 
 export type Violation =
-  | UndefinedEndpoint
-  | UndefinedEndpointResponse
-  | RequiredRequestHeaderMissing
-  | UndefinedRequestHeader
-  | RequestHeaderTypeMismatch
-  | PathParamTypeMismatch
-  | RequiredQueryParamMissing
-  | UndefinedQueryParam
-  | QueryParamTypeMismatch
-  | UndefinedRequestBody
-  | RequestBodyTypeMismatch
-  | RequiredResponseHeaderMissing
-  | UndefinedResponseHeader
-  | ResponseHeaderTypeMismatch
-  | UndefinedResponseBody
-  | ResponseBodyTypeMismatch;
+  | UndefinedEndpointViolation
+  | UndefinedEndpointResponseViolation
+  | RequiredRequestHeaderMissingViolation
+  | UndefinedRequestHeaderViolation
+  | RequestHeaderTypeDisparityViolation
+  | PathParamTypeDisparityViolation
+  | RequiredQueryParamMissingViolation
+  | UndefinedQueryParamViolation
+  | QueryParamTypeDisparityViolation
+  | UndefinedRequestBodyViolation
+  | RequestBodyTypeDisparityViolation
+  | RequiredResponseHeaderMissingViolation
+  | UndefinedResponseHeaderViolation
+  | ResponseHeaderTypeDisparityViolation
+  | UndefinedResponseBodyViolation
+  | ResponseBodyTypeDisparityViolation;
 
 export interface ViolationBase {
   message: String;
 }
 
 export interface TypeViolationBase {
-  type_violations: string[];
+  type_disparities: string[];
 }
 
-export interface UndefinedEndpoint extends ViolationBase {
+export interface UndefinedEndpointViolation extends ViolationBase {
   type: "undefined_endpoint";
 }
 
-export interface UndefinedEndpointResponse extends ViolationBase {
+export interface UndefinedEndpointResponseViolation extends ViolationBase {
   type: "undefined_endpoint_response";
 }
 
-export interface RequiredRequestHeaderMissing extends ViolationBase {
+export interface RequiredRequestHeaderMissingViolation extends ViolationBase {
   type: "required_request_header_missing";
 }
 
-export interface UndefinedRequestHeader extends ViolationBase {
+export interface UndefinedRequestHeaderViolation extends ViolationBase {
   type: "undefined_request_header";
 }
 
-export interface RequestHeaderTypeMismatch
+export interface RequestHeaderTypeDisparityViolation
   extends ViolationBase,
     TypeViolationBase {
-  type: "request_header_type_mismatch";
+  type: "request_header_type_disparity";
 }
 
-export interface PathParamTypeMismatch
+export interface PathParamTypeDisparityViolation
   extends ViolationBase,
     TypeViolationBase {
-  type: "path_param_type_mismatch";
+  type: "path_param_type_disparity";
 }
 
-export interface RequiredQueryParamMissing extends ViolationBase {
+export interface RequiredQueryParamMissingViolation extends ViolationBase {
   type: "required_query_param_missing";
 }
 
-export interface UndefinedQueryParam extends ViolationBase {
+export interface UndefinedQueryParamViolation extends ViolationBase {
   type: "undefined_query_param";
 }
 
-export interface QueryParamTypeMismatch
+export interface QueryParamTypeDisparityViolation
   extends ViolationBase,
     TypeViolationBase {
-  type: "query_param_type_mismatch";
+  type: "query_param_type_disparity";
 }
 
-export interface UndefinedRequestBody extends ViolationBase {
+export interface UndefinedRequestBodyViolation extends ViolationBase {
   type: "undefined_request_body";
 }
 
-export interface RequestBodyTypeMismatch
+export interface RequestBodyTypeDisparityViolation
   extends ViolationBase,
     TypeViolationBase {
-  type: "request_body_type_mismatch";
+  type: "request_body_type_disparity";
 }
 
-export interface RequiredResponseHeaderMissing extends ViolationBase {
+export interface RequiredResponseHeaderMissingViolation extends ViolationBase {
   type: "required_response_header_missing";
 }
 
-export interface UndefinedResponseHeader extends ViolationBase {
+export interface UndefinedResponseHeaderViolation extends ViolationBase {
   type: "undefined_response_header";
 }
 
-export interface ResponseHeaderTypeMismatch
+export interface ResponseHeaderTypeDisparityViolation
   extends ViolationBase,
     TypeViolationBase {
-  type: "response_header_type_mismatch";
+  type: "response_header_type_disparity";
 }
 
-export interface UndefinedResponseBody extends ViolationBase {
+export interface UndefinedResponseBodyViolation extends ViolationBase {
   type: "undefined_response_body";
 }
 
-export interface ResponseBodyTypeMismatch
+export interface ResponseBodyTypeDisparityViolation
   extends ViolationBase,
     TypeViolationBase {
-  type: "response_body_type_mismatch";
+  type: "response_body_type_disparity";
 }

--- a/lib/src/validation-server/spots/validate.ts
+++ b/lib/src/validation-server/spots/validate.ts
@@ -41,5 +41,91 @@ export interface ValidateRequest {
 export interface ValidateResponse {
   interaction: ValidateRequest;
   endpoint: String;
-  mismatches: String[];
+  violations: Violation[];
+}
+
+export type Violation =
+  | UndefinedEndpoint
+  | UndefinedEndpointResponse
+  | RequiredRequestHeaderMissing
+  | UndefinedRequestHeader
+  | RequestHeaderTypeMismatch
+  | PathParamTypeMismatch
+  | RequiredQueryParamMissing
+  | UndefinedQueryParam
+  | QueryParamTypeMismatch
+  | UndefinedRequestBody
+  | RequestBodyTypeMismatch
+  | RequiredResponseHeaderMissing
+  | UndefinedResponseHeader
+  | ResponseHeaderTypeMismatch
+  | UndefinedResponseBody
+  | ResponseBodyTypeMismatch;
+
+export interface ViolationBase {
+  message: String;
+}
+
+export interface UndefinedEndpoint extends ViolationBase {
+  type: "undefined_endpoint";
+}
+
+export interface UndefinedEndpointResponse extends ViolationBase {
+  type: "undefined_endpoint_response";
+}
+
+export interface RequiredRequestHeaderMissing extends ViolationBase {
+  type: "required_request_header_missing";
+}
+
+export interface UndefinedRequestHeader extends ViolationBase {
+  type: "undefined_request_header";
+}
+
+export interface RequestHeaderTypeMismatch extends ViolationBase {
+  type: "request_header_type_mismatch";
+}
+
+export interface PathParamTypeMismatch extends ViolationBase {
+  type: "path_param_type_mismatch";
+}
+
+export interface RequiredQueryParamMissing extends ViolationBase {
+  type: "required_query_param_missing";
+}
+
+export interface UndefinedQueryParam extends ViolationBase {
+  type: "undefined_query_param";
+}
+
+export interface QueryParamTypeMismatch extends ViolationBase {
+  type: "query_param_type_mismatch";
+}
+
+export interface UndefinedRequestBody extends ViolationBase {
+  type: "undefined_request_body";
+}
+
+export interface RequestBodyTypeMismatch extends ViolationBase {
+  type: "request_body_type_mismatch";
+}
+
+export interface RequiredResponseHeaderMissing extends ViolationBase {
+  type: "required_response_header_missing";
+}
+
+export interface UndefinedResponseHeader extends ViolationBase {
+  type: "undefined_response_header";
+}
+
+export interface ResponseHeaderTypeMismatch extends ViolationBase {
+  type: "response_header_type_mismatch";
+}
+
+export interface UndefinedResponseBody extends ViolationBase {
+  type: "undefined_response_body";
+}
+
+export interface ResponseBodyTypeMismatch extends ViolationBase {
+  type: "response_body_type_mismatch";
 }

--- a/lib/src/validation-server/spots/validate.ts
+++ b/lib/src/validation-server/spots/validate.ts
@@ -66,6 +66,10 @@ export interface ViolationBase {
   message: String;
 }
 
+export interface TypeViolationBase {
+  type_violations: string[];
+}
+
 export interface UndefinedEndpoint extends ViolationBase {
   type: "undefined_endpoint";
 }
@@ -82,11 +86,15 @@ export interface UndefinedRequestHeader extends ViolationBase {
   type: "undefined_request_header";
 }
 
-export interface RequestHeaderTypeMismatch extends ViolationBase {
+export interface RequestHeaderTypeMismatch
+  extends ViolationBase,
+    TypeViolationBase {
   type: "request_header_type_mismatch";
 }
 
-export interface PathParamTypeMismatch extends ViolationBase {
+export interface PathParamTypeMismatch
+  extends ViolationBase,
+    TypeViolationBase {
   type: "path_param_type_mismatch";
 }
 
@@ -98,7 +106,9 @@ export interface UndefinedQueryParam extends ViolationBase {
   type: "undefined_query_param";
 }
 
-export interface QueryParamTypeMismatch extends ViolationBase {
+export interface QueryParamTypeMismatch
+  extends ViolationBase,
+    TypeViolationBase {
   type: "query_param_type_mismatch";
 }
 
@@ -106,7 +116,9 @@ export interface UndefinedRequestBody extends ViolationBase {
   type: "undefined_request_body";
 }
 
-export interface RequestBodyTypeMismatch extends ViolationBase {
+export interface RequestBodyTypeMismatch
+  extends ViolationBase,
+    TypeViolationBase {
   type: "request_body_type_mismatch";
 }
 
@@ -118,7 +130,9 @@ export interface UndefinedResponseHeader extends ViolationBase {
   type: "undefined_response_header";
 }
 
-export interface ResponseHeaderTypeMismatch extends ViolationBase {
+export interface ResponseHeaderTypeMismatch
+  extends ViolationBase,
+    TypeViolationBase {
   type: "response_header_type_mismatch";
 }
 
@@ -126,6 +140,8 @@ export interface UndefinedResponseBody extends ViolationBase {
   type: "undefined_response_body";
 }
 
-export interface ResponseBodyTypeMismatch extends ViolationBase {
+export interface ResponseBodyTypeMismatch
+  extends ViolationBase,
+    TypeViolationBase {
   type: "response_body_type_mismatch";
 }


### PR DESCRIPTION
## Description, Motivation and Context
The messages returned from validation server currently contain very little contextual data to aid in resolving contract violations. This PR adds some contextual data including:
- Details when a type violation occurs
- The received interaction (request/response)
- The `endpoint` matched

## Checklist:

- [x] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
