### PR TITLE
Migrate no-nullable-fields-within-requests linting rule to neu namespace

### DIFF
--- a/lib/src/neu/linting/rules/__spec-examples__/no-nullable-fields-within-request-bodies/non-nullable-field-in-request-body.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/no-nullable-fields-within-request-bodies/non-nullable-field-in-request-body.ts
@@ -1,0 +1,34 @@
+import {
+  api,
+  body,
+  defaultResponse,
+  endpoint,
+  request,
+  response,
+  String
+} from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "POST",
+  path: "/users"
+})
+class Endpoint {
+  @request
+  request(
+    @body
+    body: Body
+  ) {}
+
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+
+  @defaultResponse
+  defaultResponse(@body body: Body) {}
+}
+
+interface Body {
+  body: String;
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/no-nullable-fields-within-request-bodies/nullable-field-in-request-body.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/no-nullable-fields-within-request-bodies/nullable-field-in-request-body.ts
@@ -1,0 +1,34 @@
+import {
+  api,
+  body,
+  defaultResponse,
+  endpoint,
+  request,
+  response,
+  String
+} from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "POST",
+  path: "/users"
+})
+class Endpoint {
+  @request
+  request(
+    @body
+    body: Body | null
+  ) {}
+
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+
+  @defaultResponse
+  defaultResponse(@body body: Body) {}
+}
+
+interface Body {
+  body: String | null;
+}

--- a/lib/src/neu/linting/rules/no-nullable-fields-within-request-bodies.spec.ts
+++ b/lib/src/neu/linting/rules/no-nullable-fields-within-request-bodies.spec.ts
@@ -1,0 +1,33 @@
+import { createProjectFromExistingSourceFile } from "../../../spec-helpers/helper";
+import { parseContract } from "../../parsers/contract-parser";
+import { noNullableFieldsWithinRequestBodies } from "./no-nullable-fields-within-request-bodies";
+
+describe("no-nullable-fields-within-request-bodies linter rule", () => {
+  test("returns no violations for contract containing a nullable request body field", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/no-nullable-fields-within-request-bodies/non-nullable-field-in-request-body.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    expect(noNullableFieldsWithinRequestBodies(contract)).toHaveLength(0);
+  });
+
+  test("returns a violation for contract containing a nullable request body field", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/no-nullable-fields-within-request-bodies/nullable-field-in-request-body.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    const result = noNullableFieldsWithinRequestBodies(contract);
+    expect(result).toHaveLength(2);
+    const messages = result.map(v => v.message);
+    expect(messages).toContain(
+      "Endpoint (Endpoint) request body contains a nullable field: #/"
+    );
+    expect(messages).toContain(
+      "Endpoint (Endpoint) request body contains a nullable field: #/body"
+    );
+  });
+});

--- a/lib/src/neu/linting/rules/no-nullable-fields-within-request-bodies.ts
+++ b/lib/src/neu/linting/rules/no-nullable-fields-within-request-bodies.ts
@@ -1,0 +1,96 @@
+import assertNever from "assert-never";
+import { Contract } from "../../definitions";
+import { dereferenceType, Type, TypeKind, TypeTable } from "../../types";
+import { LintingRuleViolation } from "../rule";
+
+/**
+ * Ensures nullable fields are not used in request components.
+ *
+ * @param contract a contract
+ */
+export function noNullableFieldsWithinRequestBodies(
+  contract: Contract
+): LintingRuleViolation[] {
+  const typeTable = TypeTable.fromArray(contract.types);
+
+  const violations: LintingRuleViolation[] = [];
+
+  contract.endpoints.forEach(endpoint => {
+    if (endpoint.request) {
+      if (endpoint.request.body) {
+        findNullableFieldViolation(
+          endpoint.request.body.type,
+          typeTable
+        ).forEach(path => {
+          violations.push({
+            message: `Endpoint (${endpoint.name}) request body contains a nullable field: #/${path}`
+          });
+        });
+      }
+    }
+  });
+
+  return violations;
+}
+
+/**
+ * Finds nullable field violations for a given type. The paths to the violations
+ * will be returned.
+ *
+ * @param type current type to check
+ * @param typeTable type reference table
+ * @param typePath type path for context
+ */
+function findNullableFieldViolation(
+  type: Type,
+  typeTable: TypeTable,
+  typePath: string[] = []
+): string[] {
+  switch (type.kind) {
+    case TypeKind.NULL:
+      return [typePath.join("/")];
+    case TypeKind.BOOLEAN:
+    case TypeKind.BOOLEAN_LITERAL:
+    case TypeKind.STRING:
+    case TypeKind.STRING_LITERAL:
+    case TypeKind.FLOAT:
+    case TypeKind.DOUBLE:
+    case TypeKind.FLOAT_LITERAL:
+    case TypeKind.INT32:
+    case TypeKind.INT64:
+    case TypeKind.INT_LITERAL:
+    case TypeKind.DATE:
+    case TypeKind.DATE_TIME:
+      return [];
+    case TypeKind.OBJECT:
+      return type.properties.reduce<string[]>((acc, prop) => {
+        return acc.concat(
+          findNullableFieldViolation(
+            prop.type,
+            typeTable,
+            typePath.concat(prop.name)
+          )
+        );
+      }, []);
+    case TypeKind.ARRAY:
+      return findNullableFieldViolation(
+        type.elementType,
+        typeTable,
+        typePath.concat("[]")
+      );
+    case TypeKind.UNION:
+      return type.types.reduce<string[]>((acc, t) => {
+        return acc.concat(
+          findNullableFieldViolation(t, typeTable, typePath.concat())
+        );
+      }, []);
+    case TypeKind.REFERENCE:
+      return findNullableFieldViolation(
+        dereferenceType(type, typeTable),
+        typeTable,
+        typePath
+      );
+    default:
+      throw assertNever(type);
+  }
+}


### PR DESCRIPTION
## Description, Motivation and Context
This PR migrates the linter rule `no-nullable-fields-within-requests` to the neu namespace.

## Checklist:

- [x] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
