### PR TITLE
OpenAPI 3 specification fix

### DIFF
--- a/lib/src/neu/generators/openapi3/openapi3-specification.ts
+++ b/lib/src/neu/generators/openapi3/openapi3-specification.ts
@@ -66,7 +66,7 @@ export interface PathItemObject {
   patch?: OperationObject;
   trace?: OperationObject;
   servers?: ServerObject[];
-  parameters: Array<ParameterObject | ReferenceObject>;
+  parameters?: Array<ParameterObject | ReferenceObject>;
 }
 
 // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#operationObject
@@ -238,6 +238,7 @@ export interface AnySchemaObject extends SchemaObjectBase {
 
 export interface AllOfSchemaObject extends SchemaObjectBase {
   allOf: Array<SchemaObject | ReferenceObject>;
+  discriminator?: DiscriminatorObject;
 }
 
 export interface OneOfSchemaObject extends SchemaObjectBase {

--- a/lib/src/neu/generators/openapi3/openapi3.ts
+++ b/lib/src/neu/generators/openapi3/openapi3.ts
@@ -100,7 +100,9 @@ function endpointsToPathsObject(
         component.startsWith(":") ? `{${component.slice(1)}}` : component
       )
       .join("/");
-    acc[pathName] = acc[pathName] || {};
+
+    // Note: acc[pathName] || {} breaks type safety, ternary operation is type safe
+    acc[pathName] = acc[pathName] ? acc[pathName] : {};
     const pathItemMethod = httpMethodToPathItemMethod(endpoint.method);
     acc[pathName][pathItemMethod] = endpointToOperationObject(
       endpoint,


### PR DESCRIPTION
## Description, Motivation and Context
The neu OpenAPI 3 specification does not completely align with the 3.0.2 spec. This PR fixes this. An cosmetic change has been made to the openapi 3 generator for better type checking.

