### PR TITLE
Migrate has-response-payload linting to neu namespace

### DIFF
--- a/lib/src/neu/definitions.ts
+++ b/lib/src/neu/definitions.ts
@@ -84,3 +84,10 @@ export type QueryParamArrayStrategy = "ampersand" | "comma";
 
 /** Supported HTTP methods */
 export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+/** Type guards */
+export function isSpecificResponse(
+  response: DefaultResponse
+): response is Response {
+  return "status" in response;
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/has-response-payload/endpoint-default-response-without-body.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-response-payload/endpoint-default-response-without-body.ts
@@ -1,0 +1,13 @@
+import { api, defaultResponse, endpoint } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @defaultResponse
+  defaultResponse() {}
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/has-response-payload/endpoint-specific-and-default-responses-with-body.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-response-payload/endpoint-specific-and-default-responses-with-body.ts
@@ -1,0 +1,27 @@
+import {
+  api,
+  body,
+  defaultResponse,
+  endpoint,
+  response,
+  String
+} from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+
+  @defaultResponse
+  defaultResponse(@body body: Body) {}
+}
+
+interface Body {
+  body: String;
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/has-response-payload/endpoint-specific-response-without-body.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-response-payload/endpoint-specific-response-without-body.ts
@@ -1,0 +1,13 @@
+import { api, endpoint, response } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @response({ status: 200 })
+  successResponse() {}
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/has-response/endpoint-with-default-response.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-response/endpoint-with-default-response.ts
@@ -1,0 +1,17 @@
+import { api, body, defaultResponse, endpoint, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @defaultResponse
+  defaultResponse(@body body: Body) {}
+}
+
+interface Body {
+  body: String;
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/has-response/endpoint-with-no-responses.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-response/endpoint-with-no-responses.ts
@@ -1,0 +1,10 @@
+import { api, endpoint } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {}

--- a/lib/src/neu/linting/rules/__spec-examples__/has-response/endpoint-with-specific-response.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-response/endpoint-with-specific-response.ts
@@ -1,0 +1,17 @@
+import { api, body, endpoint, response, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  body: String;
+}

--- a/lib/src/neu/linting/rules/has-response-payload.spec.ts
+++ b/lib/src/neu/linting/rules/has-response-payload.spec.ts
@@ -1,0 +1,45 @@
+import { createProjectFromExistingSourceFile } from "../../../spec-helpers/helper";
+import { parseContract } from "../../parsers/contract-parser";
+import { hasResponsePayload } from "./has-response-payload";
+
+describe("has-response-payload linter rule", () => {
+  test("returns violations for endpoint specific response with no response body", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/has-response-payload/endpoint-specific-response-without-body.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    const result = hasResponsePayload(contract);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toEqual(
+      "Endpoint (Endpoint) response for status 200 is missing a response body"
+    );
+  });
+
+  test("returns violations for endpoint default response with no response body", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/has-response-payload/endpoint-default-response-without-body.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    const result = hasResponsePayload(contract);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toEqual(
+      "Endpoint (Endpoint) default response is missing a response body"
+    );
+  });
+
+  test("returns no violations for endpoint specific or default response with a response body", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/has-response-payload/endpoint-specific-and-default-responses-with-body.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    expect(hasResponsePayload(contract)).toHaveLength(0);
+  });
+});

--- a/lib/src/neu/linting/rules/has-response-payload.ts
+++ b/lib/src/neu/linting/rules/has-response-payload.ts
@@ -1,0 +1,40 @@
+import {
+  Contract,
+  DefaultResponse,
+  Endpoint,
+  isSpecificResponse,
+  Response
+} from "../../definitions";
+import { LintingRuleViolation } from "../rule";
+
+/**
+ * Checks that all defined responses have a response body.
+ *
+ * @param contract a contract
+ */
+export function hasResponsePayload(contract: Contract): LintingRuleViolation[] {
+  const violations: LintingRuleViolation[] = [];
+
+  contract.endpoints.forEach(endpoint => {
+    findResponses(endpoint)
+      .filter(response => response.body === undefined)
+      .forEach(responseWithNoBody => {
+        const responseIdentifier = isSpecificResponse(responseWithNoBody)
+          ? `response for status ${responseWithNoBody.status}`
+          : "default response";
+
+        violations.push({
+          message: `Endpoint (${endpoint.name}) ${responseIdentifier} is missing a response body`
+        });
+      });
+  });
+
+  return violations;
+}
+
+function findResponses(endpoint: Endpoint): Array<DefaultResponse | Response> {
+  return [
+    ...endpoint.responses,
+    ...(endpoint.defaultResponse ? [endpoint.defaultResponse] : [])
+  ];
+}

--- a/lib/src/neu/linting/rules/has-response.spec.ts
+++ b/lib/src/neu/linting/rules/has-response.spec.ts
@@ -1,0 +1,40 @@
+import { createProjectFromExistingSourceFile } from "../../../spec-helpers/helper";
+import { parseContract } from "../../parsers/contract-parser";
+import { hasResponse } from "./has-response";
+
+describe("has-response linter rule", () => {
+  test("returns violations for endpoint with no responses", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/has-response/endpoint-with-no-responses.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    const result = hasResponse(contract);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toEqual(
+      "Endpoint (Endpoint) does not declare any response"
+    );
+  });
+
+  test("returns no violations for endpoint with only a specific response", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/has-response/endpoint-with-specific-response.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    expect(hasResponse(contract)).toHaveLength(0);
+  });
+
+  test("returns no violations for endpoint with only a default response", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/has-response/endpoint-with-default-response.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    expect(hasResponse(contract)).toHaveLength(0);
+  });
+});

--- a/lib/src/neu/linting/rules/has-response.ts
+++ b/lib/src/neu/linting/rules/has-response.ts
@@ -1,0 +1,25 @@
+import { Contract } from "../../definitions";
+import { LintingRuleViolation } from "../rule";
+
+/**
+ * Checks that all defined endpoints have at least one response.
+ *
+ * @param contract a contract
+ */
+export function hasResponse(contract: Contract): LintingRuleViolation[] {
+  const violations: LintingRuleViolation[] = [];
+
+  contract.endpoints
+    .filter(
+      endpoint =>
+        endpoint.responses.length === 0 &&
+        endpoint.defaultResponse === undefined
+    )
+    .forEach(endpoint => {
+      violations.push({
+        message: `Endpoint (${endpoint.name}) does not declare any response`
+      });
+    });
+
+  return violations;
+}


### PR DESCRIPTION
## Description, Motivation and Context
This PR migrates `has-response-payload` linting rule into the neu namespace. The rule has been split in two. `has-response` checks that every endpoint defines at least one response. `has-response-payload` checks that every defined response defines a body.

## Checklist:

- [x] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
