### PR TITLE
[TT-482] Fix linting cli to output every error

### DIFF
--- a/cli/src/commands/lint.ts
+++ b/cli/src/commands/lint.ts
@@ -33,7 +33,7 @@ export default class Lint extends Command {
     const lintingErrors = lint(contract);
 
     lintingErrors.forEach(error => {
-      this.error(error.message);
+      this.error(error.message, { exit: false });
     });
   }
 }

--- a/cli/src/commands/lint.ts
+++ b/cli/src/commands/lint.ts
@@ -31,9 +31,14 @@ export default class Lint extends Command {
     const contract = parse(contractPath);
     // TODO: Make it possible to specify with a config file which lint rules to enable.
     const lintingErrors = lint(contract);
+    const deferExit = lintingErrors.length > 0;
 
     lintingErrors.forEach(error => {
       this.error(error.message, { exit: false });
     });
+
+    if (deferExit) {
+      process.exit(1);
+    }
   }
 }


### PR DESCRIPTION
## Description, Motivation and Context

`this.error` will cause the app to exit with non-0 code, hence the 1st linting error only being displayed. 

This is fixed by passing  down a flag to prevent the program from stopping. 

## Checklist:

- [ ] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
