### PR TITLE
Fix bug where lint was incorrectly counting errors

### DIFF
--- a/cli/src/commands/lint.ts
+++ b/cli/src/commands/lint.ts
@@ -53,10 +53,11 @@ export default class Lint extends Command {
         warn: this.warn
       }
     );
+
+    console.log(`Found ${errorCount} errors and ${warningCount} warnings`);
+
     if (errorCount > 0) {
       process.exit(1);
     }
-
-    console.log(`Found ${errorCount} errors and ${warningCount} warnings`);
   }
 }

--- a/cli/src/commands/lint.ts
+++ b/cli/src/commands/lint.ts
@@ -54,7 +54,7 @@ export default class Lint extends Command {
       }
     );
 
-    console.log(`Found ${errorCount} errors and ${warningCount} warnings`);
+    this.log(`Found ${errorCount} errors and ${warningCount} warnings`);
 
     if (errorCount > 0) {
       process.exit(1);

--- a/cli/src/commands/lint.ts
+++ b/cli/src/commands/lint.ts
@@ -43,16 +43,20 @@ export default class Lint extends Command {
     const contract = parse(contractPath);
     const groupedLintErrors = lint(contract);
 
-    const { errorCount, warningCount } = findLintViolations(groupedLintErrors, lintConfig, {
-      error: (msg: string) => {
-        this.error(msg, { exit: false });
-      },
-      warn: this.warn
-    });
+    const { errorCount, warningCount } = findLintViolations(
+      groupedLintErrors,
+      lintConfig,
+      {
+        error: (msg: string) => {
+          this.error(msg, { exit: false });
+        },
+        warn: this.warn
+      }
+    );
     if (errorCount > 0) {
       process.exit(1);
     }
 
-    console.log(`Found ${errorCount} errors and ${warningCount} warnings`)
+    console.log(`Found ${errorCount} errors and ${warningCount} warnings`);
   }
 }

--- a/cli/src/commands/lint.ts
+++ b/cli/src/commands/lint.ts
@@ -43,15 +43,16 @@ export default class Lint extends Command {
     const contract = parse(contractPath);
     const groupedLintErrors = lint(contract);
 
-    const { errorCount } = findLintViolations(groupedLintErrors, lintConfig, {
+    const { errorCount, warningCount } = findLintViolations(groupedLintErrors, lintConfig, {
       error: (msg: string) => {
         this.error(msg, { exit: false });
       },
       warn: this.warn
     });
-
     if (errorCount > 0) {
       process.exit(1);
     }
+
+    console.log(`Found ${errorCount} errors and ${warningCount} warnings`)
   }
 }

--- a/lib/src/linting/find-lint-violations.spec.ts
+++ b/lib/src/linting/find-lint-violations.spec.ts
@@ -176,15 +176,40 @@ describe("find lint violations", () => {
     });
   });
 
-  describe("when there are no lint violations", () => {
+  describe("when there are no lint rules", () => {
     beforeEach(() => {
       const spotConfig = {
-        rules: {
-          error: "invalid"
-        }
+        rules: {}
       };
 
       findLintViolationsResult = findLintViolations([], spotConfig, {
+        error: errorMock,
+        warn: warnMock
+      });
+    });
+
+    it("should trigger no errors and no warnings", () => {
+      expect(findLintViolationsResult.errorCount).toBe(0);
+      expect(findLintViolationsResult.warningCount).toBe(0);
+      expect(errorMock).not.toBeCalled();
+      expect(warnMock).not.toBeCalled();
+    });
+  });
+
+  describe("when there are no lint violations", () => {
+    beforeEach(() => {
+      const groupedLintErrors = [
+        {
+          name: "error",
+          violations: []
+        }
+      ];
+
+      const spotConfig = {
+        rules: {}
+      };
+
+      findLintViolationsResult = findLintViolations(groupedLintErrors, spotConfig, {
         error: errorMock,
         warn: warnMock
       });

--- a/lib/src/linting/find-lint-violations.spec.ts
+++ b/lib/src/linting/find-lint-violations.spec.ts
@@ -209,10 +209,14 @@ describe("find lint violations", () => {
         rules: {}
       };
 
-      findLintViolationsResult = findLintViolations(groupedLintErrors, spotConfig, {
-        error: errorMock,
-        warn: warnMock
-      });
+      findLintViolationsResult = findLintViolations(
+        groupedLintErrors,
+        spotConfig,
+        {
+          error: errorMock,
+          warn: warnMock
+        }
+      );
     });
 
     it("should trigger no errors and no warnings", () => {

--- a/lib/src/linting/find-lint-violations.ts
+++ b/lib/src/linting/find-lint-violations.ts
@@ -33,16 +33,16 @@ export const findLintViolations = (
       case "error": {
         lintingErrors.violations.forEach(lintError => {
           error(lintError.message);
+          errorCount++;
         });
-        errorCount++;
         break;
       }
 
       case "warn": {
         lintingErrors.violations.forEach(lintWarning => {
           warn(lintWarning.message);
+          warningCount++;
         });
-        warningCount++;
         break;
       }
 


### PR DESCRIPTION
## Description, Motivation and Context

- Why is this change required?
It was incorrectly counting errors and was counting them when there was no lint violations for each of our rules resulting in it exiting with exit code 1.

Added an console.log to print the number of errors and warnings as I think it is useful.

## Checklist:

- [x] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
