### PR TITLE
[TT-684] HEAD / GET / DELETE endpoints must not declare a request payload.

### DIFF
--- a/lib/src/neu/definitions.ts
+++ b/lib/src/neu/definitions.ts
@@ -84,7 +84,7 @@ export interface Body {
 export type QueryParamArrayStrategy = "ampersand" | "comma";
 
 /** Supported HTTP methods */
-export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+export type HttpMethod = "HEAD" | "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
 /** Type guards */
 export function isSpecificResponse(

--- a/lib/src/neu/linting/rules/has-request-payload.ts
+++ b/lib/src/neu/linting/rules/has-request-payload.ts
@@ -4,9 +4,8 @@ import { LintingRuleViolation } from "../rule";
 
 /**
  * Checks that endpoint request body's conform to HTTP method semantics:
- * - GET requests MUST NOT contain a request body
+ * - GET and DELETE  requests MUST NOT contain a request body
  * - POST | PATCH | PUT requests MUST contain a request body
- * - DELETE requests MAY contain a request body
  *
  * @param contract a contract
  */
@@ -16,6 +15,8 @@ export function hasRequestPayload(contract: Contract): LintingRuleViolation[] {
   contract.endpoints.forEach(endpoint => {
     switch (endpoint.method) {
       case "GET":
+      case "HEAD":
+      case "DELETE":
         if (endpoint.request && endpoint.request.body) {
           violations.push({
             message: `Endpoint (${endpoint.name}) with HTTP method ${endpoint.method} must not contain a request body`
@@ -30,8 +31,6 @@ export function hasRequestPayload(contract: Contract): LintingRuleViolation[] {
             message: `Endpoint (${endpoint.name}) with HTTP method ${endpoint.method} must contain a request body`
           });
         }
-        break;
-      case "DELETE":
         break;
       default:
         assertNever(endpoint.method);


### PR DESCRIPTION
## Description, Motivation and Context

As per the API guidelines, HEAD / GET / DELETE endpoints must not declare a request payload. This updates the linter to take this rule into consideration. 

## Checklist:

- [ ] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
