### PR TITLE
Migrate linter rule no-nested-types-within-unions to neu namespace

### DIFF
--- a/lib/src/neu/linting/rules/__spec-examples__/no-inline-objects-within-unions/contract-inline-object-union-violations-in-each-query-param-and-body-component.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/no-inline-objects-within-unions/contract-inline-object-union-violations-in-each-query-param-and-body-component.ts
@@ -1,0 +1,41 @@
+import {
+  api,
+  body,
+  defaultResponse,
+  endpoint,
+  queryParams,
+  request,
+  response,
+  String
+} from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "POST",
+  path: "/users"
+})
+class Endpoint {
+  @request
+  request(
+    @queryParams
+    queryParams: {
+      query: InlineObjectUnion;
+    },
+    @body
+    body: Body
+  ) {}
+
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+
+  @defaultResponse
+  defaultResponse(@body body: Body) {}
+}
+
+interface Body {
+  field: InlineObjectUnion;
+}
+
+type InlineObjectUnion = { name: String } | { title: String };

--- a/lib/src/neu/linting/rules/__spec-examples__/no-inline-objects-within-unions/inline-object-or-null-union.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/no-inline-objects-within-unions/inline-object-or-null-union.ts
@@ -1,0 +1,17 @@
+import { api, body, endpoint, response, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  union: { name: String } | null;
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/no-inline-objects-within-unions/inline-objects-in-union.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/no-inline-objects-within-unions/inline-objects-in-union.ts
@@ -1,0 +1,17 @@
+import { api, body, endpoint, response, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  union: { name: String } | { title: String };
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/no-inline-objects-within-unions/referenced-objects-in-union.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/no-inline-objects-within-unions/referenced-objects-in-union.ts
@@ -1,0 +1,25 @@
+import { api, body, endpoint, response, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  union: ReferenceA | ReferenceB;
+}
+
+interface ReferenceA {
+  name: String;
+}
+
+interface ReferenceB {
+  title: String;
+}

--- a/lib/src/neu/linting/rules/no-inline-objects-within-unions.spec.ts
+++ b/lib/src/neu/linting/rules/no-inline-objects-within-unions.spec.ts
@@ -1,0 +1,59 @@
+import { createProjectFromExistingSourceFile } from "../../../spec-helpers/helper";
+import { parseContract } from "../../parsers/contract-parser";
+import { noInlineObjectsWithinUnions } from "./no-inline-objects-within-unions";
+
+describe("no-inline-objects-within-unions linter rule", () => {
+  test("returns no violations for contract containing only referenced objects in unions", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/no-inline-objects-within-unions/referenced-objects-in-union.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    expect(noInlineObjectsWithinUnions(contract)).toHaveLength(0);
+  });
+
+  test("returns no violations for contract containing single inline object and null union", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/no-inline-objects-within-unions/inline-object-or-null-union.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    expect(noInlineObjectsWithinUnions(contract)).toHaveLength(0);
+  });
+
+  test("returns a violation for contract containing inline objects in unions", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/no-inline-objects-within-unions/inline-objects-in-union.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    expect(noInlineObjectsWithinUnions(contract)).toHaveLength(1);
+  });
+
+  test("returns violations for every component of a contract", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/no-inline-objects-within-unions/contract-inline-object-union-violations-in-each-query-param-and-body-component.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    const result = noInlineObjectsWithinUnions(contract);
+    expect(result).toHaveLength(4);
+    const messages = result.map(v => v.message);
+    expect(messages).toContain(
+      "Endpoint (Endpoint) request query parameter (query) contains a union type with an inlined object member: #/"
+    );
+    expect(messages).toContain(
+      "Endpoint (Endpoint) request body contains a union type with an inlined object member: #/field"
+    );
+    expect(messages).toContain(
+      "Endpoint (Endpoint) response (200) body contains a union type with an inlined object member: #/field"
+    );
+    expect(messages).toContain(
+      "Endpoint (Endpoint) response (default) body contains a union type with an inlined object member: #/field"
+    );
+  });
+});

--- a/lib/src/neu/linting/rules/no-inline-objects-within-unions.ts
+++ b/lib/src/neu/linting/rules/no-inline-objects-within-unions.ts
@@ -1,0 +1,189 @@
+import assertNever from "assert-never";
+import { Contract } from "../../definitions";
+import {
+  dereferenceType,
+  isNullType,
+  isObjectType,
+  possibleRootTypes,
+  Type,
+  TypeKind,
+  TypeTable
+} from "../../types";
+import { LintingRuleViolation } from "../rule";
+
+/**
+ * Checks that all union members of object type are defined via type reference. This rule
+ * ensures code generators have unique type names to use for data models. This rule is ignored
+ * for two type union where one type is `null`, e.g. `{ name: String } | null`.
+ *
+ * @param contract a contract
+ */
+export function noInlineObjectsWithinUnions(
+  contract: Contract
+): LintingRuleViolation[] {
+  const typeTable = TypeTable.fromArray(contract.types);
+
+  const violations: LintingRuleViolation[] = [];
+
+  contract.endpoints.forEach(endpoint => {
+    if (endpoint.request) {
+      endpoint.request.headers.forEach(header => {
+        findInlineObjectInUnionViolations(header.type, typeTable).forEach(
+          path => {
+            violations.push({
+              message: `Endpoint (${endpoint.name}) request header (${header.name}) contains a union type with an inlined object member: #/${path}`
+            });
+          }
+        );
+      });
+      endpoint.request.pathParams.forEach(pathParam => {
+        findInlineObjectInUnionViolations(pathParam.type, typeTable).forEach(
+          path => {
+            violations.push({
+              message: `Endpoint (${endpoint.name}) request path parameter (${pathParam.name}) contains a union type with an inlined object member: #/${path}`
+            });
+          }
+        );
+      });
+      endpoint.request.queryParams.forEach(queryParam => {
+        findInlineObjectInUnionViolations(queryParam.type, typeTable).forEach(
+          path => {
+            violations.push({
+              message: `Endpoint (${endpoint.name}) request query parameter (${queryParam.name}) contains a union type with an inlined object member: #/${path}`
+            });
+          }
+        );
+      });
+      if (endpoint.request.body) {
+        findInlineObjectInUnionViolations(
+          endpoint.request.body.type,
+          typeTable
+        ).forEach(path => {
+          violations.push({
+            message: `Endpoint (${endpoint.name}) request body contains a union type with an inlined object member: #/${path}`
+          });
+        });
+      }
+    }
+    endpoint.responses.forEach(response => {
+      response.headers.forEach(header => {
+        findInlineObjectInUnionViolations(header.type, typeTable).forEach(
+          path => {
+            violations.push({
+              message: `Endpoint (${endpoint.name}) response (${response.status}) header (${header.name}) contains a union type with an inlined object member: #/${path}`
+            });
+          }
+        );
+      });
+      if (response.body) {
+        findInlineObjectInUnionViolations(
+          response.body.type,
+          typeTable
+        ).forEach(path => {
+          violations.push({
+            message: `Endpoint (${endpoint.name}) response (${response.status}) body contains a union type with an inlined object member: #/${path}`
+          });
+        });
+      }
+    });
+    if (endpoint.defaultResponse) {
+      endpoint.defaultResponse.headers.forEach(header => {
+        findInlineObjectInUnionViolations(header.type, typeTable).forEach(
+          path => {
+            violations.push({
+              message: `Endpoint (${endpoint.name}) response (default) header (${header.name}) contains a union type with an inlined object member: #/${path}`
+            });
+          }
+        );
+      });
+      if (endpoint.defaultResponse.body) {
+        findInlineObjectInUnionViolations(
+          endpoint.defaultResponse.body.type,
+          typeTable
+        ).forEach(path => {
+          violations.push({
+            message: `Endpoint (${endpoint.name}) response (default) body contains a union type with an inlined object member: #/${path}`
+          });
+        });
+      }
+    }
+  });
+
+  return violations;
+}
+
+/**
+ * Finds inline object in union violations for a given type. The paths to the violations
+ * will be returned.
+ *
+ * @param type current type to check
+ * @param typeTable type reference table
+ * @param typePath type path for context
+ */
+function findInlineObjectInUnionViolations(
+  type: Type,
+  typeTable: TypeTable,
+  typePath: string[] = []
+): string[] {
+  switch (type.kind) {
+    case TypeKind.NULL:
+    case TypeKind.BOOLEAN:
+    case TypeKind.BOOLEAN_LITERAL:
+    case TypeKind.STRING:
+    case TypeKind.STRING_LITERAL:
+    case TypeKind.FLOAT:
+    case TypeKind.DOUBLE:
+    case TypeKind.FLOAT_LITERAL:
+    case TypeKind.INT32:
+    case TypeKind.INT64:
+    case TypeKind.INT_LITERAL:
+    case TypeKind.DATE:
+    case TypeKind.DATE_TIME:
+      return [];
+    case TypeKind.OBJECT:
+      return type.properties.reduce<string[]>((acc, prop) => {
+        return acc.concat(
+          findInlineObjectInUnionViolations(
+            prop.type,
+            typeTable,
+            typePath.concat(prop.name)
+          )
+        );
+      }, []);
+    case TypeKind.ARRAY:
+      return findInlineObjectInUnionViolations(
+        type.elementType,
+        typeTable,
+        typePath.concat("[]")
+      );
+    case TypeKind.UNION:
+      const violationsInUnionTypes = type.types.reduce<string[]>((acc, t) => {
+        return acc.concat(
+          findInlineObjectInUnionViolations(t, typeTable, typePath.concat())
+        );
+      }, []);
+
+      // Get concrete types excluding null
+      const concreteTypes = possibleRootTypes(type, typeTable);
+      const concreteTypesExcludingNull = concreteTypes.filter(
+        t => !isNullType(t)
+      );
+
+      // Union of 2 types with null is valid
+      if (concreteTypesExcludingNull.length === 1) {
+        return violationsInUnionTypes;
+      }
+
+      return type.types.some(t => isObjectType(t))
+        ? violationsInUnionTypes.concat(typePath.join("/"))
+        : violationsInUnionTypes;
+    case TypeKind.REFERENCE:
+      return findInlineObjectInUnionViolations(
+        dereferenceType(type, typeTable),
+        typeTable,
+        typePath
+      );
+    default:
+      throw assertNever(type);
+  }
+}


### PR DESCRIPTION
## Description, Motivation and Context
This PR migrates the linter rule `no-nested-types-within-unions` into the neu namespace. The rule has be renamed to better reflect its functionality.

## Checklist:

- [x] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
