### PR TITLE
Fix incorrect import paths 

### DIFF
--- a/cli/src/commands/lint.ts
+++ b/cli/src/commands/lint.ts
@@ -1,7 +1,7 @@
 import { Command, flags } from "@oclif/command";
 import { lint } from "../../../lib/src/linting/linter";
 import { parse } from "../../../lib/src/parser";
-import { findLintViolations } from "lib/src/linting/find-lint-violations";
+import { findLintViolations } from "../../../lib/src/linting/find-lint-violations";
 
 const ARG_API = "spot_contract";
 

--- a/lib/src/linting/find-lint-violations.ts
+++ b/lib/src/linting/find-lint-violations.ts
@@ -1,5 +1,5 @@
 import { GroupedLintRuleViolations } from "./rule";
-import { LintConfig } from "cli/src/commands/lint";
+import { LintConfig } from "../../../cli/src/commands/lint";
 
 interface FindLintViolationsDependencies {
   error: (msg: string) => void;


### PR DESCRIPTION
## Description, Motivation and Context

- Why is this change required?
PR https://github.com/airtasker/spot/pull/768 broke the build as it added invalid import paths and eslint didn't pick them up.

## Checklist:

- [ ] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
