### PR TITLE
[AUTH-22] lint validation for request objects

### DIFF
--- a/lib/src/linting/rules/__spec-examples__/no-primitives-in-request/request-as-array.ts
+++ b/lib/src/linting/rules/__spec-examples__/no-primitives-in-request/request-as-array.ts
@@ -1,0 +1,15 @@
+import { api, body, request, endpoint } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @request
+  request(@body body: UserName) {}
+}
+
+type UserName = string[];

--- a/lib/src/linting/rules/__spec-examples__/no-primitives-in-request/request-as-object.ts
+++ b/lib/src/linting/rules/__spec-examples__/no-primitives-in-request/request-as-object.ts
@@ -1,0 +1,17 @@
+import { api, body, request, endpoint, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @request
+  request(@body body: Body) {}
+}
+
+interface Body {
+  body: String;
+}

--- a/lib/src/linting/rules/__spec-examples__/no-primitives-in-request/request-with-primitives.ts
+++ b/lib/src/linting/rules/__spec-examples__/no-primitives-in-request/request-with-primitives.ts
@@ -1,0 +1,15 @@
+import { api, body, request, endpoint } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @request
+  request(@body body: UserName) {}
+}
+
+type UserName = string;

--- a/lib/src/linting/rules/no-primitives-in-request.spec.ts
+++ b/lib/src/linting/rules/no-primitives-in-request.spec.ts
@@ -1,0 +1,37 @@
+import { parseContract } from "../../parsers/contract-parser";
+import { createProjectFromExistingSourceFile } from "../../spec-helpers/helper";
+import { noPrimitivesInRequest } from "./no-primitives-in-request";
+
+describe("no-primitives-in-request linter rule", () => {
+  test("returns violations for endpoint with a request as primitives", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/no-primitives-in-request/request-with-primitives.ts`
+    ).file;
+    const { contract } = parseContract(file).unwrapOrThrow();
+    const result = noPrimitivesInRequest(contract);
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toEqual(
+      "Endpoint (Endpoint) must contain a request as an object"
+    );
+  });
+
+  test("returns violations for endpoint with a request as array", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/no-primitives-in-request/request-as-array.ts`
+    ).file;
+    const { contract } = parseContract(file).unwrapOrThrow();
+    const result = noPrimitivesInRequest(contract);
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toEqual(
+      "Endpoint (Endpoint) must contain a request as an object"
+    );
+  });
+
+  test("returns no violations for endpoint with a request as object", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/no-primitives-in-request/request-as-object.ts`
+    ).file;
+    const { contract } = parseContract(file).unwrapOrThrow();
+    expect(noPrimitivesInRequest(contract)).toHaveLength(0);
+  });
+});

--- a/lib/src/linting/rules/no-primitives-in-request.ts
+++ b/lib/src/linting/rules/no-primitives-in-request.ts
@@ -11,6 +11,7 @@ export function noPrimitivesInRequest(
   contract: Contract
 ): LintingRuleViolation[] {
   const violations: LintingRuleViolation[] = [];
+  const typeTable = TypeTable.fromArray(contract.types);
 
   contract.endpoints.forEach(endpoint => {
     const { request } = endpoint;
@@ -18,7 +19,6 @@ export function noPrimitivesInRequest(
     if (!body) {
       return;
     }
-    const typeTable = TypeTable.fromArray(contract.types);
     const bodyType = dereferenceType(body.type, typeTable);
 
     if (bodyType.kind !== "object") {

--- a/lib/src/linting/rules/no-primitives-in-request.ts
+++ b/lib/src/linting/rules/no-primitives-in-request.ts
@@ -1,0 +1,32 @@
+import { Contract } from "../../definitions";
+import { LintingRuleViolation } from "../rule";
+import { dereferenceType, TypeTable } from "../../types";
+
+/**
+ * Request types should always be object types
+ *
+ * @param contract a contract
+ */
+export function noPrimitivesInRequest(
+  contract: Contract
+): LintingRuleViolation[] {
+  const violations: LintingRuleViolation[] = [];
+
+  contract.endpoints.forEach(endpoint => {
+    const { request } = endpoint;
+    const body = request && request.body;
+    if (!body) {
+      return;
+    }
+    const typeTable = TypeTable.fromArray(contract.types);
+    const bodyType = dereferenceType(body.type, typeTable);
+
+    if (bodyType.kind !== "object") {
+      violations.push({
+        message: `Endpoint (${endpoint.name}) must contain a request as an object`
+      });
+    }
+  });
+
+  return violations;
+}

--- a/lib/src/linting/rules/no-primitives-in-request.ts
+++ b/lib/src/linting/rules/no-primitives-in-request.ts
@@ -1,6 +1,6 @@
 import { Contract } from "../../definitions";
 import { LintingRuleViolation } from "../rule";
-import { dereferenceType, TypeTable } from "../../types";
+import { dereferenceType, TypeTable, isObjectType } from "../../types";
 
 /**
  * Request types should always be object types
@@ -21,7 +21,7 @@ export function noPrimitivesInRequest(
     }
     const bodyType = dereferenceType(body.type, typeTable);
 
-    if (bodyType.kind !== "object") {
+    if (isObjectType(bodyType) === false) {
       violations.push({
         message: `Endpoint (${endpoint.name}) must contain a request as an object`
       });

--- a/lib/src/linting/rules/no-primitives-in-request.ts
+++ b/lib/src/linting/rules/no-primitives-in-request.ts
@@ -21,7 +21,7 @@ export function noPrimitivesInRequest(
     }
     const bodyType = dereferenceType(body.type, typeTable);
 
-    if (isObjectType(bodyType) === false) {
+    if (!isObjectType(bodyType)) {
       violations.push({
         message: `Endpoint (${endpoint.name}) must contain a request as an object`
       });


### PR DESCRIPTION
## Description, Motivation and Context

- Why is this change required?
- What does it do?
It adds a linting validation for an endpoint request making sure it's an object and not a primitive or array.

## Checklist:

- [x] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
