### PR TITLE
Add OpenAPI 2 parameter utility

### DIFF
--- a/lib/src/neu/generators/openapi2/openapi2-parameter-util-pathparam.spec.ts
+++ b/lib/src/neu/generators/openapi2/openapi2-parameter-util-pathparam.spec.ts
@@ -1,0 +1,280 @@
+import { PathParam } from "../../definitions";
+import {
+  arrayType,
+  booleanLiteralType,
+  booleanType,
+  dateTimeType,
+  dateType,
+  doubleType,
+  floatLiteralType,
+  floatType,
+  int32Type,
+  int64Type,
+  intLiteralType,
+  nullType,
+  objectType,
+  referenceType,
+  stringLiteralType,
+  stringType,
+  TypeTable,
+  unionType
+} from "../../types";
+import { pathParamToPathParameterObject } from "./openapi2-parameter-util";
+
+describe("OpenAPI 2 parameter util: path param", () => {
+  test("Null type", () => {
+    const pathParam: PathParam = {
+      name: "param",
+      type: nullType()
+    };
+    expect(() =>
+      pathParamToPathParameterObject(pathParam, new TypeTable())
+    ).toThrowError("Null is not supported for parameters in OpenAPI 2");
+  });
+
+  test("Boolean type", () => {
+    const pathParam: PathParam = {
+      name: "param",
+      type: booleanType()
+    };
+    const result = pathParamToPathParameterObject(pathParam, new TypeTable());
+    expect(result).toEqual({
+      name: "param",
+      in: "path",
+      required: true,
+      type: "boolean"
+    });
+  });
+
+  test("Boolean literal type", () => {
+    const pathParam: PathParam = {
+      name: "param",
+      type: booleanLiteralType(true)
+    };
+    const result = pathParamToPathParameterObject(pathParam, new TypeTable());
+    expect(result).toEqual({
+      name: "param",
+      in: "path",
+      required: true,
+      type: "boolean",
+      enum: [true]
+    });
+  });
+
+  test("String type", () => {
+    const pathParam: PathParam = {
+      name: "param",
+      type: stringType()
+    };
+    const result = pathParamToPathParameterObject(pathParam, new TypeTable());
+    expect(result).toEqual({
+      name: "param",
+      in: "path",
+      required: true,
+      type: "string"
+    });
+  });
+
+  test("String literal type", () => {
+    const pathParam: PathParam = {
+      name: "param",
+      type: stringLiteralType("value")
+    };
+    const result = pathParamToPathParameterObject(pathParam, new TypeTable());
+    expect(result).toEqual({
+      name: "param",
+      in: "path",
+      required: true,
+      type: "string",
+      enum: ["value"]
+    });
+  });
+
+  test("Float type", () => {
+    const pathParam: PathParam = {
+      name: "param",
+      type: floatType()
+    };
+    const result = pathParamToPathParameterObject(pathParam, new TypeTable());
+    expect(result).toEqual({
+      name: "param",
+      in: "path",
+      required: true,
+      type: "number",
+      format: "float"
+    });
+  });
+
+  test("Double type", () => {
+    const pathParam: PathParam = {
+      name: "param",
+      type: doubleType()
+    };
+    const result = pathParamToPathParameterObject(pathParam, new TypeTable());
+    expect(result).toEqual({
+      name: "param",
+      in: "path",
+      required: true,
+      type: "number",
+      format: "double"
+    });
+  });
+
+  test("Float literal type", () => {
+    const pathParam: PathParam = {
+      name: "param",
+      type: floatLiteralType(0.4)
+    };
+    const result = pathParamToPathParameterObject(pathParam, new TypeTable());
+    expect(result).toEqual({
+      name: "param",
+      in: "path",
+      required: true,
+      type: "number",
+      format: "float",
+      enum: [0.4]
+    });
+  });
+
+  test("Int32 type", () => {
+    const pathParam: PathParam = {
+      name: "param",
+      type: int32Type()
+    };
+    const result = pathParamToPathParameterObject(pathParam, new TypeTable());
+    expect(result).toEqual({
+      name: "param",
+      in: "path",
+      required: true,
+      type: "integer",
+      format: "int32"
+    });
+  });
+
+  test("Int64 type", () => {
+    const pathParam: PathParam = {
+      name: "param",
+      type: int64Type()
+    };
+    const result = pathParamToPathParameterObject(pathParam, new TypeTable());
+    expect(result).toEqual({
+      name: "param",
+      in: "path",
+      required: true,
+      type: "integer",
+      format: "int64"
+    });
+  });
+
+  test("Int literal type", () => {
+    const pathParam: PathParam = {
+      name: "param",
+      type: intLiteralType(4)
+    };
+    const result = pathParamToPathParameterObject(pathParam, new TypeTable());
+    expect(result).toEqual({
+      name: "param",
+      in: "path",
+      required: true,
+      type: "integer",
+      format: "int32",
+      enum: [4]
+    });
+  });
+
+  test("Date type", () => {
+    const pathParam: PathParam = {
+      name: "param",
+      type: dateType()
+    };
+    const result = pathParamToPathParameterObject(pathParam, new TypeTable());
+    expect(result).toEqual({
+      name: "param",
+      in: "path",
+      required: true,
+      type: "string",
+      format: "date"
+    });
+  });
+
+  test("Date time type", () => {
+    const pathParam: PathParam = {
+      name: "param",
+      type: dateTimeType()
+    };
+    const result = pathParamToPathParameterObject(pathParam, new TypeTable());
+    expect(result).toEqual({
+      name: "param",
+      in: "path",
+      required: true,
+      type: "string",
+      format: "date-time"
+    });
+  });
+
+  test("Object type", () => {
+    const pathParam: PathParam = {
+      name: "param",
+      type: objectType([])
+    };
+    expect(() =>
+      pathParamToPathParameterObject(pathParam, new TypeTable())
+    ).toThrowError("Object is not supported for parameters in OpenAPI 2");
+  });
+
+  test("Reference types are deferenced", () => {
+    const pathParam: PathParam = {
+      name: "param",
+      type: referenceType("CustomType")
+    };
+    const typeTable = new TypeTable();
+    typeTable.add("CustomType", stringType());
+
+    const result = pathParamToPathParameterObject(pathParam, typeTable);
+    expect(result).toEqual({
+      name: "param",
+      in: "path",
+      required: true,
+      type: "string"
+    });
+  });
+
+  test("Array type", () => {
+    const pathParam: PathParam = {
+      name: "param",
+      type: arrayType(stringType())
+    };
+    const result = pathParamToPathParameterObject(pathParam, new TypeTable());
+    expect(result).toEqual({
+      name: "param",
+      in: "path",
+      required: true,
+      type: "array",
+      items: {
+        type: "string"
+      }
+    });
+  });
+
+  describe("Union type", () => {
+    test("Single type and null", () => {
+      const pathParam: PathParam = {
+        name: "param",
+        type: unionType([stringType(), nullType()])
+      };
+      expect(() =>
+        pathParamToPathParameterObject(pathParam, new TypeTable())
+      ).toThrowError("Unions are not supported for parameters in OpenAPI 2");
+    });
+
+    test("Multiple non-null types", () => {
+      const pathParam: PathParam = {
+        name: "param",
+        type: unionType([stringType(), booleanType()])
+      };
+      expect(() =>
+        pathParamToPathParameterObject(pathParam, new TypeTable())
+      ).toThrowError("Unions are not supported for parameters in OpenAPI 2");
+    });
+  });
+});

--- a/lib/src/neu/generators/openapi2/openapi2-parameter-util-queryparam.spec.ts
+++ b/lib/src/neu/generators/openapi2/openapi2-parameter-util-queryparam.spec.ts
@@ -1,0 +1,453 @@
+import { Config, QueryParam } from "../../definitions";
+import {
+  arrayType,
+  booleanLiteralType,
+  booleanType,
+  dateTimeType,
+  dateType,
+  doubleType,
+  floatLiteralType,
+  floatType,
+  int32Type,
+  int64Type,
+  intLiteralType,
+  nullType,
+  objectType,
+  referenceType,
+  stringLiteralType,
+  stringType,
+  TypeTable,
+  unionType
+} from "../../types";
+import { queryParamToQueryParameterObject } from "./openapi2-parameter-util";
+
+describe("OpenAPI 2 parameter util: query param", () => {
+  const ampersandConfig: Config = {
+    paramSerializationStrategy: {
+      query: {
+        array: "ampersand"
+      }
+    }
+  };
+  const commaConfig: Config = {
+    paramSerializationStrategy: {
+      query: {
+        array: "comma"
+      }
+    }
+  };
+
+  describe("Optionality", () => {
+    test("Optional param", () => {
+      const queryParam: QueryParam = {
+        name: "param",
+        type: stringType(),
+        optional: true
+      };
+      const result = queryParamToQueryParameterObject(
+        queryParam,
+        new TypeTable(),
+        ampersandConfig
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "query",
+        required: false,
+        type: "string"
+      });
+    });
+
+    test("Required param", () => {
+      const queryParam: QueryParam = {
+        name: "param",
+        type: stringType(),
+        optional: false
+      };
+      const result = queryParamToQueryParameterObject(
+        queryParam,
+        new TypeTable(),
+        ampersandConfig
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "query",
+        required: true,
+        type: "string"
+      });
+    });
+  });
+
+  describe("Types", () => {
+    test("Null type", () => {
+      const queryParam: QueryParam = {
+        name: "param",
+        type: nullType(),
+        optional: false
+      };
+      expect(() =>
+        queryParamToQueryParameterObject(
+          queryParam,
+          new TypeTable(),
+          ampersandConfig
+        )
+      ).toThrowError("Null is not supported for parameters in OpenAPI 2");
+    });
+
+    test("Boolean type", () => {
+      const queryParam: QueryParam = {
+        name: "param",
+        type: booleanType(),
+        optional: false
+      };
+      const result = queryParamToQueryParameterObject(
+        queryParam,
+        new TypeTable(),
+        ampersandConfig
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "query",
+        required: true,
+        type: "boolean"
+      });
+    });
+
+    test("Boolean literal type", () => {
+      const queryParam: QueryParam = {
+        name: "param",
+        type: booleanLiteralType(true),
+        optional: false
+      };
+      const result = queryParamToQueryParameterObject(
+        queryParam,
+        new TypeTable(),
+        ampersandConfig
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "query",
+        required: true,
+        type: "boolean",
+        enum: [true]
+      });
+    });
+
+    test("String type", () => {
+      const queryParam: QueryParam = {
+        name: "param",
+        type: stringType(),
+        optional: false
+      };
+      const result = queryParamToQueryParameterObject(
+        queryParam,
+        new TypeTable(),
+        ampersandConfig
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "query",
+        required: true,
+        type: "string"
+      });
+    });
+
+    test("String literal type", () => {
+      const queryParam: QueryParam = {
+        name: "param",
+        type: stringLiteralType("value"),
+        optional: false
+      };
+      const result = queryParamToQueryParameterObject(
+        queryParam,
+        new TypeTable(),
+        ampersandConfig
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "query",
+        required: true,
+        type: "string",
+        enum: ["value"]
+      });
+    });
+
+    test("Float type", () => {
+      const queryParam: QueryParam = {
+        name: "param",
+        type: floatType(),
+        optional: false
+      };
+      const result = queryParamToQueryParameterObject(
+        queryParam,
+        new TypeTable(),
+        ampersandConfig
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "query",
+        required: true,
+        type: "number",
+        format: "float"
+      });
+    });
+
+    test("Double type", () => {
+      const queryParam: QueryParam = {
+        name: "param",
+        type: doubleType(),
+        optional: false
+      };
+      const result = queryParamToQueryParameterObject(
+        queryParam,
+        new TypeTable(),
+        ampersandConfig
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "query",
+        required: true,
+        type: "number",
+        format: "double"
+      });
+    });
+
+    test("Float literal type", () => {
+      const queryParam: QueryParam = {
+        name: "param",
+        type: floatLiteralType(0.4),
+        optional: false
+      };
+      const result = queryParamToQueryParameterObject(
+        queryParam,
+        new TypeTable(),
+        ampersandConfig
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "query",
+        required: true,
+        type: "number",
+        format: "float",
+        enum: [0.4]
+      });
+    });
+
+    test("Int32 type", () => {
+      const queryParam: QueryParam = {
+        name: "param",
+        type: int32Type(),
+        optional: false
+      };
+      const result = queryParamToQueryParameterObject(
+        queryParam,
+        new TypeTable(),
+        ampersandConfig
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "query",
+        required: true,
+        type: "integer",
+        format: "int32"
+      });
+    });
+
+    test("Int64 type", () => {
+      const queryParam: QueryParam = {
+        name: "param",
+        type: int64Type(),
+        optional: false
+      };
+      const result = queryParamToQueryParameterObject(
+        queryParam,
+        new TypeTable(),
+        ampersandConfig
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "query",
+        required: true,
+        type: "integer",
+        format: "int64"
+      });
+    });
+
+    test("Int literal type", () => {
+      const queryParam: QueryParam = {
+        name: "param",
+        type: intLiteralType(4),
+        optional: false
+      };
+      const result = queryParamToQueryParameterObject(
+        queryParam,
+        new TypeTable(),
+        ampersandConfig
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "query",
+        required: true,
+        type: "integer",
+        format: "int32",
+        enum: [4]
+      });
+    });
+
+    test("Date type", () => {
+      const queryParam: QueryParam = {
+        name: "param",
+        type: dateType(),
+        optional: false
+      };
+      const result = queryParamToQueryParameterObject(
+        queryParam,
+        new TypeTable(),
+        ampersandConfig
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "query",
+        required: true,
+        type: "string",
+        format: "date"
+      });
+    });
+
+    test("Date time type", () => {
+      const queryParam: QueryParam = {
+        name: "param",
+        type: dateTimeType(),
+        optional: false
+      };
+      const result = queryParamToQueryParameterObject(
+        queryParam,
+        new TypeTable(),
+        ampersandConfig
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "query",
+        required: true,
+        type: "string",
+        format: "date-time"
+      });
+    });
+
+    test("Object type", () => {
+      const queryParam: QueryParam = {
+        name: "param",
+        type: objectType([]),
+        optional: false
+      };
+      expect(() =>
+        queryParamToQueryParameterObject(
+          queryParam,
+          new TypeTable(),
+          ampersandConfig
+        )
+      ).toThrowError("Object is not supported for parameters in OpenAPI 2");
+    });
+
+    test("Reference types are deferenced", () => {
+      const queryParam: QueryParam = {
+        name: "param",
+        type: referenceType("CustomType"),
+        optional: false
+      };
+      const typeTable = new TypeTable();
+      typeTable.add("CustomType", stringType());
+
+      const result = queryParamToQueryParameterObject(
+        queryParam,
+        typeTable,
+        ampersandConfig
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "query",
+        required: true,
+        type: "string"
+      });
+    });
+
+    describe("Array type", () => {
+      test("Ampersand serialization strategy", () => {
+        const queryParam: QueryParam = {
+          name: "param",
+          type: arrayType(stringType()),
+          optional: false
+        };
+        const result = queryParamToQueryParameterObject(
+          queryParam,
+          new TypeTable(),
+          ampersandConfig
+        );
+        expect(result).toEqual({
+          name: "param",
+          in: "query",
+          required: true,
+          type: "array",
+          items: {
+            type: "string"
+          },
+          collectionFormat: "multi"
+        });
+      });
+
+      test("Comma serialization strategy", () => {
+        const queryParam: QueryParam = {
+          name: "param",
+          type: arrayType(stringType()),
+          optional: false
+        };
+        const result = queryParamToQueryParameterObject(
+          queryParam,
+          new TypeTable(),
+          commaConfig
+        );
+        expect(result).toEqual({
+          name: "param",
+          in: "query",
+          required: true,
+          type: "array",
+          items: {
+            type: "string"
+          },
+          collectionFormat: "csv"
+        });
+      });
+    });
+
+    describe("Union type", () => {
+      test("Single type and null", () => {
+        const queryParam: QueryParam = {
+          name: "param",
+          type: unionType([stringType(), nullType()]),
+          optional: false
+        };
+        expect(() =>
+          queryParamToQueryParameterObject(
+            queryParam,
+            new TypeTable(),
+            ampersandConfig
+          )
+        ).toThrowError("Unions are not supported for parameters in OpenAPI 2");
+      });
+
+      test("Multiple non-null types", () => {
+        const queryParam: QueryParam = {
+          name: "param",
+          type: unionType([stringType(), booleanType()]),
+          optional: false
+        };
+        expect(() =>
+          queryParamToQueryParameterObject(
+            queryParam,
+            new TypeTable(),
+            ampersandConfig
+          )
+        ).toThrowError("Unions are not supported for parameters in OpenAPI 2");
+      });
+    });
+  });
+});

--- a/lib/src/neu/generators/openapi2/openapi2-parameter-util-requestheader.spec.ts
+++ b/lib/src/neu/generators/openapi2/openapi2-parameter-util-requestheader.spec.ts
@@ -1,0 +1,377 @@
+import { Header } from "../../definitions";
+import {
+  arrayType,
+  booleanLiteralType,
+  booleanType,
+  dateTimeType,
+  dateType,
+  doubleType,
+  floatLiteralType,
+  floatType,
+  int32Type,
+  int64Type,
+  intLiteralType,
+  nullType,
+  objectType,
+  referenceType,
+  stringLiteralType,
+  stringType,
+  TypeTable,
+  unionType
+} from "../../types";
+import { requestHeaderToHeaderParameterObject } from "./openapi2-parameter-util";
+
+describe("OpenAPI 2 parameter util: request header", () => {
+  describe("Optionality", () => {
+    test("Optional header", () => {
+      const header: Header = {
+        name: "param",
+        type: stringType(),
+        optional: true
+      };
+      const result = requestHeaderToHeaderParameterObject(
+        header,
+        new TypeTable()
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "header",
+        required: false,
+        type: "string"
+      });
+    });
+
+    test("Required header", () => {
+      const header: Header = {
+        name: "param",
+        type: stringType(),
+        optional: false
+      };
+      const result = requestHeaderToHeaderParameterObject(
+        header,
+        new TypeTable()
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "header",
+        required: true,
+        type: "string"
+      });
+    });
+  });
+
+  describe("Types", () => {
+    test("Null type", () => {
+      const header: Header = {
+        name: "param",
+        type: nullType(),
+        optional: false
+      };
+      expect(() =>
+        requestHeaderToHeaderParameterObject(header, new TypeTable())
+      ).toThrowError("Null is not supported for parameters in OpenAPI 2");
+    });
+
+    test("Boolean type", () => {
+      const header: Header = {
+        name: "param",
+        type: booleanType(),
+        optional: false
+      };
+      const result = requestHeaderToHeaderParameterObject(
+        header,
+        new TypeTable()
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "header",
+        required: true,
+        type: "boolean"
+      });
+    });
+
+    test("Boolean literal type", () => {
+      const header: Header = {
+        name: "param",
+        type: booleanLiteralType(true),
+        optional: false
+      };
+      const result = requestHeaderToHeaderParameterObject(
+        header,
+        new TypeTable()
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "header",
+        required: true,
+        type: "boolean",
+        enum: [true]
+      });
+    });
+
+    test("String type", () => {
+      const header: Header = {
+        name: "param",
+        type: stringType(),
+        optional: false
+      };
+      const result = requestHeaderToHeaderParameterObject(
+        header,
+        new TypeTable()
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "header",
+        required: true,
+        type: "string"
+      });
+    });
+
+    test("String literal type", () => {
+      const header: Header = {
+        name: "param",
+        type: stringLiteralType("value"),
+        optional: false
+      };
+      const result = requestHeaderToHeaderParameterObject(
+        header,
+        new TypeTable()
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "header",
+        required: true,
+        type: "string",
+        enum: ["value"]
+      });
+    });
+
+    test("Float type", () => {
+      const header: Header = {
+        name: "param",
+        type: floatType(),
+        optional: false
+      };
+      const result = requestHeaderToHeaderParameterObject(
+        header,
+        new TypeTable()
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "header",
+        required: true,
+        type: "number",
+        format: "float"
+      });
+    });
+
+    test("Double type", () => {
+      const header: Header = {
+        name: "param",
+        type: doubleType(),
+        optional: false
+      };
+      const result = requestHeaderToHeaderParameterObject(
+        header,
+        new TypeTable()
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "header",
+        required: true,
+        type: "number",
+        format: "double"
+      });
+    });
+
+    test("Float literal type", () => {
+      const header: Header = {
+        name: "param",
+        type: floatLiteralType(0.4),
+        optional: false
+      };
+      const result = requestHeaderToHeaderParameterObject(
+        header,
+        new TypeTable()
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "header",
+        required: true,
+        type: "number",
+        format: "float",
+        enum: [0.4]
+      });
+    });
+
+    test("Int32 type", () => {
+      const header: Header = {
+        name: "param",
+        type: int32Type(),
+        optional: false
+      };
+      const result = requestHeaderToHeaderParameterObject(
+        header,
+        new TypeTable()
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "header",
+        required: true,
+        type: "integer",
+        format: "int32"
+      });
+    });
+
+    test("Int64 type", () => {
+      const header: Header = {
+        name: "param",
+        type: int64Type(),
+        optional: false
+      };
+      const result = requestHeaderToHeaderParameterObject(
+        header,
+        new TypeTable()
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "header",
+        required: true,
+        type: "integer",
+        format: "int64"
+      });
+    });
+
+    test("Int literal type", () => {
+      const header: Header = {
+        name: "param",
+        type: intLiteralType(4),
+        optional: false
+      };
+      const result = requestHeaderToHeaderParameterObject(
+        header,
+        new TypeTable()
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "header",
+        required: true,
+        type: "integer",
+        format: "int32",
+        enum: [4]
+      });
+    });
+
+    test("Date type", () => {
+      const header: Header = {
+        name: "param",
+        type: dateType(),
+        optional: false
+      };
+      const result = requestHeaderToHeaderParameterObject(
+        header,
+        new TypeTable()
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "header",
+        required: true,
+        type: "string",
+        format: "date"
+      });
+    });
+
+    test("Date time type", () => {
+      const header: Header = {
+        name: "param",
+        type: dateTimeType(),
+        optional: false
+      };
+      const result = requestHeaderToHeaderParameterObject(
+        header,
+        new TypeTable()
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "header",
+        required: true,
+        type: "string",
+        format: "date-time"
+      });
+    });
+
+    test("Object type", () => {
+      const header: Header = {
+        name: "param",
+        type: objectType([]),
+        optional: false
+      };
+      expect(() =>
+        requestHeaderToHeaderParameterObject(header, new TypeTable())
+      ).toThrowError("Object is not supported for parameters in OpenAPI 2");
+    });
+
+    test("Reference types are deferenced", () => {
+      const header: Header = {
+        name: "param",
+        type: referenceType("CustomType"),
+        optional: false
+      };
+      const typeTable = new TypeTable();
+      typeTable.add("CustomType", stringType());
+
+      const result = requestHeaderToHeaderParameterObject(header, typeTable);
+      expect(result).toEqual({
+        name: "param",
+        in: "header",
+        required: true,
+        type: "string"
+      });
+    });
+
+    test("Array type", () => {
+      const header: Header = {
+        name: "param",
+        type: arrayType(stringType()),
+        optional: false
+      };
+      const result = requestHeaderToHeaderParameterObject(
+        header,
+        new TypeTable()
+      );
+      expect(result).toEqual({
+        name: "param",
+        in: "header",
+        required: true,
+        type: "array",
+        items: {
+          type: "string"
+        }
+      });
+    });
+
+    describe("Union type", () => {
+      test("Single type and null", () => {
+        const header: Header = {
+          name: "param",
+          type: unionType([stringType(), nullType()]),
+          optional: false
+        };
+        expect(() =>
+          requestHeaderToHeaderParameterObject(header, new TypeTable())
+        ).toThrowError("Unions are not supported for parameters in OpenAPI 2");
+      });
+
+      test("Multiple non-null types", () => {
+        const header: Header = {
+          name: "param",
+          type: unionType([stringType(), booleanType()]),
+          optional: false
+        };
+        expect(() =>
+          requestHeaderToHeaderParameterObject(header, new TypeTable())
+        ).toThrowError("Unions are not supported for parameters in OpenAPI 2");
+      });
+    });
+  });
+});

--- a/lib/src/neu/generators/openapi2/openapi2-parameter-util-responseheader.spec.ts
+++ b/lib/src/neu/generators/openapi2/openapi2-parameter-util-responseheader.spec.ts
@@ -1,0 +1,284 @@
+import { Header } from "../../definitions";
+import {
+  arrayType,
+  booleanLiteralType,
+  booleanType,
+  dateTimeType,
+  dateType,
+  doubleType,
+  floatLiteralType,
+  floatType,
+  int32Type,
+  int64Type,
+  intLiteralType,
+  nullType,
+  objectType,
+  referenceType,
+  stringLiteralType,
+  stringType,
+  TypeTable,
+  unionType
+} from "../../types";
+import { responseHeaderToHeaderObject } from "./openapi2-parameter-util";
+
+describe("OpenAPI 2 parameter util: response header", () => {
+  describe("Optionality", () => {
+    test("Optional header has not effect", () => {
+      const header: Header = {
+        name: "param",
+        type: stringType(),
+        optional: true
+      };
+      const result = responseHeaderToHeaderObject(header, new TypeTable());
+      expect(result).toEqual({
+        type: "string"
+      });
+    });
+
+    test("Required header has no effect", () => {
+      const header: Header = {
+        name: "param",
+        type: stringType(),
+        optional: false
+      };
+      const result = responseHeaderToHeaderObject(header, new TypeTable());
+      expect(result).toEqual({
+        type: "string"
+      });
+    });
+  });
+
+  describe("Types", () => {
+    test("Null type", () => {
+      const header: Header = {
+        name: "param",
+        type: nullType(),
+        optional: false
+      };
+      expect(() =>
+        responseHeaderToHeaderObject(header, new TypeTable())
+      ).toThrowError("Null is not supported for parameters in OpenAPI 2");
+    });
+
+    test("Boolean type", () => {
+      const header: Header = {
+        name: "param",
+        type: booleanType(),
+        optional: false
+      };
+      const result = responseHeaderToHeaderObject(header, new TypeTable());
+      expect(result).toEqual({
+        type: "boolean"
+      });
+    });
+
+    test("Boolean literal type", () => {
+      const header: Header = {
+        name: "param",
+        type: booleanLiteralType(true),
+        optional: false
+      };
+      const result = responseHeaderToHeaderObject(header, new TypeTable());
+      expect(result).toEqual({
+        type: "boolean",
+        enum: [true]
+      });
+    });
+
+    test("String type", () => {
+      const header: Header = {
+        name: "param",
+        type: stringType(),
+        optional: false
+      };
+      const result = responseHeaderToHeaderObject(header, new TypeTable());
+      expect(result).toEqual({
+        type: "string"
+      });
+    });
+
+    test("String literal type", () => {
+      const header: Header = {
+        name: "param",
+        type: stringLiteralType("value"),
+        optional: false
+      };
+      const result = responseHeaderToHeaderObject(header, new TypeTable());
+      expect(result).toEqual({
+        type: "string",
+        enum: ["value"]
+      });
+    });
+
+    test("Float type", () => {
+      const header: Header = {
+        name: "param",
+        type: floatType(),
+        optional: false
+      };
+      const result = responseHeaderToHeaderObject(header, new TypeTable());
+      expect(result).toEqual({
+        type: "number",
+        format: "float"
+      });
+    });
+
+    test("Double type", () => {
+      const header: Header = {
+        name: "param",
+        type: doubleType(),
+        optional: false
+      };
+      const result = responseHeaderToHeaderObject(header, new TypeTable());
+      expect(result).toEqual({
+        type: "number",
+        format: "double"
+      });
+    });
+
+    test("Float literal type", () => {
+      const header: Header = {
+        name: "param",
+        type: floatLiteralType(0.4),
+        optional: false
+      };
+      const result = responseHeaderToHeaderObject(header, new TypeTable());
+      expect(result).toEqual({
+        type: "number",
+        format: "float",
+        enum: [0.4]
+      });
+    });
+
+    test("Int32 type", () => {
+      const header: Header = {
+        name: "param",
+        type: int32Type(),
+        optional: false
+      };
+      const result = responseHeaderToHeaderObject(header, new TypeTable());
+      expect(result).toEqual({
+        type: "integer",
+        format: "int32"
+      });
+    });
+
+    test("Int64 type", () => {
+      const header: Header = {
+        name: "param",
+        type: int64Type(),
+        optional: false
+      };
+      const result = responseHeaderToHeaderObject(header, new TypeTable());
+      expect(result).toEqual({
+        type: "integer",
+        format: "int64"
+      });
+    });
+
+    test("Int literal type", () => {
+      const header: Header = {
+        name: "param",
+        type: intLiteralType(4),
+        optional: false
+      };
+      const result = responseHeaderToHeaderObject(header, new TypeTable());
+      expect(result).toEqual({
+        type: "integer",
+        format: "int32",
+        enum: [4]
+      });
+    });
+
+    test("Date type", () => {
+      const header: Header = {
+        name: "param",
+        type: dateType(),
+        optional: false
+      };
+      const result = responseHeaderToHeaderObject(header, new TypeTable());
+      expect(result).toEqual({
+        type: "string",
+        format: "date"
+      });
+    });
+
+    test("Date time type", () => {
+      const header: Header = {
+        name: "param",
+        type: dateTimeType(),
+        optional: false
+      };
+      const result = responseHeaderToHeaderObject(header, new TypeTable());
+      expect(result).toEqual({
+        type: "string",
+        format: "date-time"
+      });
+    });
+
+    test("Object type", () => {
+      const header: Header = {
+        name: "param",
+        type: objectType([]),
+        optional: false
+      };
+      expect(() =>
+        responseHeaderToHeaderObject(header, new TypeTable())
+      ).toThrowError("Object is not supported for parameters in OpenAPI 2");
+    });
+
+    test("Reference types are deferenced", () => {
+      const header: Header = {
+        name: "param",
+        type: referenceType("CustomType"),
+        optional: false
+      };
+      const typeTable = new TypeTable();
+      typeTable.add("CustomType", stringType());
+
+      const result = responseHeaderToHeaderObject(header, typeTable);
+      expect(result).toEqual({
+        type: "string"
+      });
+    });
+
+    test("Array type", () => {
+      const header: Header = {
+        name: "param",
+        type: arrayType(stringType()),
+        optional: false
+      };
+      const result = responseHeaderToHeaderObject(header, new TypeTable());
+      expect(result).toEqual({
+        type: "array",
+        items: {
+          type: "string"
+        }
+      });
+    });
+
+    describe("Union type", () => {
+      test("Single type and null", () => {
+        const header: Header = {
+          name: "param",
+          type: unionType([stringType(), nullType()]),
+          optional: false
+        };
+        expect(() =>
+          responseHeaderToHeaderObject(header, new TypeTable())
+        ).toThrowError("Unions are not supported for parameters in OpenAPI 2");
+      });
+
+      test("Multiple non-null types", () => {
+        const header: Header = {
+          name: "param",
+          type: unionType([stringType(), booleanType()]),
+          optional: false
+        };
+        expect(() =>
+          responseHeaderToHeaderObject(header, new TypeTable())
+        ).toThrowError("Unions are not supported for parameters in OpenAPI 2");
+      });
+    });
+  });
+});

--- a/lib/src/neu/generators/openapi2/openapi2-parameter-util.ts
+++ b/lib/src/neu/generators/openapi2/openapi2-parameter-util.ts
@@ -1,0 +1,249 @@
+import assertNever from "assert-never";
+import { Config, Header, PathParam, QueryParam } from "../../definitions";
+import {
+  ArrayType,
+  dereferenceType,
+  isArrayType,
+  ReferenceType,
+  Type,
+  TypeKind,
+  TypeTable
+} from "../../types";
+import {
+  ArrayMultiParameterObjectType,
+  ArrayParameterObjectType,
+  BooleanParameterObjectType,
+  HeaderObject,
+  HeaderParameterObject,
+  IntegerParameterObjectType,
+  ItemsObject,
+  NumberParameterObjectType,
+  PathParameterObject,
+  QueryParameterObject,
+  StringParameterObject
+} from "./openapi2-specification";
+
+export function pathParamToPathParameterObject(
+  pathParam: PathParam,
+  typeTable: TypeTable
+): PathParameterObject {
+  const concreteType = dereferenceType(pathParam.type, typeTable);
+
+  return {
+    name: pathParam.name,
+    in: "path",
+    description: pathParam.description,
+    required: true,
+    ...(isArrayType(concreteType)
+      ? pathParamArrayTypeToParameterArrayTypeObject(concreteType, typeTable)
+      : basicTypeToParameterBasicTypeObject(concreteType))
+  };
+}
+
+export function requestHeaderToHeaderParameterObject(
+  header: Header,
+  typeTable: TypeTable
+): HeaderParameterObject {
+  const concreteType = dereferenceType(header.type, typeTable);
+
+  return {
+    name: header.name,
+    in: "header",
+    description: header.description,
+    required: !header.optional,
+    ...(isArrayType(concreteType)
+      ? headerArrayTypeToParameterArrayTypeObject(concreteType, typeTable)
+      : basicTypeToParameterBasicTypeObject(concreteType))
+  };
+}
+
+export function queryParamToQueryParameterObject(
+  queryParam: QueryParam,
+  typeTable: TypeTable,
+  config: Config
+): QueryParameterObject {
+  const concreteType = dereferenceType(queryParam.type, typeTable);
+
+  return {
+    name: queryParam.name,
+    in: "query",
+    description: queryParam.description,
+    required: !queryParam.optional,
+    ...(isArrayType(concreteType)
+      ? queryParamArrayTypeToParameterArrayTypeObject(
+          concreteType,
+          typeTable,
+          config
+        )
+      : basicTypeToParameterBasicTypeObject(concreteType))
+  };
+}
+
+export function responseHeaderToHeaderObject(
+  header: Header,
+  typeTable: TypeTable
+): HeaderObject {
+  // TODO: warn header optionality is ignored for header object
+  return {
+    description: header.description,
+    ...typeToItemsObject(header.type, typeTable)
+  };
+}
+
+function basicTypeToParameterBasicTypeObject(
+  type: Exclude<Type, ArrayType | ReferenceType>
+):
+  | StringParameterObject
+  | NumberParameterObjectType
+  | IntegerParameterObjectType
+  | BooleanParameterObjectType {
+  switch (type.kind) {
+    case TypeKind.NULL:
+      throw new Error("Null is not supported for parameters in OpenAPI 2");
+    case TypeKind.BOOLEAN:
+      return booleanParameterObject();
+    case TypeKind.BOOLEAN_LITERAL:
+      return booleanParameterObject({ values: [type.value] });
+    case TypeKind.STRING:
+      return stringParameterObject();
+    case TypeKind.STRING_LITERAL:
+      return stringParameterObject({ values: [type.value] });
+    case TypeKind.FLOAT:
+      return numberParameterObject({ format: "float" });
+    case TypeKind.DOUBLE:
+      return numberParameterObject({ format: "double" });
+    case TypeKind.FLOAT_LITERAL:
+      return numberParameterObject({
+        values: [type.value],
+        format: "float"
+      });
+    case TypeKind.INT32:
+      return integerParameterObject({ format: "int32" });
+    case TypeKind.INT64:
+      return integerParameterObject({ format: "int64" });
+    case TypeKind.INT_LITERAL:
+      return integerParameterObject({
+        values: [type.value],
+        format: "int32"
+      });
+    case TypeKind.DATE:
+      return stringParameterObject({ format: "date" });
+    case TypeKind.DATE_TIME:
+      return stringParameterObject({ format: "date-time" });
+    case TypeKind.OBJECT:
+      throw new Error("Object is not supported for parameters in OpenAPI 2");
+    case TypeKind.UNION:
+      throw new Error("Unions are not supported for parameters in OpenAPI 2");
+    default:
+      assertNever(type);
+  }
+}
+
+function booleanParameterObject(
+  opts: { values?: boolean[] } = {}
+): BooleanParameterObjectType {
+  return {
+    type: "boolean",
+    enum: opts.values
+  };
+}
+
+function stringParameterObject(
+  opts: {
+    values?: string[];
+    format?: StringParameterObject["format"];
+  } = {}
+): StringParameterObject {
+  return {
+    type: "string",
+    enum: opts.values,
+    format: opts.format
+  };
+}
+
+function numberParameterObject(
+  opts: {
+    values?: number[];
+    format?: NumberParameterObjectType["format"];
+  } = {}
+): NumberParameterObjectType {
+  return {
+    type: "number",
+    enum: opts.values,
+    format: opts.format
+  };
+}
+
+function integerParameterObject(
+  opts: {
+    values?: number[];
+    format?: IntegerParameterObjectType["format"];
+  } = {}
+): IntegerParameterObjectType {
+  return {
+    type: "integer",
+    enum: opts.values,
+    format: opts.format
+  };
+}
+
+const pathParamArrayTypeToParameterArrayTypeObject = arrayTypeToParameterArrayTypeObject;
+const headerArrayTypeToParameterArrayTypeObject = arrayTypeToParameterArrayTypeObject;
+const queryParamArrayTypeToParameterArrayTypeObject = (
+  type: ArrayType,
+  typeTable: TypeTable,
+  config: Config
+) =>
+  arrayTypeToParameterArrayMultiTypeObject(
+    type,
+    typeTable,
+    configToQueryParameterCollectionFormat(config)
+  );
+
+function arrayTypeToParameterArrayTypeObject(
+  type: ArrayType,
+  typeTable: TypeTable,
+  collectionFormat?: ArrayParameterObjectType["collectionFormat"]
+): ArrayParameterObjectType {
+  return {
+    type: "array",
+    collectionFormat,
+    items: typeToItemsObject(type.elementType, typeTable)
+  };
+}
+
+function arrayTypeToParameterArrayMultiTypeObject(
+  type: ArrayType,
+  typeTable: TypeTable,
+  collectionFormat?: ArrayMultiParameterObjectType["collectionFormat"]
+): ArrayMultiParameterObjectType {
+  return {
+    type: "array",
+    collectionFormat,
+    items: typeToItemsObject(type.elementType, typeTable)
+  };
+}
+
+function typeToItemsObject(type: Type, typeTable: TypeTable): ItemsObject {
+  const concreteType = dereferenceType(type, typeTable);
+
+  return isArrayType(concreteType)
+    ? {
+        type: "array",
+        items: typeToItemsObject(concreteType.elementType, typeTable)
+      }
+    : basicTypeToParameterBasicTypeObject(concreteType);
+}
+
+function configToQueryParameterCollectionFormat(
+  config: Config
+): ArrayMultiParameterObjectType["collectionFormat"] {
+  switch (config.paramSerializationStrategy.query.array) {
+    case "ampersand":
+      return "multi";
+    case "comma":
+      return "csv";
+    default:
+      assertNever(config.paramSerializationStrategy.query.array);
+  }
+}


### PR DESCRIPTION
## Description, Motivation and Context
This PR adds an OpenAPI 2 parameter utility to facilitate generation of [Parameter Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject)
