### PR TITLE
Migrate checksum to neu namespace

### DIFF
--- a/lib/src/neu/checksum/__spec-examples__/contract.ts
+++ b/lib/src/neu/checksum/__spec-examples__/contract.ts
@@ -1,0 +1,17 @@
+import { api, body, endpoint, response, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  union: String | null;
+}

--- a/lib/src/neu/checksum/hash.spec.ts
+++ b/lib/src/neu/checksum/hash.spec.ts
@@ -1,0 +1,57 @@
+import { createProjectFromExistingSourceFile } from "../../spec-helpers/helper";
+import { Endpoint } from "../definitions";
+import { parseContract } from "../parsers/contract-parser";
+import { TypeKind } from "../types";
+import { hashContract } from "./hash";
+
+describe("Hash", () => {
+  describe("hashContract", () => {
+    it("returns a consistent hash", () => {
+      const file = createProjectFromExistingSourceFile(
+        `${__dirname}/__spec-examples__/contract.ts`
+      ).file;
+
+      const { contract } = parseContract(file).unwrapOrThrow();
+
+      const hash0 = hashContract(contract);
+      const hash1 = hashContract(contract);
+
+      expect(hash0).toEqual(hash1);
+    });
+
+    it("returns a new hash when a new endpoint is added", () => {
+      const file = createProjectFromExistingSourceFile(
+        `${__dirname}/__spec-examples__/contract.ts`
+      ).file;
+
+      const { contract } = parseContract(file).unwrapOrThrow();
+
+      const hash0 = hashContract(contract);
+
+      const endpointDefinition: Endpoint = {
+        name: "testEndpoint",
+        description: "test endpoint",
+        tags: ["test"],
+        method: "GET",
+        path: "/test",
+        request: {
+          headers: [],
+          pathParams: [],
+          queryParams: [],
+          body: {
+            type: {
+              kind: TypeKind.STRING
+            }
+          }
+        },
+        responses: []
+      };
+
+      contract.endpoints.push(endpointDefinition);
+
+      const hash1 = hashContract(contract);
+
+      expect(hash0).not.toEqual(hash1);
+    });
+  });
+});

--- a/lib/src/neu/checksum/hash.ts
+++ b/lib/src/neu/checksum/hash.ts
@@ -1,0 +1,10 @@
+import { createHash } from "crypto";
+import { Contract } from "../definitions";
+
+export function hashContract(contract: Contract): string {
+  const contractDefinitionString = JSON.stringify(contract);
+
+  return createHash("sha1")
+    .update(contractDefinitionString)
+    .digest("hex");
+}


### PR DESCRIPTION
## Description, Motivation and Context
This PR migrates the checksum logic to the neu namespace. The CLI command will not use this until a full migration the neu namespace occurs.

## Checklist:

- [x] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
