### PR TITLE
Migrate no-omittable-fields-within-responses linter rule to neu namespace

### DIFF
--- a/lib/src/neu/linting/rules/__spec-examples__/no-omittable-fields-within-response-bodies/no-omittable-field-in-response-body.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/no-omittable-fields-within-response-bodies/no-omittable-field-in-response-body.ts
@@ -1,0 +1,31 @@
+import {
+  api,
+  body,
+  defaultResponse,
+  endpoint,
+  request,
+  response,
+  String
+} from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @request
+  request(@body body: Body) {}
+
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+
+  @defaultResponse
+  defaultResponse(@body body: Body) {}
+}
+
+interface Body {
+  field: String;
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/no-omittable-fields-within-response-bodies/omittable-field-in-response-body.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/no-omittable-fields-within-response-bodies/omittable-field-in-response-body.ts
@@ -1,0 +1,31 @@
+import {
+  api,
+  body,
+  defaultResponse,
+  endpoint,
+  request,
+  response,
+  String
+} from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @request
+  request(@body body: Body) {}
+
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+
+  @defaultResponse
+  defaultResponse(@body body: Body) {}
+}
+
+interface Body {
+  field?: String;
+}

--- a/lib/src/neu/linting/rules/no-omittable-fields-within-response-bodies.spec.ts
+++ b/lib/src/neu/linting/rules/no-omittable-fields-within-response-bodies.spec.ts
@@ -1,0 +1,33 @@
+import { createProjectFromExistingSourceFile } from "../../../spec-helpers/helper";
+import { parseContract } from "../../parsers/contract-parser";
+import { noOmittableFieldsWithinResponseBodies } from "./no-omittable-fields-within-response-bodies";
+
+describe("no-omittable-fields-within-response-bodies linter rule", () => {
+  test("returns no violations for contract containing no omittable response body fields", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/no-omittable-fields-within-response-bodies/no-omittable-field-in-response-body.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    expect(noOmittableFieldsWithinResponseBodies(contract)).toHaveLength(0);
+  });
+
+  test("returns a violation for contract containing a omittable response body fields", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/no-omittable-fields-within-response-bodies/omittable-field-in-response-body.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    const result = noOmittableFieldsWithinResponseBodies(contract);
+    expect(result).toHaveLength(2);
+    const messages = result.map(v => v.message);
+    expect(messages).toContain(
+      "Endpoint (Endpoint) response (200) body contains an omittable field: #/field"
+    );
+    expect(messages).toContain(
+      "Endpoint (Endpoint) response (default) body contains an omittable field: #/field"
+    );
+  });
+});

--- a/lib/src/neu/linting/rules/no-omittable-fields-within-response-bodies.ts
+++ b/lib/src/neu/linting/rules/no-omittable-fields-within-response-bodies.ts
@@ -1,0 +1,118 @@
+import assertNever from "assert-never";
+import { Contract } from "../../definitions";
+import { dereferenceType, Type, TypeKind, TypeTable } from "../../types";
+import { LintingRuleViolation } from "../rule";
+
+/**
+ * Ensures omittable fields are not used in response bodies.
+ *
+ * @param contract a contract
+ */
+export function noOmittableFieldsWithinResponseBodies(
+  contract: Contract
+): LintingRuleViolation[] {
+  const typeTable = TypeTable.fromArray(contract.types);
+
+  const violations: LintingRuleViolation[] = [];
+
+  contract.endpoints.forEach(endpoint => {
+    endpoint.responses.forEach(response => {
+      if (response.body) {
+        findOmittableFieldViolation(response.body.type, typeTable).forEach(
+          path => {
+            violations.push({
+              message: `Endpoint (${endpoint.name}) response (${response.status}) body contains an omittable field: #/${path}`
+            });
+          }
+        );
+      }
+    });
+    if (endpoint.defaultResponse) {
+      if (endpoint.defaultResponse.body) {
+        findOmittableFieldViolation(
+          endpoint.defaultResponse.body.type,
+          typeTable
+        ).forEach(path => {
+          violations.push({
+            message: `Endpoint (${endpoint.name}) response (default) body contains an omittable field: #/${path}`
+          });
+        });
+      }
+    }
+  });
+
+  return violations;
+}
+
+/**
+ * Finds omittable field violations for a given type. The paths to the violations
+ * will be returned.
+ *
+ * @param type current type to check
+ * @param typeTable type reference table
+ * @param typePath type path for context
+ */
+function findOmittableFieldViolation(
+  type: Type,
+  typeTable: TypeTable,
+  typePath: string[] = []
+): string[] {
+  switch (type.kind) {
+    case TypeKind.NULL:
+    case TypeKind.BOOLEAN:
+    case TypeKind.BOOLEAN_LITERAL:
+    case TypeKind.STRING:
+    case TypeKind.STRING_LITERAL:
+    case TypeKind.FLOAT:
+    case TypeKind.DOUBLE:
+    case TypeKind.FLOAT_LITERAL:
+    case TypeKind.INT32:
+    case TypeKind.INT64:
+    case TypeKind.INT_LITERAL:
+    case TypeKind.DATE:
+    case TypeKind.DATE_TIME:
+      return [];
+    case TypeKind.OBJECT:
+      const violationsInObjectPropTypes = type.properties.reduce<string[]>(
+        (acc, prop) => {
+          return acc.concat(
+            findOmittableFieldViolation(
+              prop.type,
+              typeTable,
+              typePath.concat(prop.name)
+            )
+          );
+        },
+        []
+      );
+      const violationsInObjectProps = type.properties.reduce<string[]>(
+        (acc, prop) => {
+          return prop.optional
+            ? acc.concat(typePath.concat(prop.name).join("/"))
+            : acc;
+        },
+        []
+      );
+      return violationsInObjectProps.concat(violationsInObjectPropTypes);
+    case TypeKind.ARRAY:
+      return findOmittableFieldViolation(
+        type.elementType,
+        typeTable,
+        typePath.concat("[]")
+      );
+    case TypeKind.UNION:
+      return type.types.reduce<string[]>((acc, t) => {
+        return acc.concat(
+          findOmittableFieldViolation(t, typeTable, typePath.concat())
+        );
+      }, []);
+    case TypeKind.REFERENCE:
+      return findOmittableFieldViolation(
+        dereferenceType(type, typeTable),
+        typeTable,
+        typePath
+      );
+    default:
+      throw assertNever(type);
+  }
+}


### PR DESCRIPTION
## Description, Motivation and Context
This PR migrates the linter rule `no-omiitable-fields-within-responses` to the neu namespace

## Checklist:

- [x] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
