### PR TITLE
Empty string validation against string type

### DIFF
--- a/lib/src/neu/verifications/string-validator.spec.ts
+++ b/lib/src/neu/verifications/string-validator.spec.ts
@@ -60,6 +60,12 @@ describe("validators", () => {
       expect(result).toBe(true);
       expect(validator.messages.length).toEqual(0);
     });
+
+    test("should return true for an empty string matching string", () => {
+      const result = validator.run({ name: "param", value: "" }, stringType());
+      expect(result).toBe(true);
+      expect(validator.messages.length).toEqual(0);
+    });
   });
 
   describe("invalid inputs", () => {

--- a/lib/src/neu/verifications/string-validator.ts
+++ b/lib/src/neu/verifications/string-validator.ts
@@ -47,7 +47,7 @@ export class StringValidator {
     [DOUBLE]: validators.isFloat,
     [FLOAT_LITERAL]: validators.isFloat,
     [INT_LITERAL]: validators.isInt,
-    [STRING]: Boolean
+    [STRING]: (str: string) => typeof str === "string"
   };
 
   static getErrorMessage(input: string, type: string): string {


### PR DESCRIPTION
## Description, Motivation and Context
The `StringValidator` currently returns `false` when matching the empty string `""` against the string type. This PR changes the string type validation function to use `typeof`.

## Checklist:

- [x] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
