### PR TITLE
Adds the abailty to specify api versions

### DIFF
--- a/lib/src/definitions.ts
+++ b/lib/src/definitions.ts
@@ -3,6 +3,7 @@ import { Type, TypeDef } from "./types";
 export interface Contract {
   name: string;
   description?: string;
+  version?: string
   config: Config;
   types: { name: string; typeDef: TypeDef }[];
   security?: SecurityHeader;

--- a/lib/src/definitions.ts
+++ b/lib/src/definitions.ts
@@ -3,7 +3,7 @@ import { Type, TypeDef } from "./types";
 export interface Contract {
   name: string;
   description?: string;
-  version?: string
+  version?: string;
   config: Config;
   types: { name: string; typeDef: TypeDef }[];
   security?: SecurityHeader;

--- a/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
@@ -277,7 +277,7 @@ exports[`OpenAPI 2 generator HTTP verbs PUT endpoint 1`] = `
 }"
 `;
 
-exports[`OpenAPI 2 generator contract with version produces a versioned OpenAPI 2 contract 1`] = `
+exports[`OpenAPI 2 generator contract with version produces a versioned OpenAPI 2 1`] = `
 "{
   \\"swagger\\": \\"2.0\\",
   \\"info\\": {

--- a/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
@@ -277,6 +277,23 @@ exports[`OpenAPI 2 generator HTTP verbs PUT endpoint 1`] = `
 }"
 `;
 
+exports[`OpenAPI 2 generator contract with version produces a versioned OpenAPI 2 contract 1`] = `
+"{
+  \\"swagger\\": \\"2.0\\",
+  \\"info\\": {
+    \\"title\\": \\"versioned-contract\\",
+    \\"version\\": \\"0.1.0\\"
+  },
+  \\"consumes\\": [
+    \\"application/json\\"
+  ],
+  \\"produces\\": [
+    \\"application/json\\"
+  ],
+  \\"paths\\": {}
+}"
+`;
+
 exports[`OpenAPI 2 generator headers endpoint with request headers 1`] = `
 "{
   \\"swagger\\": \\"2.0\\",

--- a/lib/src/generators/openapi2/__spec-examples__/versioned-contract.ts
+++ b/lib/src/generators/openapi2/__spec-examples__/versioned-contract.ts
@@ -1,0 +1,4 @@
+import { api } from "@airtasker/spot";
+
+@api({ name: "versioned-contract", version: "0.1.0" })
+class Contract {}

--- a/lib/src/generators/openapi2/openapi2.spec.ts
+++ b/lib/src/generators/openapi2/openapi2.spec.ts
@@ -28,7 +28,7 @@ describe("OpenAPI 2 generator", () => {
     expect(JSON.stringify(result, null, 2)).toMatchSnapshot();
     const spectralResult = await spectral.run(result);
     expect(spectralResult).toHaveLength(0);
-  })
+  });
 
   describe("security", () => {
     test("contract with security header", async () => {

--- a/lib/src/generators/openapi2/openapi2.spec.ts
+++ b/lib/src/generators/openapi2/openapi2.spec.ts
@@ -21,6 +21,15 @@ describe("OpenAPI 2 generator", () => {
     expect(spectralResult).toHaveLength(0);
   });
 
+  test("contract with version produces a versioned OpenAPI 2", async () => {
+    const contract = generateContract("versioned-contract.ts");
+    const result = generateOpenAPI2(contract);
+
+    expect(JSON.stringify(result, null, 2)).toMatchSnapshot();
+    const spectralResult = await spectral.run(result);
+    expect(spectralResult).toHaveLength(0);
+  })
+
   describe("security", () => {
     test("contract with security header", async () => {
       const contract = generateContract("contract-with-security-header.ts");

--- a/lib/src/generators/openapi2/openapi2.ts
+++ b/lib/src/generators/openapi2/openapi2.ts
@@ -47,7 +47,7 @@ export function generateOpenAPI2(contract: Contract): OpenApiV2 {
     info: {
       title: contract.name,
       description: contract.description,
-      version: "0.0.0"
+      version: contract.version ?? "0.0.0"
     },
     consumes: ["application/json"],
     produces: ["application/json"],

--- a/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
@@ -881,3 +881,14 @@ exports[`OpenAPI 3 generator security contract with security header 1`] = `
   ]
 }"
 `;
+
+exports[`OpenAPI 3 generator versioned contract produces a versioned OpenAPI 3 1`] = `
+"{
+  \\"openapi\\": \\"3.0.2\\",
+  \\"info\\": {
+    \\"title\\": \\"versioned-contract\\",
+    \\"version\\": \\"0.1.0\\"
+  },
+  \\"paths\\": {}
+}"
+`;

--- a/lib/src/generators/openapi3/__spec-examples__/versioned-contract.ts
+++ b/lib/src/generators/openapi3/__spec-examples__/versioned-contract.ts
@@ -1,0 +1,4 @@
+import { api } from "@airtasker/spot";
+
+@api({ name: "versioned-contract", version: "0.1.0" })
+class Contract {}

--- a/lib/src/generators/openapi3/openapi3.spec.ts
+++ b/lib/src/generators/openapi3/openapi3.spec.ts
@@ -21,6 +21,15 @@ describe("OpenAPI 3 generator", () => {
     expect(spectralResult).toHaveLength(0);
   });
 
+  test("versioned contract produces a versioned OpenAPI 3", async () => {
+    const contract = generateContract("versioned-contract.ts");
+    const result = generateOpenAPI3(contract);
+
+    expect(JSON.stringify(result, null, 2)).toMatchSnapshot();
+    const spectralResult = await spectral.run(result);
+    expect(spectralResult).toHaveLength(0);
+  })
+
   describe("security", () => {
     test("contract with security header", async () => {
       const contract = generateContract("contract-with-security-header.ts");

--- a/lib/src/generators/openapi3/openapi3.spec.ts
+++ b/lib/src/generators/openapi3/openapi3.spec.ts
@@ -28,7 +28,7 @@ describe("OpenAPI 3 generator", () => {
     expect(JSON.stringify(result, null, 2)).toMatchSnapshot();
     const spectralResult = await spectral.run(result);
     expect(spectralResult).toHaveLength(0);
-  })
+  });
 
   describe("security", () => {
     test("contract with security header", async () => {

--- a/lib/src/generators/openapi3/openapi3.ts
+++ b/lib/src/generators/openapi3/openapi3.ts
@@ -49,7 +49,7 @@ export function generateOpenAPI3(contract: Contract): OpenApiV3 {
     info: {
       title: contract.name,
       description: contract.description,
-      version: "0.0.0"
+      version: contract.version ?? "0.0.0"
     },
     paths: endpointsToPathsObject(
       contract.endpoints,

--- a/lib/src/parsers/contract-parser.spec.ts
+++ b/lib/src/parsers/contract-parser.spec.ts
@@ -61,7 +61,7 @@ describe("contract parser", () => {
       name: "contract",
       security: undefined,
       types: [],
-      version: "0.0.0"
+      version: undefined
     });
   });
 

--- a/lib/src/parsers/contract-parser.spec.ts
+++ b/lib/src/parsers/contract-parser.spec.ts
@@ -60,7 +60,8 @@ describe("contract parser", () => {
       endpoints: [],
       name: "contract",
       security: undefined,
-      types: []
+      types: [],
+      version: "0.0.0"
     });
   });
 

--- a/lib/src/parsers/contract-parser.ts
+++ b/lib/src/parsers/contract-parser.ts
@@ -61,11 +61,10 @@ export function parseContract(
   const description = descriptionDoc?.getDescription().trim();
 
   // Handle Version
-  let version = "0.0.0";
   const versionProp = getObjLiteralProp<ApiConfig>(decoratorConfig, "version");
-  if (versionProp) {
-    version = getPropValueAsStringOrThrow(versionProp)?.getLiteralText().trim();
-  }
+  const version = versionProp
+    ? getPropValueAsStringOrThrow(versionProp).getLiteralText().trim()
+    : undefined;
 
   // Handle config
   const configResult = resolveConfig(klass);

--- a/lib/src/parsers/contract-parser.ts
+++ b/lib/src/parsers/contract-parser.ts
@@ -10,7 +10,7 @@ import { parseEndpoint } from "./endpoint-parser";
 import {
   getClassWithDecoratorOrThrow,
   getDecoratorConfigOrThrow,
-  getJsDoc,
+  getJsDoc, getObjLiteralProp,
   getObjLiteralPropOrThrow,
   getPropertyWithDecorator,
   getPropValueAsStringOrThrow,
@@ -59,6 +59,13 @@ export function parseContract(
   const descriptionDoc = getJsDoc(klass);
   const description = descriptionDoc?.getDescription().trim();
 
+  // Handle Version
+  let version = "0.0.0";
+  const versionProp = getObjLiteralProp<ApiConfig>(decoratorConfig, "version")
+  if(versionProp) {
+    version = getPropValueAsStringOrThrow(versionProp)?.getLiteralText().trim();
+  }
+
   // Handle config
   const configResult = resolveConfig(klass);
   if (configResult.isErr()) return configResult;
@@ -104,7 +111,7 @@ export function parseContract(
   // Handle Types
   const types = typeTable.toArray();
 
-  const contract = { name, description, types, config, security, endpoints };
+  const contract = { name, description, types, config, security, endpoints, version };
   return ok({ contract, lociTable });
 }
 

--- a/lib/src/parsers/contract-parser.ts
+++ b/lib/src/parsers/contract-parser.ts
@@ -10,7 +10,8 @@ import { parseEndpoint } from "./endpoint-parser";
 import {
   getClassWithDecoratorOrThrow,
   getDecoratorConfigOrThrow,
-  getJsDoc, getObjLiteralProp,
+  getJsDoc,
+  getObjLiteralProp,
   getObjLiteralPropOrThrow,
   getPropertyWithDecorator,
   getPropValueAsStringOrThrow,
@@ -61,8 +62,8 @@ export function parseContract(
 
   // Handle Version
   let version = "0.0.0";
-  const versionProp = getObjLiteralProp<ApiConfig>(decoratorConfig, "version")
-  if(versionProp) {
+  const versionProp = getObjLiteralProp<ApiConfig>(decoratorConfig, "version");
+  if (versionProp) {
     version = getPropValueAsStringOrThrow(versionProp)?.getLiteralText().trim();
   }
 
@@ -111,7 +112,15 @@ export function parseContract(
   // Handle Types
   const types = typeTable.toArray();
 
-  const contract = { name, description, types, config, security, endpoints, version };
+  const contract = {
+    name,
+    description,
+    types,
+    config,
+    security,
+    endpoints,
+    version
+  };
   return ok({ contract, lociTable });
 }
 

--- a/lib/src/syntax/api.ts
+++ b/lib/src/syntax/api.ts
@@ -15,5 +15,6 @@ export function api(config: ApiConfig) {
 export interface ApiConfig {
   /** Name of the API. This should be the name of the service that is being documented */
   name: string;
+  /** Version of this document */
   version?: string;
 }

--- a/lib/src/syntax/api.ts
+++ b/lib/src/syntax/api.ts
@@ -14,6 +14,6 @@ export function api(config: ApiConfig) {
 
 export interface ApiConfig {
   /** Name of the API. This should be the name of the service that is being documented */
-  name: string,
-  version?: string
+  name: string;
+  version?: string;
 }

--- a/lib/src/syntax/api.ts
+++ b/lib/src/syntax/api.ts
@@ -14,5 +14,6 @@ export function api(config: ApiConfig) {
 
 export interface ApiConfig {
   /** Name of the API. This should be the name of the service that is being documented */
-  name: string;
+  name: string,
+  version?: string
 }


### PR DESCRIPTION
## Description, Motivation and Context

- Why is this change required?
This addresses this issue: https://github.com/airtasker/spot/issues/652
As a developer using the spot system to create my api documentation, I require the need to version my docs. This allows me to trigger events in my pipelines and keep everyone in our organization consistently up to date.
- What does it do?
This provides the capability to version the API documentation from the spot doc itself, rather than manually through the generated contract which will get overwritten on the next document change.

## Checklist:

- [ x ] I've added/updated tests to cover my changes
- [ x ] I've created an issue associated with this PR
I have not created an issue due to the fact that one was already created.