### PR TITLE
Remove usage of Result<> wrapper in ContractMismatcher

### DIFF
--- a/lib/src/neu/validation-server/server.ts
+++ b/lib/src/neu/validation-server/server.ts
@@ -40,18 +40,11 @@ export function runValidationServer(
 
       const contractValidator = new ContractMismatcher(contract);
 
-      const validatorResult = contractValidator.findViolations(
+      const { violations, context } = contractValidator.findViolations(
         userInputRequest,
         userInputResponse
       );
 
-      if (validatorResult.isErr()) {
-        const error = validatorResult.unwrapErr();
-        res.status(500).send(makeInternalServerError([error.message]));
-        return;
-      }
-
-      const { violations, context } = validatorResult.unwrap();
       const responseBody: ValidateResponse = {
         interaction: {
           request: body.request,

--- a/lib/src/neu/validation-server/verifications/contract-mismatcher.spec.ts
+++ b/lib/src/neu/validation-server/verifications/contract-mismatcher.spec.ts
@@ -76,7 +76,7 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findViolations(request, response);
-    expect(result.unwrapOrThrow().violations).toHaveLength(0);
+    expect(result.violations).toHaveLength(0);
   });
 
   test("a violation is found, missing 1 property on request body.", () => {
@@ -105,8 +105,8 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findViolations(request, response);
-    expect(result.unwrapOrThrow().violations).toHaveLength(1);
-    expect(result.unwrapOrThrow().violations[0].message).toBe(
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].message).toBe(
       `Request body type disparity:\n${JSON.stringify(
         {
           data: {
@@ -150,8 +150,8 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findViolations(request, response);
-    expect(result.unwrapOrThrow().violations).toHaveLength(1);
-    expect(result.unwrapOrThrow().violations[0].message).toBe(
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].message).toBe(
       'Request body type disparity:\n{\n  "data": {\n    "firstName": "Maple",\n    "lastName": "Syrup",\n    "age": 1,\n    "email": "maple.syrup@airtasker.com",\n    "address": "Doggo bed",\n    "createdAt": "invalidDate"\n  }\n}\n- #.data.createdAt should match format "date"'
     );
   });
@@ -182,8 +182,8 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findViolations(request, response);
-    expect(result.unwrapOrThrow().violations).toHaveLength(1);
-    expect(result.unwrapOrThrow().violations[0].message).toBe(
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].message).toBe(
       "Endpoint POST /compan/5/users not found."
     );
   });
@@ -214,9 +214,8 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findViolations(request, response);
-    const unwrappedResult = result.unwrapOrThrow();
-    expect(unwrappedResult.violations).toHaveLength(1);
-    expect(unwrappedResult.violations[0].message).toBe(
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].message).toBe(
       "Endpoint POST /some/prefix/company/5/users not found."
     );
   });
@@ -237,8 +236,8 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findViolations(request, response);
-    expect(result.unwrapOrThrow().violations).toHaveLength(1);
-    expect(result.unwrapOrThrow().violations[0].message).toBe(
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].message).toBe(
       'Required request header "x-id" missing'
     );
   });
@@ -259,8 +258,8 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findViolations(request, response);
-    expect(result.unwrapOrThrow().violations).toHaveLength(1);
-    expect(result.unwrapOrThrow().violations[0].message).toBe(
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].message).toBe(
       'Request header "x-id" type disparity: "x-id" should be float'
     );
   });
@@ -281,8 +280,8 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findViolations(request, response);
-    expect(result.unwrapOrThrow().violations).toHaveLength(1);
-    expect(result.unwrapOrThrow().violations[0].message).toBe(
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].message).toBe(
       'Required response header "accept" missing'
     );
   });
@@ -303,8 +302,8 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findViolations(request, response);
-    expect(result.unwrapOrThrow().violations).toHaveLength(1);
-    expect(result.unwrapOrThrow().violations[0].message).toBe(
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].message).toBe(
       'Response header "accept" type disparity: "accept" should be float'
     );
   });
@@ -339,7 +338,7 @@ describe("contract mismatch finder", () => {
       }
     };
     const result = mismatcher.findViolations(request, response);
-    expect(result.unwrapOrThrow().violations).toHaveLength(0);
+    expect(result.violations).toHaveLength(0);
   });
 
   describe("a violation is found, query params do not conform to contract", () => {
@@ -372,8 +371,8 @@ describe("contract mismatch finder", () => {
       };
 
       const result = mismatcher.findViolations(request, response);
-      expect(result.unwrapOrThrow().violations).toHaveLength(1);
-      expect(result.unwrapOrThrow().violations[0].message).toBe(
+      expect(result.violations).toHaveLength(1);
+      expect(result.violations[0].message).toBe(
         'Query param "id" not defined in contract request query params'
       );
     });
@@ -407,8 +406,8 @@ describe("contract mismatch finder", () => {
       };
 
       const result = mismatcher.findViolations(request, response);
-      expect(result.unwrapOrThrow().violations).toHaveLength(1);
-      expect(result.unwrapOrThrow().violations[0].message).toBe(
+      expect(result.violations).toHaveLength(1);
+      expect(result.violations[0].message).toBe(
         'Query param "user" type disparity: ".user.id" should be float'
       );
     });
@@ -442,8 +441,8 @@ describe("contract mismatch finder", () => {
       };
 
       const result = mismatcher.findViolations(request, response);
-      expect(result.unwrapOrThrow().violations).toHaveLength(1);
-      expect(result.unwrapOrThrow().violations[0].message).toBe(
+      expect(result.violations).toHaveLength(1);
+      expect(result.violations[0].message).toBe(
         'Query param "ids" type disparity: "ids[0]" should be float'
       );
     });
@@ -477,8 +476,8 @@ describe("contract mismatch finder", () => {
       };
 
       const result = mismatcher.findViolations(request, response);
-      expect(result.unwrapOrThrow().violations).toHaveLength(1);
-      expect(result.unwrapOrThrow().violations[0].message).toBe(
+      expect(result.violations).toHaveLength(1);
+      expect(result.violations[0].message).toBe(
         'Query param "date" type disparity: "date" should be date'
       );
     });

--- a/lib/src/neu/validation-server/verifications/contract-mismatcher.ts
+++ b/lib/src/neu/validation-server/verifications/contract-mismatcher.ts
@@ -13,7 +13,6 @@ import {
 import { generateJsonSchemaType } from "../../generators/json-schema-generator";
 import { JsonSchemaType } from "../../schemas/json-schema";
 import { Type, TypeTable } from "../../types";
-import { err, ok, Result } from "../../util";
 import { Violation } from "../spots/validate";
 import {
   BodyTypeDisparityMismatch,
@@ -72,53 +71,50 @@ export class ContractMismatcher {
   findViolations(
     userInputRequest: UserInputRequest,
     userInputResponse: UserInputResponse
-  ): Result<{ violations: Violation[]; context: { endpoint: string } }, Error> {
+  ): { violations: Violation[]; context: { endpoint: string } } {
     const violations: Violation[] = [];
 
     // Get endpoint
     // Return violation if endpoint does not exist on the contract
-    const expectedEndpointResult = this.getEndpointByRequest(userInputRequest);
-    if (expectedEndpointResult.isErr()) {
-      return ok({
+    const expectedEndpoint = this.getEndpointByRequest(userInputRequest);
+    if (!expectedEndpoint) {
+      return {
         violations: [
-          undefinedEndpointViolation(expectedEndpointResult.unwrapErr().message)
+          undefinedEndpointViolation(
+            `Endpoint ${userInputRequest.method} ${userInputRequest.path} not found.`
+          )
         ],
         context: { endpoint: "" }
-      });
+      };
     }
-    const expectedEndpoint = expectedEndpointResult.unwrap();
 
     // Get request
     const expectedRequest = expectedEndpoint.request;
 
     // Get response
     // Return violation if endpoint response does not exist on the contract
-    const expectedResponseResult = this.getRelevantResponse(
+    const expectedResponse = this.getRelevantResponse(
       expectedEndpoint,
       userInputResponse.statusCode
     );
-    if (expectedResponseResult.isErr()) {
-      return ok({
+    if (!expectedResponse) {
+      return {
         violations: [
           undefinedEndpointResponseViolation(
-            expectedResponseResult.unwrapErr().message
+            `There is no response or default response defined on ${expectedEndpoint.path}:${expectedEndpoint.method}`
           )
         ],
         context: { endpoint: expectedEndpoint.name }
-      });
+      };
     }
-    const expectedResponse = expectedResponseResult.unwrap();
 
     // Find request header mismatches
-    const requestHeaderMismatchesResult = this.findHeaderMismatches(
+    const requestHeaderMismatches = this.findHeaderMismatches(
       (expectedRequest && expectedRequest.headers) || [],
       userInputRequest.headers,
       true
     );
-    if (requestHeaderMismatchesResult.isErr()) {
-      return requestHeaderMismatchesResult;
-    }
-    requestHeaderMismatchesResult.unwrap().forEach(m => {
+    requestHeaderMismatches.forEach(m => {
       switch (m.kind) {
         case MismatchKind.REQUIRED_HEADER_MISSING:
           violations.push(
@@ -150,14 +146,11 @@ export class ContractMismatcher {
     });
 
     // Find response header mismatches
-    const responseHeaderMismatchesResult = this.findHeaderMismatches(
+    const responseHeaderMismatches = this.findHeaderMismatches(
       expectedResponse.headers,
       userInputResponse.headers
     );
-    if (responseHeaderMismatchesResult.isErr()) {
-      return responseHeaderMismatchesResult;
-    }
-    responseHeaderMismatchesResult.unwrap().forEach(m => {
+    responseHeaderMismatches.forEach(m => {
       switch (m.kind) {
         case MismatchKind.REQUIRED_HEADER_MISSING:
           violations.push(
@@ -189,15 +182,12 @@ export class ContractMismatcher {
     });
 
     // Find request body mismatches
-    const requestBodyMismatchesResult = this.findBodyMismatches(
+    const requestBodyMismatches = this.findBodyMismatches(
       expectedRequest && expectedRequest.body,
       userInputRequest.body,
       true
     );
-    if (requestBodyMismatchesResult.isErr()) {
-      return requestBodyMismatchesResult;
-    }
-    requestBodyMismatchesResult.unwrap().forEach(m => {
+    requestBodyMismatches.forEach(m => {
       switch (m.kind) {
         case MismatchKind.UNDEFINED_BODY:
           violations.push(
@@ -222,14 +212,11 @@ export class ContractMismatcher {
     });
 
     // Find response body mismatches
-    const responseBodyMismatchesResult = this.findBodyMismatches(
+    const responseBodyMismatches = this.findBodyMismatches(
       expectedResponse.body,
       userInputResponse.body
     );
-    if (responseBodyMismatchesResult.isErr()) {
-      return responseBodyMismatchesResult;
-    }
-    responseBodyMismatchesResult.unwrap().forEach(m => {
+    responseBodyMismatches.forEach(m => {
       switch (m.kind) {
         case MismatchKind.UNDEFINED_BODY:
           violations.push(
@@ -254,14 +241,11 @@ export class ContractMismatcher {
     });
 
     // Find path parameter mismatches
-    const pathParamMismatchesResult = this.findPathParamMismatches(
+    const pathParamMismatches = this.findPathParamMismatches(
       expectedEndpoint,
       userInputRequest.path
     );
-    if (pathParamMismatchesResult.isErr()) {
-      return pathParamMismatchesResult;
-    }
-    pathParamMismatchesResult.unwrap().forEach(m => {
+    pathParamMismatches.forEach(m => {
       switch (m.kind) {
         case MismatchKind.PATH_PARAM_TYPE_DISPARITY:
           violations.push(
@@ -279,14 +263,11 @@ export class ContractMismatcher {
     });
 
     // Find query parameter mismatches
-    const queryParamMismatchesResult = this.findQueryParamMismatches(
+    const queryParamMismatches = this.findQueryParamMismatches(
       expectedEndpoint,
       userInputRequest.path
     );
-    if (queryParamMismatchesResult.isErr()) {
-      return queryParamMismatchesResult;
-    }
-    queryParamMismatchesResult.unwrap().forEach(m => {
+    queryParamMismatches.forEach(m => {
       switch (m.kind) {
         case MismatchKind.REQUIRED_QUERY_PARAM_MISSING:
           violations.push(
@@ -317,20 +298,17 @@ export class ContractMismatcher {
       }
     });
 
-    return ok({ violations, context: { endpoint: expectedEndpoint.name } });
+    return { violations, context: { endpoint: expectedEndpoint.name } };
   }
 
   private findHeaderMismatches(
     contractHeaders: Header[],
     inputHeaders: UserInputHeader[],
     strict: boolean = false
-  ): Result<
-    Array<
-      | RequiredHeaderMissingMismatch
-      | UndefinedHeaderMismatch
-      | HeaderTypeDisparityMismatch
-    >,
-    Error
+  ): Array<
+    | RequiredHeaderMissingMismatch
+    | UndefinedHeaderMismatch
+    | HeaderTypeDisparityMismatch
   > {
     const mismatches = [];
 
@@ -369,13 +347,13 @@ export class ContractMismatcher {
         });
     }
 
-    return ok(mismatches);
+    return mismatches;
   }
 
   private findPathParamMismatches(
     contractEndpoint: Endpoint,
     inputPath: string
-  ): Result<PathParamTypeDisparityMismatch[], Error> {
+  ): PathParamTypeDisparityMismatch[] {
     const contractPathParams =
       (contractEndpoint.request && contractEndpoint.request.pathParams) || [];
 
@@ -384,10 +362,8 @@ export class ContractMismatcher {
 
     // Sanity check, this should never happen if called after ensuring the input path matches the correct endpoint
     if (contractPathArray.length !== inputPathArray.length) {
-      return err(
-        new Error(
-          `Unexpected error: endpoint path (${contractEndpoint.path}) does not match input path (${inputPath})`
-        )
+      throw new Error(
+        `Unexpected error: endpoint path (${contractEndpoint.path}) does not match input path (${inputPath})`
       );
     }
 
@@ -399,10 +375,8 @@ export class ContractMismatcher {
         );
 
         if (!contractPathParam) {
-          return err(
-            new Error(
-              "Unexpected error: could not find path param on contract."
-            )
+          throw new Error(
+            "Unexpected error: could not find path param on contract."
           );
         }
         const contractPathParamType = contractPathParam.type;
@@ -421,22 +395,22 @@ export class ContractMismatcher {
         }
       }
     }
-    return ok(mismatches);
+    return mismatches;
   }
 
   private findBodyMismatches(
     contractBody: Body | undefined,
     inputBody: UserInputBody,
     strict: boolean = false
-  ): Result<Array<UndefinedBodyMismatch | BodyTypeDisparityMismatch>, Error> {
+  ): Array<UndefinedBodyMismatch | BodyTypeDisparityMismatch> {
     if (contractBody === undefined) {
       if (inputBody === undefined) {
-        return ok([]);
+        return [];
       }
       if (strict) {
-        return ok([undefinedBodyMismatch()]);
+        return [undefinedBodyMismatch()];
       }
-      return ok([]);
+      return [];
     }
 
     const jsv = new JsonSchemaValidator({
@@ -459,14 +433,12 @@ export class ContractMismatcher {
     const valid = validateFn(inputBody);
 
     if (valid) {
-      return ok([]);
+      return [];
     }
 
     if (!validateFn.errors) {
-      return err(
-        new Error(
-          `Body Validation reaches unexpected error for ${inputBody} with contract body ${contractBody.type}`
-        )
+      throw new Error(
+        `Body Validation reaches unexpected error for ${inputBody} with contract body ${contractBody.type}`
       );
     }
 
@@ -476,15 +448,15 @@ export class ContractMismatcher {
     });
 
     if (bodyTypeMismatches.length > 0) {
-      return ok([
+      return [
         bodyTypeDisparityMismatch(
           JSON.stringify(inputBody, undefined, 2),
           bodyTypeMismatches
         )
-      ]);
+      ];
     }
 
-    return ok([]);
+    return [];
   }
 
   private getQueryParamsArraySerializationStrategy(): { comma: boolean } {
@@ -497,13 +469,10 @@ export class ContractMismatcher {
   private findQueryParamMismatches(
     contractEndpoint: Endpoint,
     inputPath: string
-  ): Result<
-    Array<
-      | RequiredQueryParamMissingMismatch
-      | UndefinedQueryParamMismatch
-      | QueryParamTypeDisparityMismatch
-    >,
-    Error
+  ): Array<
+    | RequiredQueryParamMissingMismatch
+    | UndefinedQueryParamMismatch
+    | QueryParamTypeDisparityMismatch
   > {
     const contractQueryParams =
       (contractEndpoint.request && contractEndpoint.request.queryParams) || [];
@@ -563,7 +532,7 @@ export class ContractMismatcher {
         mismatches.push(undefinedQueryParamMismatch(key));
       });
 
-    return ok(mismatches);
+    return mismatches;
   }
 
   private findMismatchOnStringContent(
@@ -583,30 +552,26 @@ export class ContractMismatcher {
   private getRelevantResponse(
     endpoint: Endpoint,
     userInputStatusCode: number
-  ): Result<Response | DefaultResponse, Error> {
+  ): Response | DefaultResponse | null {
     if (endpoint.responses.length > 0) {
       for (const contractResponse of endpoint.responses) {
         if (contractResponse.status === userInputStatusCode) {
-          return ok(contractResponse);
+          return contractResponse;
         }
       }
     }
 
     if (endpoint.defaultResponse) {
-      return ok(endpoint.defaultResponse);
+      return endpoint.defaultResponse;
     }
 
-    // No response headers defined on the contract. This is ok for responses.
-    return err(
-      new Error(
-        `There is no response or default response defined on ${endpoint.path}:${endpoint.method}`
-      )
-    );
+    // No response headers defined on the contract.
+    return null;
   }
 
   private getEndpointByRequest(
     userInputRequest: UserInputRequest
-  ): Result<Endpoint, Error> {
+  ): Endpoint | null {
     const userInputRequestPath = userInputRequest.path.split("?")[0];
 
     const endpoint = this.contract.endpoints.find((value, _0, _1) => {
@@ -616,15 +581,7 @@ export class ContractMismatcher {
       );
     });
 
-    if (endpoint) {
-      return ok(endpoint);
-    }
-
-    return err(
-      new Error(
-        `Endpoint ${userInputRequest.method} ${userInputRequest.path} not found.`
-      )
-    );
+    return endpoint || null;
   }
 }
 


### PR DESCRIPTION
## Description, Motivation and Context

The Result<> wrapper is a useful pattern to distinguish between the "happy path" and a possible error scenario.

In the context of ContractMismatcher, most error scenarios seem to correspond to unexpected errors. These should be impossible, because at this stage the contract has been parsed successfully. Therefore, throwing an error may be a better option as it reflects a problem with Spot itself.

This PR proposes to remove usage of the Result<> wrapper in ContractMismatcher. This would make its usage simpler, as otherwise users of the library may assume that `result.isOk()` indicates the absence of violation (a mistake I made myself).

*Before:*
```ts
const validatorResult = contractValidator.findViolations(...);
if (validatorResult.isErr()) {
  // Handle Spot internal errors.
} else {
  const validatorResultUnwrapped = validatorResult.unwrap();
  if (validatorResultUnwrapped.violations.length > 0) {
    // There are violations.
  } else {
    // We're fine!
  }
}
```

*After:*
```ts
const validatorResult = contractValidator.findViolations(...);
if (validatorResult.violations.length > 0) {
  // There are violations.
} else {
  // We're fine!
}
```

## Checklist:

- [x] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
