### PR TITLE
Migrate no-nullable-arrays linter rule to neu namespace

### DIFF
--- a/lib/src/neu/linting/rules/__spec-examples__/no-nullable-arrays/contract-with-nullable-violations-in-each-nullable-component.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/no-nullable-arrays/contract-with-nullable-violations-in-each-nullable-component.ts
@@ -1,0 +1,42 @@
+import {
+  api,
+  body,
+  defaultResponse,
+  endpoint,
+  request,
+  response,
+  String
+} from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "POST",
+  path: "/companies"
+})
+class Endpoint {
+  @request
+  request(
+    @body
+    body: RequestBody
+  ) {}
+
+  @response({ status: 200 })
+  successResponse(@body body: SuccessBody) {}
+
+  @defaultResponse
+  defaultResponse(@body body: ErrorBody) {}
+}
+
+interface RequestBody {
+  array: String[] | null;
+}
+
+interface SuccessBody {
+  array: String[] | null;
+}
+
+interface ErrorBody {
+  array: String[] | null;
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/no-nullable-arrays/non-nullable-array.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/no-nullable-arrays/non-nullable-array.ts
@@ -1,0 +1,17 @@
+import { api, body, endpoint, response, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  array: String[];
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/no-nullable-arrays/nullable-array.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/no-nullable-arrays/nullable-array.ts
@@ -1,0 +1,17 @@
+import { api, body, endpoint, response, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  array: String[] | null;
+}

--- a/lib/src/neu/linting/rules/no-nullable-arrays.spec.ts
+++ b/lib/src/neu/linting/rules/no-nullable-arrays.spec.ts
@@ -1,0 +1,46 @@
+import { createProjectFromExistingSourceFile } from "../../../spec-helpers/helper";
+import { parseContract } from "../../parsers/contract-parser";
+import { noNullableArrays } from "./no-nullable-arrays";
+
+describe("no-nullable-arrays linter rule", () => {
+  test("returns no violations for contract containing a non nullable array", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/no-nullable-arrays/non-nullable-array.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    expect(noNullableArrays(contract)).toHaveLength(0);
+  });
+
+  test("returns a violation for contract containing a nullable arrays", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/no-nullable-arrays/nullable-array.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    expect(noNullableArrays(contract)).toHaveLength(1);
+  });
+
+  test("returns violations for every nullable component of a contract", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/no-nullable-arrays/contract-with-nullable-violations-in-each-nullable-component.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    const result = noNullableArrays(contract);
+    expect(result).toHaveLength(3);
+    const messages = result.map(v => v.message);
+    expect(messages).toContain(
+      "Endpoint (Endpoint) request body contains a nullable array type: #/array"
+    );
+    expect(messages).toContain(
+      "Endpoint (Endpoint) response (200) body contains a nullable array type: #/array"
+    );
+    expect(messages).toContain(
+      "Endpoint (Endpoint) response (default) body contains a nullable array type: #/array"
+    );
+  });
+});

--- a/lib/src/neu/linting/rules/no-nullable-arrays.ts
+++ b/lib/src/neu/linting/rules/no-nullable-arrays.ts
@@ -1,0 +1,167 @@
+import assertNever from "assert-never";
+import { Contract } from "../../definitions";
+import {
+  dereferenceType,
+  isArrayType,
+  isNullType,
+  possibleRootTypes,
+  Type,
+  TypeKind,
+  TypeTable
+} from "../../types";
+import { LintingRuleViolation } from "../rule";
+
+/**
+ * Ensures that arrays are not part of nullable unions
+ *
+ * @param contract a contract
+ */
+export function noNullableArrays(contract: Contract): LintingRuleViolation[] {
+  const typeTable = TypeTable.fromArray(contract.types);
+
+  const violations: LintingRuleViolation[] = [];
+
+  contract.endpoints.forEach(endpoint => {
+    if (endpoint.request) {
+      endpoint.request.headers.forEach(header => {
+        findNullableArrayViolations(header.type, typeTable).forEach(path => {
+          violations.push({
+            message: `Endpoint (${endpoint.name}) request header (${header.name}) contains a nullable array type: #/${path}`
+          });
+        });
+      });
+      endpoint.request.pathParams.forEach(pathParam => {
+        findNullableArrayViolations(pathParam.type, typeTable).forEach(path => {
+          violations.push({
+            message: `Endpoint (${endpoint.name}) request path parameter (${pathParam.name}) contains a nullable array type: #/${path}`
+          });
+        });
+      });
+      endpoint.request.queryParams.forEach(queryParam => {
+        findNullableArrayViolations(queryParam.type, typeTable).forEach(
+          path => {
+            violations.push({
+              message: `Endpoint (${endpoint.name}) request query parameter (${queryParam.name}) contains a nullable array type: #/${path}`
+            });
+          }
+        );
+      });
+      if (endpoint.request.body) {
+        findNullableArrayViolations(
+          endpoint.request.body.type,
+          typeTable
+        ).forEach(path => {
+          violations.push({
+            message: `Endpoint (${endpoint.name}) request body contains a nullable array type: #/${path}`
+          });
+        });
+      }
+    }
+    endpoint.responses.forEach(response => {
+      response.headers.forEach(header => {
+        findNullableArrayViolations(header.type, typeTable).forEach(path => {
+          violations.push({
+            message: `Endpoint (${endpoint.name}) response (${response.status}) header (${header.name}) contains a nullable array type: #/${path}`
+          });
+        });
+      });
+      if (response.body) {
+        findNullableArrayViolations(response.body.type, typeTable).forEach(
+          path => {
+            violations.push({
+              message: `Endpoint (${endpoint.name}) response (${response.status}) body contains a nullable array type: #/${path}`
+            });
+          }
+        );
+      }
+    });
+    if (endpoint.defaultResponse) {
+      endpoint.defaultResponse.headers.forEach(header => {
+        findNullableArrayViolations(header.type, typeTable).forEach(path => {
+          violations.push({
+            message: `Endpoint (${endpoint.name}) response (default) header (${header.name}) contains a nullable array type: #/${path}`
+          });
+        });
+      });
+      if (endpoint.defaultResponse.body) {
+        findNullableArrayViolations(
+          endpoint.defaultResponse.body.type,
+          typeTable
+        ).forEach(path => {
+          violations.push({
+            message: `Endpoint (${endpoint.name}) response (default) body contains a nullable array type: #/${path}`
+          });
+        });
+      }
+    }
+  });
+
+  return violations;
+}
+
+/**
+ * Finds nullable array violations for a given type. The paths to the violations
+ * will be returned.
+ *
+ * @param type current type to check
+ * @param typeTable type reference table
+ * @param typePath type path for context
+ */
+function findNullableArrayViolations(
+  type: Type,
+  typeTable: TypeTable,
+  typePath: string[] = []
+): string[] {
+  switch (type.kind) {
+    case TypeKind.NULL:
+    case TypeKind.BOOLEAN:
+    case TypeKind.BOOLEAN_LITERAL:
+    case TypeKind.STRING:
+    case TypeKind.STRING_LITERAL:
+    case TypeKind.FLOAT:
+    case TypeKind.DOUBLE:
+    case TypeKind.FLOAT_LITERAL:
+    case TypeKind.INT32:
+    case TypeKind.INT64:
+    case TypeKind.INT_LITERAL:
+    case TypeKind.DATE:
+    case TypeKind.DATE_TIME:
+      return [];
+    case TypeKind.OBJECT:
+      return type.properties.reduce<string[]>((acc, prop) => {
+        return acc.concat(
+          findNullableArrayViolations(
+            prop.type,
+            typeTable,
+            typePath.concat(prop.name)
+          )
+        );
+      }, []);
+    case TypeKind.ARRAY:
+      return findNullableArrayViolations(
+        type.elementType,
+        typeTable,
+        typePath.concat("[]")
+      );
+    case TypeKind.UNION:
+      const violationsInUnionTypes = type.types.reduce<string[]>((acc, t) => {
+        return acc.concat(
+          findNullableArrayViolations(t, typeTable, typePath.concat())
+        );
+      }, []);
+
+      const concreteTypes = possibleRootTypes(type, typeTable);
+
+      return concreteTypes.some(isArrayType) && concreteTypes.some(isNullType)
+        ? violationsInUnionTypes.concat(typePath.join("/"))
+        : violationsInUnionTypes;
+    case TypeKind.REFERENCE:
+      return findNullableArrayViolations(
+        dereferenceType(type, typeTable),
+        typeTable,
+        typePath
+      );
+    default:
+      throw assertNever(type);
+  }
+}


### PR DESCRIPTION
## Description, Motivation and Context
This PR migrates the linter rule `no-nullable-arrays` to the neu namespace.

## Checklist:

- [x] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
