### PR TITLE
Union support for string validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ OPTIONS
   --all  see all commands in CLI
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.1/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.3/src/commands/help.ts)_
 
 ## `spot init`
 

--- a/lib/src/neu/validation-server/verifications/string-validator.spec.ts
+++ b/lib/src/neu/validation-server/verifications/string-validator.spec.ts
@@ -5,10 +5,10 @@ import {
   int64Type,
   objectType,
   referenceType,
+  stringLiteralType,
   stringType,
   TypeTable,
-  unionType,
-  stringLiteralType
+  unionType
 } from "../../types";
 import { StringValidator } from "./string-validator";
 

--- a/lib/src/neu/validation-server/verifications/string-validator.spec.ts
+++ b/lib/src/neu/validation-server/verifications/string-validator.spec.ts
@@ -6,7 +6,9 @@ import {
   objectType,
   referenceType,
   stringType,
-  TypeTable
+  TypeTable,
+  unionType,
+  stringLiteralType
 } from "../../types";
 import { StringValidator } from "./string-validator";
 
@@ -66,6 +68,18 @@ describe("validators", () => {
       expect(result).toBe(true);
       expect(validator.messages.length).toEqual(0);
     });
+
+    test("should return true when value matches a union type", () => {
+      const result = validator.run(
+        { name: "param", value: "unionElementA" },
+        unionType([
+          stringLiteralType("unionElementA"),
+          stringLiteralType("unionElementB")
+        ])
+      );
+      expect(result).toBe(true);
+      expect(validator.messages.length).toEqual(0);
+    });
   });
 
   describe("invalid inputs", () => {
@@ -106,6 +120,20 @@ describe("validators", () => {
       );
       expect(result).toBe(false);
       expect(validator.messages[0]).toEqual('".param.id" should be int64');
+    });
+
+    test("should return an error value doesn't match a union type", () => {
+      const result = validator.run(
+        { name: "param", value: "unknownElement" },
+        unionType([
+          stringLiteralType("unionElementA"),
+          stringLiteralType("unionElementB")
+        ])
+      );
+      expect(result).toBe(false);
+      expect(validator.messages[0]).toEqual(
+        '"param" should be a member of a union'
+      );
     });
   });
 });


### PR DESCRIPTION
## Description, Motivation and Context
The String Validator (used for query/path/header params) currently does not support unions (as well as boolean and string literals). This PR adds validation support for these types.

## Checklist:

- [x] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
