### PR TITLE
[TT-685] No query parameters in PATCH/PUT/POST endpoints

### DIFF
--- a/lib/src/neu/linting/rules/__spec-examples__/has-query-parameters/patch-endpoint-with-query-parameters.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-query-parameters/patch-endpoint-with-query-parameters.ts
@@ -1,0 +1,34 @@
+import {
+  api,
+  body,
+  endpoint,
+  Float,
+  queryParams,
+  request,
+  response,
+  String
+} from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "PATCH",
+  path: "/users"
+})
+class PatchEndpoint {
+  @request
+  request(
+    @queryParams
+    queryParams: {
+      query: String | Float;
+    }
+  ) {}
+
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  body: String;
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/has-query-parameters/patch-endpoint-without-query-parameters.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-query-parameters/patch-endpoint-without-query-parameters.ts
@@ -1,0 +1,27 @@
+import {
+  api,
+  body,
+  endpoint,
+  request,
+  response,
+  String
+} from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "PATCH",
+  path: "/users"
+})
+class PatchEndpoint {
+  @request
+  request() {}
+
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  body: String;
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/has-query-parameters/post-endpoint-with-query-parameters.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-query-parameters/post-endpoint-with-query-parameters.ts
@@ -1,0 +1,36 @@
+import {
+  api,
+  body,
+  endpoint,
+  Float,
+  queryParams,
+  request,
+  response,
+  String
+} from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "POST",
+  path: "/users"
+})
+class PostEndpoint {
+  @request
+  request(
+    @queryParams
+    queryParams: {
+      query: String | Float;
+    },
+    @body
+    body: Body
+  ) {}
+
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  body: String;
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/has-query-parameters/post-endpoint-without-query-parameters.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-query-parameters/post-endpoint-without-query-parameters.ts
@@ -1,0 +1,29 @@
+import {
+  api,
+  body,
+  endpoint,
+  request,
+  response,
+  String
+} from "@airtasker/spot";
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "POST",
+  path: "/users"
+})
+class PostEndpoint {
+  @request
+  request(
+    @body
+    body: Body
+  ) {}
+
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  body: String;
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/has-query-parameters/put-endpoint-with-query-parameters.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-query-parameters/put-endpoint-with-query-parameters.ts
@@ -1,0 +1,36 @@
+import {
+  api,
+  body,
+  endpoint,
+  Float,
+  queryParams,
+  request,
+  response,
+  String
+} from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "PUT",
+  path: "/users"
+})
+class PutEndpoint {
+  @request
+  request(
+    @queryParams
+    queryParams: {
+      query: String | Float;
+    },
+    @body
+    body: Body
+  ) {}
+
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  body: String;
+}

--- a/lib/src/neu/linting/rules/__spec-examples__/has-query-parameters/put-endpoint-without-query-parameters.ts
+++ b/lib/src/neu/linting/rules/__spec-examples__/has-query-parameters/put-endpoint-without-query-parameters.ts
@@ -1,0 +1,30 @@
+import {
+  api,
+  body,
+  endpoint,
+  request,
+  response,
+  String
+} from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "PUT",
+  path: "/users"
+})
+class PutEndpoint {
+  @request
+  request(
+    @body
+    body: Body
+  ) {}
+
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  body: String;
+}

--- a/lib/src/neu/linting/rules/has-query-parameters.spec.ts
+++ b/lib/src/neu/linting/rules/has-query-parameters.spec.ts
@@ -30,7 +30,7 @@ describe("has-request-payload linter rule", () => {
   });
 
   describe("HTTP POST", () => {
-    test("returns violations for endpoint with quey parameters", () => {
+    test("returns violations for endpoint with query parameters", () => {
       const file = createProjectFromExistingSourceFile(
         `${__dirname}/__spec-examples__/has-query-parameters/post-endpoint-with-query-parameters.ts`
       ).file;
@@ -56,7 +56,7 @@ describe("has-request-payload linter rule", () => {
   });
 
   describe("HTTP PUT", () => {
-    test("returns violations for endpoint with quey parameters", () => {
+    test("returns violations for endpoint with query parameters", () => {
       const file = createProjectFromExistingSourceFile(
         `${__dirname}/__spec-examples__/has-query-parameters/put-endpoint-with-query-parameters.ts`
       ).file;

--- a/lib/src/neu/linting/rules/has-query-parameters.spec.ts
+++ b/lib/src/neu/linting/rules/has-query-parameters.spec.ts
@@ -1,0 +1,83 @@
+import { createProjectFromExistingSourceFile } from "../../../spec-helpers/helper";
+import { parseContract } from "../../parsers/contract-parser";
+import { hasQueryParameters } from "./has-query-parameters";
+
+describe("has-request-payload linter rule", () => {
+  describe("HTTP PATCH", () => {
+    test("returns violations for endpoint with query parameters", () => {
+      const file = createProjectFromExistingSourceFile(
+        `${__dirname}/__spec-examples__/has-query-parameters/patch-endpoint-with-query-parameters.ts`
+      ).file;
+
+      const { contract } = parseContract(file).unwrapOrThrow();
+
+      const result = hasQueryParameters(contract);
+      expect(result).toHaveLength(1);
+      const message = result[0].message;
+      expect(message).toEqual(
+        "Endpoint (PatchEndpoint) with HTTP method PATCH must not contain query parameters"
+      );
+    });
+    test("returns no violations for endpoint with no query parameters", () => {
+      const file = createProjectFromExistingSourceFile(
+        `${__dirname}/__spec-examples__/has-query-parameters/patch-endpoint-without-query-parameters.ts`
+      ).file;
+
+      const { contract } = parseContract(file).unwrapOrThrow();
+
+      expect(hasQueryParameters(contract)).toHaveLength(0);
+    });
+  });
+
+  describe("HTTP POST", () => {
+    test("returns violations for endpoint with quey parameters", () => {
+      const file = createProjectFromExistingSourceFile(
+        `${__dirname}/__spec-examples__/has-query-parameters/post-endpoint-with-query-parameters.ts`
+      ).file;
+
+      const { contract } = parseContract(file).unwrapOrThrow();
+
+      const result = hasQueryParameters(contract);
+      expect(result).toHaveLength(1);
+      const message = result[0].message;
+      expect(message).toEqual(
+        "Endpoint (PostEndpoint) with HTTP method POST must not contain query parameters"
+      );
+    });
+    test("returns no violations for endpoint with no query parameters", () => {
+      const file = createProjectFromExistingSourceFile(
+        `${__dirname}/__spec-examples__/has-query-parameters/post-endpoint-without-query-parameters.ts`
+      ).file;
+
+      const { contract } = parseContract(file).unwrapOrThrow();
+
+      expect(hasQueryParameters(contract)).toHaveLength(0);
+    });
+  });
+
+  describe("HTTP PUT", () => {
+    test("returns violations for endpoint with quey parameters", () => {
+      const file = createProjectFromExistingSourceFile(
+        `${__dirname}/__spec-examples__/has-query-parameters/put-endpoint-with-query-parameters.ts`
+      ).file;
+
+      const { contract } = parseContract(file).unwrapOrThrow();
+
+      const result = hasQueryParameters(contract);
+      expect(result).toHaveLength(1);
+      const message = result[0].message;
+      expect(message).toEqual(
+        "Endpoint (PutEndpoint) with HTTP method PUT must not contain query parameters"
+      );
+    });
+    test("returns no violations for endpoint with no query parameters", () => {
+      const file = createProjectFromExistingSourceFile(
+        `${__dirname}/__spec-examples__/has-query-parameters/put-endpoint-without-query-parameters.ts`
+      ).file;
+
+      const { contract } = parseContract(file).unwrapOrThrow();
+
+      expect(hasQueryParameters(contract)).toHaveLength(0);
+    });
+  });
+});

--- a/lib/src/neu/linting/rules/has-query-parameters.ts
+++ b/lib/src/neu/linting/rules/has-query-parameters.ts
@@ -1,0 +1,34 @@
+import assertNever from "assert-never";
+import { Contract } from "../../definitions";
+import { LintingRuleViolation } from "../rule";
+
+/**
+ * Checks that endpoint request payload conform to HTTP method semantics:
+ * - POST | PATCH | PUT requests MUST NOT contain query parameters
+ *
+ * @param contract a contract
+ */
+export function hasQueryParameters(contract: Contract): LintingRuleViolation[] {
+  const violations: LintingRuleViolation[] = [];
+
+  contract.endpoints.forEach(endpoint => {
+    switch (endpoint.method) {
+      case "DELETE":
+      case "GET":
+        break;
+      case "PATCH":
+      case "POST":
+      case "PUT":
+        if (endpoint.request && endpoint.request.queryParams.length > 0) {
+          violations.push({
+            message: `Endpoint (${endpoint.name}) with HTTP method ${endpoint.method} must not contain query parameters`
+          });
+        }
+        break;
+      default:
+        assertNever(endpoint.method);
+    }
+  });
+
+  return violations;
+}

--- a/lib/src/neu/linting/rules/has-query-parameters.ts
+++ b/lib/src/neu/linting/rules/has-query-parameters.ts
@@ -4,7 +4,7 @@ import { LintingRuleViolation } from "../rule";
 
 /**
  * Checks that endpoint request payload conform to HTTP method semantics:
- * - POST | PATCH | PUT requests MUST NOT contain query parameters
+ * - PATCH | PUT | POST requests MUST NOT contain query parameters
  *
  * @param contract a contract
  */


### PR DESCRIPTION
## Description, Motivation and Context

This ensures `PATCH/POST/PUT` endpoints don't contain query parameters. 

## Checklist:

- [x] I've added/updated tests to cover my changes
- [x] I've created an issue associated with this PR
