### PR TITLE
Add JsDoc support for reference types

### DIFF
--- a/lib/src/definitions.ts
+++ b/lib/src/definitions.ts
@@ -1,10 +1,10 @@
-import { Type } from "./types";
+import { Type, TypeDef } from "./types";
 
 export interface Contract {
   name: string;
   description?: string;
   config: Config;
-  types: { name: string; type: Type }[];
+  types: { name: string; typeDef: TypeDef }[];
   security?: SecurityHeader;
   endpoints: Endpoint[];
 }

--- a/lib/src/generators/json-schema/json-schema.ts
+++ b/lib/src/generators/json-schema/json-schema.ts
@@ -8,7 +8,7 @@ export function generateJsonSchema(contract: Contract): JsonSchema {
     definitions: contract.types.reduce<{
       [typeName: string]: JsonSchemaType;
     }>((acc, typeNode) => {
-      acc[typeNode.name] = typeToJsonSchemaType(typeNode.type);
+      acc[typeNode.name] = typeToJsonSchemaType(typeNode.typeDef.type);
       return acc;
     }, {})
   };

--- a/lib/src/generators/openapi2/openapi2-parameter-util-pathparam.spec.ts
+++ b/lib/src/generators/openapi2/openapi2-parameter-util-pathparam.spec.ts
@@ -228,7 +228,7 @@ describe("OpenAPI 2 parameter util: path param", () => {
       type: referenceType("CustomType")
     };
     const typeTable = new TypeTable();
-    typeTable.add("CustomType", stringType());
+    typeTable.add("CustomType", { type: stringType() });
 
     const result = pathParamToPathParameterObject(pathParam, typeTable);
     expect(result).toEqual({

--- a/lib/src/generators/openapi2/openapi2-parameter-util-queryparam.spec.ts
+++ b/lib/src/generators/openapi2/openapi2-parameter-util-queryparam.spec.ts
@@ -355,7 +355,7 @@ describe("OpenAPI 2 parameter util: query param", () => {
         optional: false
       };
       const typeTable = new TypeTable();
-      typeTable.add("CustomType", stringType());
+      typeTable.add("CustomType", { type: stringType() });
 
       const result = queryParamToQueryParameterObject(
         queryParam,

--- a/lib/src/generators/openapi2/openapi2-parameter-util-requestheader.spec.ts
+++ b/lib/src/generators/openapi2/openapi2-parameter-util-requestheader.spec.ts
@@ -318,7 +318,7 @@ describe("OpenAPI 2 parameter util: request header", () => {
         optional: false
       };
       const typeTable = new TypeTable();
-      typeTable.add("CustomType", stringType());
+      typeTable.add("CustomType", { type: stringType() });
 
       const result = requestHeaderToHeaderParameterObject(header, typeTable);
       expect(result).toEqual({

--- a/lib/src/generators/openapi2/openapi2-parameter-util-responseheader.spec.ts
+++ b/lib/src/generators/openapi2/openapi2-parameter-util-responseheader.spec.ts
@@ -234,7 +234,7 @@ describe("OpenAPI 2 parameter util: response header", () => {
         optional: false
       };
       const typeTable = new TypeTable();
-      typeTable.add("CustomType", stringType());
+      typeTable.add("CustomType", { type: stringType() });
 
       const result = responseHeaderToHeaderObject(header, typeTable);
       expect(result).toEqual({

--- a/lib/src/generators/openapi2/openapi2-type-util.spec.ts
+++ b/lib/src/generators/openapi2/openapi2-type-util.spec.ts
@@ -348,7 +348,7 @@ describe("OpenAPI 2 type util", () => {
 
       test("CustomType | null", () => {
         const typeTable = new TypeTable();
-        typeTable.add("CustomType", stringType());
+        typeTable.add("CustomType", { type: stringType() });
 
         const result = typeToSchemaObject(
           unionType([referenceType("CustomType"), nullType()]),
@@ -501,7 +501,7 @@ describe("OpenAPI 2 type util", () => {
   describe("referenceType", () => {
     test("converts to reference object", () => {
       const typeTable = new TypeTable();
-      typeTable.add("CustomType", stringType());
+      typeTable.add("CustomType", { type: stringType() });
 
       const result = typeToSchemaObject(referenceType("CustomType"), typeTable);
       expect(result).toEqual({

--- a/lib/src/generators/openapi2/openapi2-type-util.ts
+++ b/lib/src/generators/openapi2/openapi2-type-util.ts
@@ -139,7 +139,11 @@ function objectTypeToSchema(
     type.properties.length > 0
       ? type.properties.reduce<ObjectPropertiesSchemaObject>(
           (acc, property) => {
-            acc[property.name] = typeToSchemaObject(property.type, typeTable);
+            const propType = typeToSchemaObject(property.type, typeTable);
+            if (!isReferenceSchemaObject(propType)) {
+              propType.description = property.description;
+            }
+            acc[property.name] = propType;
             return acc;
           },
           {}
@@ -249,4 +253,10 @@ function createEnum<T>(
 ): (T | null)[] | undefined {
   if (!values) return;
   return nullable ? [...values, null] : values;
+}
+
+export function isReferenceSchemaObject(
+  typeObject: SchemaObject
+): typeObject is ReferenceSchemaObject {
+  return "$ref" in typeObject;
 }

--- a/lib/src/generators/openapi2/openapi2.ts
+++ b/lib/src/generators/openapi2/openapi2.ts
@@ -33,7 +33,10 @@ import {
   ResponsesObject,
   SecurityDefinitionsObject
 } from "./openapi2-specification";
-import { typeToSchemaObject } from "./openapi2-type-util";
+import {
+  typeToSchemaObject,
+  isReferenceSchemaObject
+} from "./openapi2-type-util";
 
 const SECURITY_HEADER_SCHEME_NAME = "SecurityHeader";
 
@@ -76,7 +79,11 @@ function contractTypesToDefinitionsObject(
   }
 
   return types.reduce<DefinitionsObject>((acc, t) => {
-    acc[t.name] = typeToSchemaObject(t.type, typeTable);
+    const schemaObject = typeToSchemaObject(t.typeDef.type, typeTable);
+    if (!isReferenceSchemaObject(schemaObject)) {
+      schemaObject.description = t.typeDef.description;
+    }
+    acc[t.name] = schemaObject;
     return acc;
   }, {});
 }

--- a/lib/src/generators/openapi3/openapi3-type-util.spec.ts
+++ b/lib/src/generators/openapi3/openapi3-type-util.spec.ts
@@ -158,7 +158,12 @@ describe("OpenAPI 3 type util", () => {
     test("converts to object schema", () => {
       const result = typeToSchemaOrReferenceObject(
         objectType([
-          { name: "a", type: stringType(), optional: false },
+          {
+            name: "a",
+            type: stringType(),
+            optional: false,
+            description: "description"
+          },
           { name: "b", type: stringType(), optional: true }
         ]),
         new TypeTable()
@@ -166,7 +171,7 @@ describe("OpenAPI 3 type util", () => {
       expect(result).toEqual({
         type: "object",
         properties: {
-          a: { type: "string" },
+          a: { type: "string", description: "description" },
           b: { type: "string" }
         },
         required: ["a"]
@@ -375,7 +380,7 @@ describe("OpenAPI 3 type util", () => {
 
       test("CustomType | null", () => {
         const typeTable = new TypeTable();
-        typeTable.add("CustomType", stringType());
+        typeTable.add("CustomType", { type: stringType() });
 
         const result = typeToSchemaOrReferenceObject(
           unionType([referenceType("CustomType"), nullType()]),
@@ -592,13 +597,12 @@ describe("OpenAPI 3 type util", () => {
 
       test('{ type: "a", a: string; } | CustomObjectTypeB', () => {
         const typeTable = new TypeTable();
-        typeTable.add(
-          "CustomObjectTypeB",
-          objectType([
+        typeTable.add("CustomObjectTypeB", {
+          type: objectType([
             { name: "type", type: stringLiteralType("b"), optional: false },
             { name: "b", type: stringType(), optional: false }
           ])
-        );
+        });
 
         const result = typeToSchemaOrReferenceObject(
           unionType(
@@ -633,20 +637,18 @@ describe("OpenAPI 3 type util", () => {
 
       test("CustomObjectTypeA | CustomObjectTypeB", () => {
         const typeTable = new TypeTable();
-        typeTable.add(
-          "CustomObjectTypeA",
-          objectType([
+        typeTable.add("CustomObjectTypeA", {
+          type: objectType([
             { name: "type", type: stringLiteralType("a"), optional: false },
             { name: "a", type: stringType(), optional: false }
           ])
-        );
-        typeTable.add(
-          "CustomObjectTypeB",
-          objectType([
+        });
+        typeTable.add("CustomObjectTypeB", {
+          type: objectType([
             { name: "type", type: stringLiteralType("b"), optional: false },
             { name: "b", type: stringType(), optional: false }
           ])
-        );
+        });
 
         const result = typeToSchemaOrReferenceObject(
           unionType(
@@ -675,7 +677,7 @@ describe("OpenAPI 3 type util", () => {
 
       test("CustomType | boolean", () => {
         const typeTable = new TypeTable();
-        typeTable.add("CustomType", stringType());
+        typeTable.add("CustomType", { type: stringType() });
 
         const result = typeToSchemaOrReferenceObject(
           unionType([referenceType("CustomType"), booleanType()]),
@@ -691,10 +693,10 @@ describe("OpenAPI 3 type util", () => {
     });
   });
 
-  describe("referenceType", () => {
+  describe("Reference type", () => {
     test("converts to reference object", () => {
       const typeTable = new TypeTable();
-      typeTable.add("CustomType", stringType());
+      typeTable.add("CustomType", { type: stringType() });
 
       const result = typeToSchemaOrReferenceObject(
         referenceType("CustomType"),

--- a/lib/src/generators/openapi3/openapi3-type-util.ts
+++ b/lib/src/generators/openapi3/openapi3-type-util.ts
@@ -143,10 +143,14 @@ function objectTypeToSchema(
     type.properties.length > 0
       ? type.properties.reduce<ObjectPropertiesSchemaObject>(
           (acc, property) => {
-            acc[property.name] = typeToSchemaOrReferenceObject(
+            const propType = typeToSchemaOrReferenceObject(
               property.type,
               typeTable
             );
+            if (!isReferenceObject(propType)) {
+              propType.description = property.description;
+            }
+            acc[property.name] = propType;
             return acc;
           },
           {}
@@ -320,4 +324,10 @@ function createEnum<T>(
 ): (T | null)[] | undefined {
   if (!values) return;
   return nullable ? [...values, null] : values;
+}
+
+export function isReferenceObject(
+  typeObject: SchemaObject | ReferenceObject
+): typeObject is ReferenceObject {
+  return "$ref" in typeObject;
 }

--- a/lib/src/generators/openapi3/openapi3.ts
+++ b/lib/src/generators/openapi3/openapi3.ts
@@ -35,7 +35,10 @@ import {
   ResponseObject,
   ResponsesObject
 } from "./openapi3-specification";
-import { typeToSchemaOrReferenceObject } from "./openapi3-type-util";
+import {
+  typeToSchemaOrReferenceObject,
+  isReferenceObject
+} from "./openapi3-type-util";
 
 const SECURITY_HEADER_SCHEME_NAME = "SecurityHeader";
 
@@ -303,7 +306,11 @@ function contractTypesToComponentsObjectSchemas(
   typeTable: TypeTable
 ): ComponentsObject["schemas"] {
   return types.reduce<Required<ComponentsObject>["schemas"]>((acc, t) => {
-    acc[t.name] = typeToSchemaOrReferenceObject(t.type, typeTable);
+    const typeObject = typeToSchemaOrReferenceObject(t.typeDef.type, typeTable);
+    if (!isReferenceObject(typeObject)) {
+      typeObject.description = t.typeDef.description;
+    }
+    acc[t.name] = typeObject;
     return acc;
   }, {});
 }

--- a/lib/src/mock-server/dummy.spec.ts
+++ b/lib/src/mock-server/dummy.spec.ts
@@ -95,7 +95,7 @@ describe("Dummy", () => {
     });
     test("type reference", () => {
       const types = new TypeTable();
-      types.add("other", stringLiteralType("other constant"));
+      types.add("other", { type: stringLiteralType("other constant") });
       expect(generateData(types, referenceType("other"))).toBe(
         "other constant"
       );

--- a/lib/src/mock-server/dummy.ts
+++ b/lib/src/mock-server/dummy.ts
@@ -57,7 +57,7 @@ export function generateData(types: TypeTable, type: Type): any {
         type.types[randomInteger(type.types.length - 1)]
       );
     case TypeKind.REFERENCE: {
-      const referencedType = types.get(type.name);
+      const referencedType = types.get(type.name)?.type;
       if (!referencedType) {
         throw new Error(`Missing referenced type: ${type.name}`);
       }

--- a/lib/src/parsers/__spec-examples__/body.ts
+++ b/lib/src/parsers/__spec-examples__/body.ts
@@ -4,6 +4,8 @@ class BodyClass {
   bodyMethod(
     notBody: string,
     @body body: string,
+    /** Body description */
+    @body bodyWithDescription: string,
     @body optionalBody?: string
   ) {}
 }

--- a/lib/src/parsers/__spec-examples__/types.ts
+++ b/lib/src/parsers/__spec-examples__/types.ts
@@ -30,6 +30,7 @@ interface TypeInterface {
   Date: Date;
   DateTime: DateTime;
   literalObject: {
+    /** Property description */
     propertyA: string;
     propertyB?: boolean;
   };
@@ -43,7 +44,9 @@ interface TypeInterface {
     | null;
   aliasString: AliasString;
   aliasArray: AliasArray;
+  aliasWithDescription: AliasWithDescription;
   interface: Interface;
+  interfaceWithDescription: InterfaceWithDescription;
   interfaceExtends: InterfaceExtends;
   indexedAccess: IndexedAccess["root"];
   indexedAccessNested: IndexedAccess["child"]["nested"]["secondNest"];
@@ -70,7 +73,15 @@ type AliasString = string;
 
 type AliasArray = string[];
 
+/** Alias description */
+type AliasWithDescription = string;
+
 interface Interface {
+  interfaceProperty: boolean;
+}
+
+/** Interface description */
+interface InterfaceWithDescription {
   interfaceProperty: boolean;
 }
 

--- a/lib/src/parsers/body-parser.spec.ts
+++ b/lib/src/parsers/body-parser.spec.ts
@@ -34,6 +34,20 @@ describe("body parser", () => {
     });
   });
 
+  test("parses @body decorated parameter with description", () => {
+    const result = parseBody(
+      method.getParameterOrThrow("bodyWithDescription"),
+      typeTable,
+      lociTable
+    ).unwrapOrThrow();
+
+    expect(result).toStrictEqual({
+      type: {
+        kind: TypeKind.STRING
+      }
+    });
+  });
+
   test("fails to parse optional @body decorated parameter", () => {
     expect(
       parseBody(

--- a/lib/src/parsers/body-parser.ts
+++ b/lib/src/parsers/body-parser.ts
@@ -11,6 +11,7 @@ export function parseBody(
   typeTable: TypeTable,
   lociTable: LociTable
 ): Result<Body, ParserError> {
+  // TODO: retrieve JsDoc as body description https://github.com/dsherret/ts-morph/issues/753
   parameter.getDecoratorOrThrow("body");
   if (parameter.hasQuestionToken()) {
     return err(

--- a/lib/src/parsers/type-parser.spec.ts
+++ b/lib/src/parsers/type-parser.spec.ts
@@ -219,7 +219,7 @@ describe("type parser", () => {
         kind: TypeKind.OBJECT,
         properties: [
           {
-            description: undefined,
+            description: "Property description",
             name: "propertyA",
             optional: false,
             type: {
@@ -361,7 +361,8 @@ describe("type parser", () => {
     );
     expect(typeTable.size).toBe(1);
     expect(typeTable.getOrError("AliasString")).toStrictEqual({
-      kind: TypeKind.STRING
+      description: undefined,
+      type: { kind: TypeKind.STRING }
     });
   });
 
@@ -378,10 +379,29 @@ describe("type parser", () => {
     );
     expect(typeTable.size).toBe(1);
     expect(typeTable.getOrError("AliasArray")).toStrictEqual({
-      kind: TypeKind.ARRAY,
-      elementType: {
-        kind: TypeKind.STRING
+      description: undefined,
+      type: {
+        kind: TypeKind.ARRAY,
+        elementType: { kind: TypeKind.STRING }
       }
+    });
+  });
+
+  test("parses aliases with descriptions", () => {
+    const type = interphace
+      .getPropertyOrThrow("aliasWithDescription")
+      .getTypeNodeOrThrow();
+
+    expect(parseType(type, typeTable, lociTable).unwrapOrThrow()).toStrictEqual(
+      {
+        kind: TypeKind.REFERENCE,
+        name: "AliasWithDescription"
+      }
+    );
+    expect(typeTable.size).toBe(1);
+    expect(typeTable.getOrError("AliasWithDescription")).toStrictEqual({
+      description: "Alias description",
+      type: { kind: TypeKind.STRING }
     });
   });
 
@@ -398,17 +418,50 @@ describe("type parser", () => {
     );
     expect(typeTable.size).toBe(1);
     expect(typeTable.getOrError("Interface")).toStrictEqual({
-      kind: TypeKind.OBJECT,
-      properties: [
-        {
-          description: undefined,
-          name: "interfaceProperty",
-          optional: false,
-          type: {
-            kind: TypeKind.BOOLEAN
+      description: undefined,
+      type: {
+        kind: TypeKind.OBJECT,
+        properties: [
+          {
+            description: undefined,
+            name: "interfaceProperty",
+            optional: false,
+            type: {
+              kind: TypeKind.BOOLEAN
+            }
           }
-        }
-      ]
+        ]
+      }
+    });
+  });
+
+  test("parses interfaces with descriptions", () => {
+    const type = interphace
+      .getPropertyOrThrow("interfaceWithDescription")
+      .getTypeNodeOrThrow();
+
+    expect(parseType(type, typeTable, lociTable).unwrapOrThrow()).toStrictEqual(
+      {
+        kind: TypeKind.REFERENCE,
+        name: "InterfaceWithDescription"
+      }
+    );
+    expect(typeTable.size).toBe(1);
+    expect(typeTable.getOrError("InterfaceWithDescription")).toStrictEqual({
+      description: "Interface description",
+      type: {
+        kind: TypeKind.OBJECT,
+        properties: [
+          {
+            description: undefined,
+            name: "interfaceProperty",
+            optional: false,
+            type: {
+              kind: TypeKind.BOOLEAN
+            }
+          }
+        ]
+      }
     });
   });
 
@@ -425,25 +478,28 @@ describe("type parser", () => {
     );
     expect(typeTable.size).toBe(1);
     expect(typeTable.getOrError("InterfaceExtends")).toStrictEqual({
-      kind: TypeKind.OBJECT,
-      properties: [
-        {
-          description: undefined,
-          name: "interfaceExtendsProperty",
-          optional: false,
-          type: {
-            kind: TypeKind.BOOLEAN
+      description: undefined,
+      type: {
+        kind: TypeKind.OBJECT,
+        properties: [
+          {
+            description: undefined,
+            name: "interfaceExtendsProperty",
+            optional: false,
+            type: {
+              kind: TypeKind.BOOLEAN
+            }
+          },
+          {
+            description: undefined,
+            name: "interfaceProperty",
+            optional: false,
+            type: {
+              kind: TypeKind.BOOLEAN
+            }
           }
-        },
-        {
-          description: undefined,
-          name: "interfaceProperty",
-          optional: false,
-          type: {
-            kind: TypeKind.BOOLEAN
-          }
-        }
-      ]
+        ]
+      }
     });
   });
 

--- a/lib/src/parsers/type-parser.ts
+++ b/lib/src/parsers/type-parser.ts
@@ -136,6 +136,7 @@ function parseTypeReference(
 
   const declaration = declarationResult.unwrap();
   const name = declaration.getName();
+  const description = getJsDoc(declaration)?.getDescription().trim();
 
   if (TypeGuards.isTypeAliasDeclaration(declaration)) {
     const decTypeNode = declaration.getTypeNodeOrThrow();
@@ -181,7 +182,7 @@ function parseTypeReference(
       } else {
         const targetTypeResult = parseType(decTypeNode, typeTable, lociTable);
         if (targetTypeResult.isErr()) return targetTypeResult;
-        typeTable.add(name, targetTypeResult.unwrap());
+        typeTable.add(name, { type: targetTypeResult.unwrap(), description });
         lociTable.addMorphNode(LociTable.typeKey(name), decTypeNode);
       }
       return ok(referenceType(name));
@@ -201,7 +202,7 @@ function parseTypeReference(
           lociTable
         );
         if (targetTypeResult.isErr()) return targetTypeResult;
-        typeTable.add(name, targetTypeResult.unwrap());
+        typeTable.add(name, { type: targetTypeResult.unwrap(), description });
         lociTable.addMorphNode(LociTable.typeKey(name), declaration);
       }
       return ok(referenceType(name));
@@ -520,7 +521,7 @@ function resolveIndexedAccessType(
     );
   }
   if (currentType.kind === TypeKind.REFERENCE) {
-    const referencedType = typeTable.getOrError(currentType.name);
+    const referencedType = typeTable.getOrError(currentType.name).type;
     return resolveIndexedAccessType(propertyChain, referencedType, typeTable);
   }
   throw new Error("Indexed type error");

--- a/lib/src/validation-server/verifications/contract-mismatcher.ts
+++ b/lib/src/validation-server/verifications/contract-mismatcher.ts
@@ -423,7 +423,7 @@ export class ContractMismatcher {
         [key: string]: JsonSchemaType;
       }>((defAcc, typeNode) => {
         return {
-          [typeNode.name]: typeToJsonSchemaType(typeNode.type, !strict),
+          [typeNode.name]: typeToJsonSchemaType(typeNode.typeDef.type, !strict),
           ...defAcc
         };
       }, {})

--- a/lib/src/validation-server/verifications/string-validator.spec.ts
+++ b/lib/src/validation-server/verifications/string-validator.spec.ts
@@ -17,10 +17,9 @@ describe("validators", () => {
 
   beforeEach(() => {
     const typeTable = new TypeTable();
-    typeTable.add(
-      "obj1",
-      objectType([{ name: "id", type: int64Type(), optional: false }])
-    );
+    typeTable.add("obj1", {
+      type: objectType([{ name: "id", type: int64Type(), optional: false }])
+    });
     validator = new StringValidator(typeTable);
   });
 


### PR DESCRIPTION
## Description, Motivation and Context
Fixes regression from parser migration. Brings back reference type descriptions.

Descriptions for reference types are stored in the common `TypeTable`. These are used to generate OpenAPI schema components/definitions.

Partially addresses #711 
