### PR TITLE
OpenAPI 2 type utility

### DIFF
--- a/lib/src/neu/generators/openapi2/openapi2-type-util.spec.ts
+++ b/lib/src/neu/generators/openapi2/openapi2-type-util.spec.ts
@@ -1,0 +1,512 @@
+import {
+  arrayType,
+  booleanLiteralType,
+  booleanType,
+  dateTimeType,
+  dateType,
+  doubleType,
+  floatLiteralType,
+  floatType,
+  int32Type,
+  int64Type,
+  intLiteralType,
+  nullType,
+  objectType,
+  referenceType,
+  stringLiteralType,
+  stringType,
+  TypeTable,
+  unionType
+} from "../../types";
+import { typeToSchemaObject } from "./openapi2-type-util";
+
+describe("OpenAPI 2 type util", () => {
+  describe("Null type", () => {
+    test("fails to convert to schema", () => {
+      expect(() =>
+        typeToSchemaObject(nullType(), new TypeTable())
+      ).toThrowError("Null must be part of a union for OpenAPI 2");
+    });
+  });
+
+  describe("Boolean type", () => {
+    test("converts to boolean schema", () => {
+      const result = typeToSchemaObject(booleanType(), new TypeTable());
+      expect(result).toEqual({ type: "boolean" });
+    });
+  });
+
+  describe("Boolean literal type", () => {
+    test("converts to boolean schema with true enum for true value", () => {
+      const result = typeToSchemaObject(
+        booleanLiteralType(true),
+        new TypeTable()
+      );
+      expect(result).toEqual({ type: "boolean", enum: [true] });
+    });
+
+    test("converts to boolean schema with false enum for false value", () => {
+      const result = typeToSchemaObject(
+        booleanLiteralType(false),
+        new TypeTable()
+      );
+      expect(result).toEqual({ type: "boolean", enum: [false] });
+    });
+  });
+
+  describe("String type", () => {
+    test("converts to string schema", () => {
+      const result = typeToSchemaObject(stringType(), new TypeTable());
+      expect(result).toEqual({ type: "string" });
+    });
+  });
+
+  describe("String literal type", () => {
+    test("converts to string schema with enum", () => {
+      const result = typeToSchemaObject(
+        stringLiteralType("value"),
+        new TypeTable()
+      );
+      expect(result).toEqual({ type: "string", enum: ["value"] });
+    });
+  });
+
+  describe("Float type", () => {
+    test("converts to number schema with float format", () => {
+      const result = typeToSchemaObject(floatType(), new TypeTable());
+      expect(result).toEqual({ type: "number", format: "float" });
+    });
+  });
+
+  describe("Double type", () => {
+    test("converts to number schema with double format", () => {
+      const result = typeToSchemaObject(doubleType(), new TypeTable());
+      expect(result).toEqual({ type: "number", format: "double" });
+    });
+  });
+
+  describe("Float literal type", () => {
+    test("converts to number schema with float format and enum", () => {
+      const result = typeToSchemaObject(floatLiteralType(3.5), new TypeTable());
+      expect(result).toEqual({ type: "number", format: "float", enum: [3.5] });
+    });
+  });
+
+  describe("Int32 type", () => {
+    test("converts to integer schema with int32 format", () => {
+      const result = typeToSchemaObject(int32Type(), new TypeTable());
+      expect(result).toEqual({ type: "integer", format: "int32" });
+    });
+  });
+
+  describe("Int64 type", () => {
+    test("converts to integer schema with int64 format", () => {
+      const result = typeToSchemaObject(int64Type(), new TypeTable());
+      expect(result).toEqual({ type: "integer", format: "int64" });
+    });
+  });
+
+  describe("Int literal type", () => {
+    test("converts to integer schema with int32 format and enum", () => {
+      const result = typeToSchemaObject(intLiteralType(4), new TypeTable());
+      expect(result).toEqual({ type: "integer", format: "int32", enum: [4] });
+    });
+  });
+
+  describe("Date type", () => {
+    test("converts to string schema with date format", () => {
+      const result = typeToSchemaObject(dateType(), new TypeTable());
+      expect(result).toEqual({ type: "string", format: "date" });
+    });
+  });
+
+  describe("Date time type", () => {
+    test("converts to string schema with date-time format", () => {
+      const result = typeToSchemaObject(dateTimeType(), new TypeTable());
+      expect(result).toEqual({ type: "string", format: "date-time" });
+    });
+  });
+
+  describe("Object type", () => {
+    test("converts to object schema", () => {
+      const result = typeToSchemaObject(
+        objectType([
+          { name: "a", type: stringType(), optional: false },
+          { name: "b", type: stringType(), optional: true }
+        ]),
+        new TypeTable()
+      );
+      expect(result).toEqual({
+        type: "object",
+        properties: {
+          a: { type: "string" },
+          b: { type: "string" }
+        },
+        required: ["a"]
+      });
+    });
+  });
+
+  describe("Array type", () => {
+    test("converts to array schema", () => {
+      const result = typeToSchemaObject(
+        arrayType(stringType()),
+        new TypeTable()
+      );
+      expect(result).toEqual({
+        type: "array",
+        items: { type: "string" }
+      });
+    });
+  });
+
+  describe("Union type", () => {
+    describe("single type and null", () => {
+      test("boolean | null", () => {
+        const result = typeToSchemaObject(
+          unionType([booleanType(), nullType()]),
+          new TypeTable()
+        );
+        expect(result).toEqual({ type: "boolean", "x-nullable": true });
+      });
+
+      test("true | null", () => {
+        const result = typeToSchemaObject(
+          unionType([booleanLiteralType(true), nullType()]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "boolean",
+          enum: [true, null],
+          "x-nullable": true
+        });
+      });
+
+      test("false | null", () => {
+        const result = typeToSchemaObject(
+          unionType([booleanLiteralType(false), nullType()]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "boolean",
+          enum: [false, null],
+          "x-nullable": true
+        });
+      });
+
+      test("string | null", () => {
+        const result = typeToSchemaObject(
+          unionType([stringType(), nullType()]),
+          new TypeTable()
+        );
+        expect(result).toEqual({ type: "string", "x-nullable": true });
+      });
+
+      test('"custom" | null', () => {
+        const result = typeToSchemaObject(
+          unionType([stringLiteralType("custom"), nullType()]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "string",
+          enum: ["custom", null],
+          "x-nullable": true
+        });
+      });
+
+      test("Float | null", () => {
+        const result = typeToSchemaObject(
+          unionType([floatType(), nullType()]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "number",
+          format: "float",
+          "x-nullable": true
+        });
+      });
+
+      test("Double | null", () => {
+        const result = typeToSchemaObject(
+          unionType([doubleType(), nullType()]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "number",
+          format: "double",
+          "x-nullable": true
+        });
+      });
+
+      test("3.5 | null", () => {
+        const result = typeToSchemaObject(
+          unionType([floatLiteralType(3.5), nullType()]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "number",
+          format: "float",
+          enum: [3.5, null],
+          "x-nullable": true
+        });
+      });
+
+      test("Int32 | null", () => {
+        const result = typeToSchemaObject(
+          unionType([int32Type(), nullType()]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "integer",
+          format: "int32",
+          "x-nullable": true
+        });
+      });
+
+      test("Int64 | null", () => {
+        const result = typeToSchemaObject(
+          unionType([int64Type(), nullType()]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "integer",
+          format: "int64",
+          "x-nullable": true
+        });
+      });
+
+      test("4 | null", () => {
+        const result = typeToSchemaObject(
+          unionType([intLiteralType(4), nullType()]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "integer",
+          format: "int32",
+          enum: [4, null],
+          "x-nullable": true
+        });
+      });
+
+      test("Date | null", () => {
+        const result = typeToSchemaObject(
+          unionType([dateType(), nullType()]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "string",
+          format: "date",
+          "x-nullable": true
+        });
+      });
+
+      test("DateTime | null", () => {
+        const result = typeToSchemaObject(
+          unionType([dateTimeType(), nullType()]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "string",
+          format: "date-time",
+          "x-nullable": true
+        });
+      });
+
+      test("{ a: string; b?: string; } | null", () => {
+        const result = typeToSchemaObject(
+          unionType([
+            objectType([
+              { name: "a", type: stringType(), optional: false },
+              { name: "b", type: stringType(), optional: true }
+            ]),
+            nullType()
+          ]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "object",
+          properties: {
+            a: { type: "string" },
+            b: { type: "string" }
+          },
+          required: ["a"],
+          "x-nullable": true
+        });
+      });
+
+      test("string[] | null", () => {
+        const result = typeToSchemaObject(
+          unionType([arrayType(stringType()), nullType()]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "array",
+          items: { type: "string" },
+          "x-nullable": true
+        });
+      });
+
+      test("CustomType | null", () => {
+        const typeTable = new TypeTable();
+        typeTable.add("CustomType", stringType());
+
+        const result = typeToSchemaObject(
+          unionType([referenceType("CustomType"), nullType()]),
+          typeTable
+        );
+        expect(result).toEqual({
+          allOf: [{ $ref: "#/definitions/CustomType" }],
+          "x-nullable": true
+        });
+      });
+    });
+
+    describe("multiple single type literals", () => {
+      test("true | false", () => {
+        const result = typeToSchemaObject(
+          unionType([booleanLiteralType(true), booleanLiteralType(false)]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "boolean",
+          enum: [true, false]
+        });
+      });
+
+      test("true | false | null", () => {
+        const result = typeToSchemaObject(
+          unionType([
+            booleanLiteralType(true),
+            booleanLiteralType(false),
+            nullType()
+          ]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "boolean",
+          enum: [true, false, null],
+          "x-nullable": true
+        });
+      });
+
+      test('"one" | "two" | "three"', () => {
+        const result = typeToSchemaObject(
+          unionType([
+            stringLiteralType("one"),
+            stringLiteralType("two"),
+            stringLiteralType("three")
+          ]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "string",
+          enum: ["one", "two", "three"]
+        });
+      });
+
+      test('"one" | "two" | "three" | null', () => {
+        const result = typeToSchemaObject(
+          unionType([
+            stringLiteralType("one"),
+            stringLiteralType("two"),
+            stringLiteralType("three"),
+            nullType()
+          ]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "string",
+          enum: ["one", "two", "three", null],
+          "x-nullable": true
+        });
+      });
+
+      test("1.1 | 1.2 | 1.3", () => {
+        const result = typeToSchemaObject(
+          unionType([
+            floatLiteralType(1.1),
+            floatLiteralType(1.2),
+            floatLiteralType(1.3)
+          ]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "number",
+          format: "float",
+          enum: [1.1, 1.2, 1.3]
+        });
+      });
+
+      test("1.1 | 1.2 | 1.3 | null", () => {
+        const result = typeToSchemaObject(
+          unionType([
+            floatLiteralType(1.1),
+            floatLiteralType(1.2),
+            floatLiteralType(1.3),
+            nullType()
+          ]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "number",
+          format: "float",
+          enum: [1.1, 1.2, 1.3, null],
+          "x-nullable": true
+        });
+      });
+
+      test("1 | 2 | 3", () => {
+        const result = typeToSchemaObject(
+          unionType([intLiteralType(1), intLiteralType(2), intLiteralType(3)]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "integer",
+          format: "int32",
+          enum: [1, 2, 3]
+        });
+      });
+
+      test("1 | 2 | 3 | null", () => {
+        const result = typeToSchemaObject(
+          unionType([
+            intLiteralType(1),
+            intLiteralType(2),
+            intLiteralType(3),
+            nullType()
+          ]),
+          new TypeTable()
+        );
+        expect(result).toEqual({
+          type: "integer",
+          format: "int32",
+          enum: [1, 2, 3, null],
+          "x-nullable": true
+        });
+      });
+    });
+
+    describe("multiple unique types", () => {
+      test("fails to convert to schema", () => {
+        expect(() =>
+          typeToSchemaObject(
+            unionType([stringType(), booleanType()]),
+            new TypeTable()
+          )
+        ).toThrowError("Unions are not supported in OpenAPI 2");
+      });
+    });
+  });
+
+  describe("referenceType", () => {
+    test("converts to reference object", () => {
+      const typeTable = new TypeTable();
+      typeTable.add("CustomType", stringType());
+
+      const result = typeToSchemaObject(referenceType("CustomType"), typeTable);
+      expect(result).toEqual({
+        $ref: "#/definitions/CustomType"
+      });
+    });
+  });
+});

--- a/lib/src/neu/generators/openapi2/openapi2-type-util.ts
+++ b/lib/src/neu/generators/openapi2/openapi2-type-util.ts
@@ -1,0 +1,252 @@
+import assertNever from "assert-never";
+import {
+  areBooleanLiteralTypes,
+  areFloatLiteralTypes,
+  areIntLiteralTypes,
+  areStringLiteralTypes,
+  ArrayType,
+  isNotNullType,
+  isNullType,
+  ObjectType,
+  ReferenceType,
+  Type,
+  TypeKind,
+  TypeTable,
+  UnionType
+} from "../../types";
+import {
+  AllOfSchemaObject,
+  ArraySchemaObject,
+  BooleanSchemaObject,
+  IntegerSchemaObject,
+  NumberSchemaObject,
+  ObjectPropertiesSchemaObject,
+  ObjectSchemaObject,
+  ReferenceSchemaObject,
+  SchemaObject,
+  StringSchemaObject
+} from "./openapi2-specification";
+
+export function typeToSchemaObject(
+  type: Type,
+  typeTable: TypeTable,
+  nullable?: boolean
+): SchemaObject {
+  switch (type.kind) {
+    case TypeKind.NULL:
+      throw new Error("Null must be part of a union for OpenAPI 2");
+    case TypeKind.BOOLEAN:
+      return booleanSchema({ nullable });
+    case TypeKind.BOOLEAN_LITERAL:
+      return booleanSchema({ values: [type.value], nullable });
+    case TypeKind.STRING:
+      return stringSchema({ nullable });
+    case TypeKind.STRING_LITERAL:
+      return stringSchema({ values: [type.value], nullable });
+    case TypeKind.FLOAT:
+      return numberSchema({ format: "float", nullable });
+    case TypeKind.DOUBLE:
+      return numberSchema({ format: "double", nullable });
+    case TypeKind.FLOAT_LITERAL:
+      return numberSchema({ values: [type.value], format: "float", nullable });
+    case TypeKind.INT32:
+      return integerSchema({ format: "int32", nullable });
+    case TypeKind.INT64:
+      return integerSchema({ format: "int64", nullable });
+    case TypeKind.INT_LITERAL:
+      return integerSchema({ values: [type.value], format: "int32", nullable });
+    case TypeKind.DATE:
+      return stringSchema({ format: "date", nullable });
+    case TypeKind.DATE_TIME:
+      return stringSchema({ format: "date-time", nullable });
+    case TypeKind.OBJECT:
+      return objectTypeToSchema(type, typeTable, nullable);
+    case TypeKind.ARRAY:
+      return arrayTypeToSchema(type, typeTable, nullable);
+    case TypeKind.UNION:
+      return unionTypeToSchema(type, typeTable);
+    case TypeKind.REFERENCE:
+      return referenceTypeToSchema(type, nullable);
+    default:
+      assertNever(type);
+  }
+}
+
+function booleanSchema(
+  opts: {
+    values?: boolean[];
+    nullable?: boolean;
+  } = {}
+): BooleanSchemaObject {
+  return {
+    type: "boolean",
+    enum: createEnum(opts.values, opts.nullable),
+    "x-nullable": opts.nullable || undefined
+  };
+}
+
+function stringSchema(
+  opts: {
+    values?: string[];
+    nullable?: boolean;
+    format?: StringSchemaObject["format"];
+  } = {}
+): StringSchemaObject {
+  return {
+    type: "string",
+    enum: createEnum(opts.values, opts.nullable),
+    format: opts.format,
+    "x-nullable": opts.nullable || undefined
+  };
+}
+
+function numberSchema(
+  opts: {
+    values?: number[];
+    nullable?: boolean;
+    format?: NumberSchemaObject["format"];
+  } = {}
+): NumberSchemaObject {
+  return {
+    type: "number",
+    enum: createEnum(opts.values, opts.nullable),
+    format: opts.format,
+    "x-nullable": opts.nullable || undefined
+  };
+}
+
+function integerSchema(
+  opts: {
+    values?: number[];
+    nullable?: boolean;
+    format?: IntegerSchemaObject["format"];
+  } = {}
+): IntegerSchemaObject {
+  return {
+    type: "integer",
+    enum: createEnum(opts.values, opts.nullable),
+    format: opts.format,
+    "x-nullable": opts.nullable || undefined
+  };
+}
+
+function objectTypeToSchema(
+  type: ObjectType,
+  typeTable: TypeTable,
+  nullable?: boolean
+): ObjectSchemaObject {
+  const properties =
+    type.properties.length > 0
+      ? type.properties.reduce<ObjectPropertiesSchemaObject>(
+          (acc, property) => {
+            acc[property.name] = typeToSchemaObject(property.type, typeTable);
+            return acc;
+          },
+          {}
+        )
+      : undefined;
+
+  const requiredProperties = type.properties
+    .filter(p => !p.optional)
+    .map(p => p.name);
+  const required =
+    requiredProperties.length > 0 ? requiredProperties : undefined;
+
+  return {
+    type: "object",
+    properties,
+    required,
+    "x-nullable": nullable || undefined
+  };
+}
+
+function arrayTypeToSchema(
+  type: ArrayType,
+  typeTable: TypeTable,
+  nullable?: boolean
+): ArraySchemaObject {
+  return {
+    type: "array",
+    items: typeToSchemaObject(type.elementType, typeTable),
+    "x-nullable": nullable || undefined
+  };
+}
+
+/**
+ * Unions are NOT flattened
+ */
+function unionTypeToSchema(
+  type: UnionType,
+  typeTable: TypeTable
+): SchemaObject {
+  // Sanity check
+  if (type.types.length === 0) {
+    throw new Error("Unexpected type: union with no types");
+  }
+
+  const nullable = type.types.some(isNullType);
+  const nonNullTypes = type.types.filter(isNotNullType);
+
+  switch (nonNullTypes.length) {
+    case 0: // previous guard guarantees only null was present
+      throw new Error("Null must be part of a union for OpenAPI 2");
+    case 1: // not an OpenAPI union, but a single type, possibly nullable
+      return typeToSchemaObject(nonNullTypes[0], typeTable, nullable);
+    default:
+      if (areBooleanLiteralTypes(nonNullTypes)) {
+        return booleanSchema({
+          values: nonNullTypes.map(t => t.value),
+          nullable
+        });
+      } else if (areStringLiteralTypes(nonNullTypes)) {
+        return stringSchema({
+          values: nonNullTypes.map(t => t.value),
+          nullable
+        });
+      } else if (areFloatLiteralTypes(nonNullTypes)) {
+        return numberSchema({
+          values: nonNullTypes.map(t => t.value),
+          format: "float",
+          nullable
+        });
+      } else if (areIntLiteralTypes(nonNullTypes)) {
+        return integerSchema({
+          values: nonNullTypes.map(t => t.value),
+          format: "int32",
+          nullable
+        });
+      } else {
+        // See https://github.com/OAI/OpenAPI-Specification/issues/333
+        throw new Error(`Unions are not supported in OpenAPI 2`);
+      }
+  }
+}
+
+function referenceTypeToSchema(
+  type: ReferenceType,
+  nullable?: boolean
+): ReferenceSchemaObject | AllOfSchemaObject {
+  if (nullable) {
+    return {
+      "x-nullable": true,
+      allOf: [{ $ref: referenceObjectValue(type.name) }]
+    };
+  } else {
+    return { $ref: referenceObjectValue(type.name) };
+  }
+}
+
+function referenceObjectValue(referenceName: string): string {
+  return `#/definitions/${referenceName}`;
+}
+
+/**
+ * Enum generation helper
+ */
+function createEnum<T>(
+  values?: T[],
+  nullable?: boolean
+): Array<T | null> | undefined {
+  if (!values) return;
+  return nullable ? [...values, null] : values;
+}


### PR DESCRIPTION
## Description, Motivation and Context
This PR adds a schema type utility for generating OpenAPI 2 compatible [Schema Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schemaObject)
