### PR TITLE
Array type parsing fix

### DIFF
--- a/lib/src/neu/generators/openapi3/openapi3-type-util.spec.ts
+++ b/lib/src/neu/generators/openapi3/openapi3-type-util.spec.ts
@@ -673,13 +673,13 @@ describe("OpenAPI 3 type util", () => {
         });
       });
 
-      test("CustomType | string", () => {
+      test("CustomType | boolean", () => {
         const typeTable = new TypeTable();
         typeTable.add("CustomType", stringType());
 
         const result = typeToSchemaOrReferenceObject(
           unionType([referenceType("CustomType"), booleanType()]),
-          new TypeTable()
+          typeTable
         );
         expect(result).toEqual({
           oneOf: [

--- a/lib/src/neu/parsers/__spec-examples__/types.ts
+++ b/lib/src/neu/parsers/__spec-examples__/types.ts
@@ -34,14 +34,15 @@ interface TypeInterface {
     propertyB?: boolean;
   };
   array: boolean[];
-  Array: Array<{ a: boolean }>;
+  arrayConstructor: Array<{ a: boolean }>;
   union: boolean | Date | null;
   unionDiscriminated: DiscriminatedUnionElementA | DiscriminatedUnionElementB;
   unionDiscriminatedNullable:
     | DiscriminatedUnionElementA
     | DiscriminatedUnionElementB
     | null;
-  alias: AliasString;
+  aliasString: AliasString;
+  aliasArray: AliasArray;
   interface: Interface;
   interfaceExtends: InterfaceExtends;
   indexedAccess: IndexedAccess["root"];
@@ -66,6 +67,8 @@ interface DiscriminatedUnionElementB {
 }
 
 type AliasString = string;
+
+type AliasArray = string[];
 
 interface Interface {
   interfaceProperty: boolean;

--- a/lib/src/neu/parsers/type-parser.spec.ts
+++ b/lib/src/neu/parsers/type-parser.spec.ts
@@ -252,8 +252,10 @@ describe("type parser", () => {
     );
   });
 
-  test("parses complex Array", () => {
-    const type = interphace.getPropertyOrThrow("Array").getTypeNodeOrThrow();
+  test("parses Array constructor", () => {
+    const type = interphace
+      .getPropertyOrThrow("arrayConstructor")
+      .getTypeNodeOrThrow();
 
     expect(parseType(type, typeTable, lociTable).unwrapOrThrow()).toStrictEqual(
       {
@@ -346,8 +348,10 @@ describe("type parser", () => {
     );
   });
 
-  test("parses type aliases", () => {
-    const type = interphace.getPropertyOrThrow("alias").getTypeNodeOrThrow();
+  test("parses basic type aliases", () => {
+    const type = interphace
+      .getPropertyOrThrow("aliasString")
+      .getTypeNodeOrThrow();
 
     expect(parseType(type, typeTable, lociTable).unwrapOrThrow()).toStrictEqual(
       {
@@ -358,6 +362,26 @@ describe("type parser", () => {
     expect(typeTable.size).toBe(1);
     expect(typeTable.getOrError("AliasString")).toStrictEqual({
       kind: TypeKind.STRING
+    });
+  });
+
+  test("parses array type aliases", () => {
+    const type = interphace
+      .getPropertyOrThrow("aliasArray")
+      .getTypeNodeOrThrow();
+
+    expect(parseType(type, typeTable, lociTable).unwrapOrThrow()).toStrictEqual(
+      {
+        kind: TypeKind.REFERENCE,
+        name: "AliasArray"
+      }
+    );
+    expect(typeTable.size).toBe(1);
+    expect(typeTable.getOrError("AliasArray")).toStrictEqual({
+      kind: TypeKind.ARRAY,
+      elementType: {
+        kind: TypeKind.STRING
+      }
     });
   });
 

--- a/lib/src/neu/parsers/type-parser.ts
+++ b/lib/src/neu/parsers/type-parser.ts
@@ -59,7 +59,11 @@ export function parseType(
 ): Result<Type, ParserError> {
   // Type references must be parsed first to ensure internal type aliases are handled
   if (TypeGuards.isTypeReferenceNode(typeNode)) {
-    if (typeNode.getType().isArray()) {
+    if (
+      typeNode.getType().isArray() &&
+      typeNode.getTypeArguments().length > 0
+    ) {
+      // TypeScript forbids use of Array constructor without at least one type argument
       return parseArrayConstructorType(typeNode, typeTable, lociTable);
     }
     return parseTypeReference(typeNode, typeTable, lociTable);


### PR DESCRIPTION
## Description, Motivation and Context
Type aliases referencing basic arrays (non-Array constructor) are incorrectly treated as Array constructor types, which results in a parser error as Array constructor types expect type arguments (basic arrays do not). This PR fixes this behaviour by checking type arguments `.length` to determine if an array is an Array constructor. The TypeScript compiler forbids Array constructors without type arguments, so this can be safely assumed.

