### PR TITLE
add example to pathParams

### DIFF
--- a/lib/src/definitions.ts
+++ b/lib/src/definitions.ts
@@ -63,7 +63,12 @@ export interface PathParam {
   name: string;
   description?: string;
   type: Type;
-  examples?: Record<string, string>;
+  examples?: Example[];
+}
+
+export interface Example {
+  name: string;
+  value: string;
 }
 
 export interface QueryParam {

--- a/lib/src/definitions.ts
+++ b/lib/src/definitions.ts
@@ -63,7 +63,7 @@ export interface PathParam {
   name: string;
   description?: string;
   type: Type;
-  example?: string;
+  examples?: Record<string, string>;
 }
 
 export interface QueryParam {

--- a/lib/src/definitions.ts
+++ b/lib/src/definitions.ts
@@ -68,7 +68,7 @@ export interface PathParam {
 
 export interface Example {
   name: string;
-  value: string;
+  value: string; // TODO: encapsulate type information
 }
 
 export interface QueryParam {

--- a/lib/src/definitions.ts
+++ b/lib/src/definitions.ts
@@ -63,6 +63,7 @@ export interface PathParam {
   name: string;
   description?: string;
   type: Type;
+  example?: string;
 }
 
 export interface QueryParam {

--- a/lib/src/parsers/__spec-examples__/path-params.ts
+++ b/lib/src/parsers/__spec-examples__/path-params.ts
@@ -13,7 +13,7 @@ class PathParamsClass {
       arrayProperty: string[];
       /** property-example description
        * @example property-example
-       * property-example-value
+       * "property-example-value"
        *  */
       "property-with-example": string;
       /** property-two-examples description
@@ -71,6 +71,13 @@ class PathParamsClass {
     @pathParams
     pathParamsWithIllegalPropertyArrayType: {
       property: null[];
+    },
+    @pathParams
+    paramsWithUnquotedStringExample: {
+      /**@example
+       * invalid-property-example
+       */
+      property: string;
     },
     @pathParams
     optionalPathParams?: {

--- a/lib/src/parsers/__spec-examples__/path-params.ts
+++ b/lib/src/parsers/__spec-examples__/path-params.ts
@@ -19,9 +19,9 @@ class PathParamsClass {
       "property-with-example": string;
       /** property-two-examples description
        * @example property-example-one
-       * property-example-one-value
+       * 123
        * @example property-example-two
-       * property-example-two-value
+       * 456
        * */
       "property-with-examples": Integer;
     },

--- a/lib/src/parsers/__spec-examples__/path-params.ts
+++ b/lib/src/parsers/__spec-examples__/path-params.ts
@@ -11,6 +11,14 @@ class PathParamsClass {
       /** property description */
       "property-with-description": string;
       arrayProperty: string[];
+      /** property description
+       * @example property-example */
+      "property-with-example": string;
+    },
+    @pathParams
+    paramsWithEmptyExample: {
+      /**@example */
+      property: string;
     },
     @pathParams
     pathParamsWithOptionalProperty: {

--- a/lib/src/parsers/__spec-examples__/path-params.ts
+++ b/lib/src/parsers/__spec-examples__/path-params.ts
@@ -1,4 +1,4 @@
-import { pathParams } from "@airtasker/spot";
+import { pathParams, Integer } from "@airtasker/spot";
 import { TypeKind, FloatType, Int32Type } from "../../types";
 
 class PathParamsClass {
@@ -18,12 +18,12 @@ class PathParamsClass {
        *  */
       "property-with-example": string;
       /** property-two-examples description
-       * @example property-example-one 
+       * @example property-example-one
        * property-example-one-value
-       * @example property-example-two 
+       * @example property-example-two
        * property-example-two-value
        * */
-      "property-with-examples": Int32Type;
+      "property-with-examples": Integer;
     },
     @pathParams
     paramsWithEmptyExample: {
@@ -36,13 +36,20 @@ class PathParamsClass {
        * 123
        * @example name
        * 456
-      */
+       */
       property: string;
     },
     @pathParams
     paramsWithExampleWithoutValue: {
       /**@example name*/
       property: string;
+    },
+    @pathParams
+    paramsWithNonMatchingExampleType: {
+      /**@example name
+       * This_is_not_an_integer
+       */
+      property: Integer;
     },
     @pathParams
     pathParamsWithOptionalProperty: {

--- a/lib/src/parsers/__spec-examples__/path-params.ts
+++ b/lib/src/parsers/__spec-examples__/path-params.ts
@@ -1,5 +1,5 @@
 import { pathParams } from "@airtasker/spot";
-import { TypeKind, FloatType } from "../../types";
+import { TypeKind, FloatType, Int32Type } from "../../types";
 
 class PathParamsClass {
   pathParamsMethod(
@@ -23,7 +23,7 @@ class PathParamsClass {
        * @example property-example-two 
        * property-example-two-value
        * */
-      "property-with-examples": string[];
+      "property-with-examples": Int32Type;
     },
     @pathParams
     paramsWithEmptyExample: {

--- a/lib/src/parsers/__spec-examples__/path-params.ts
+++ b/lib/src/parsers/__spec-examples__/path-params.ts
@@ -1,5 +1,4 @@
 import { pathParams, Integer } from "@airtasker/spot";
-import { TypeKind, FloatType, Int32Type } from "../../types";
 
 class PathParamsClass {
   pathParamsMethod(

--- a/lib/src/parsers/__spec-examples__/path-params.ts
+++ b/lib/src/parsers/__spec-examples__/path-params.ts
@@ -1,4 +1,5 @@
 import { pathParams } from "@airtasker/spot";
+import { TypeKind, FloatType } from "../../types";
 
 class PathParamsClass {
   pathParamsMethod(
@@ -11,13 +12,36 @@ class PathParamsClass {
       /** property description */
       "property-with-description": string;
       arrayProperty: string[];
-      /** property description
-       * @example property-example */
+      /** property-example description
+       * @example property-example
+       * property-example-value
+       *  */
       "property-with-example": string;
+      /** property-two-examples description
+       * @example property-example-one 
+       * property-example-one-value
+       * @example property-example-two 
+       * property-example-two-value
+       * */
+      "property-with-examples": string[];
     },
     @pathParams
     paramsWithEmptyExample: {
       /**@example */
+      property: string;
+    },
+    @pathParams
+    paramsWithDuplicateExampleName: {
+      /**@example name
+       * 123
+       * @example name
+       * 456
+      */
+      property: string;
+    },
+    @pathParams
+    paramsWithExampleWithoutValue: {
+      /**@example name*/
       property: string;
     },
     @pathParams

--- a/lib/src/parsers/__spec-examples__/path-params.ts
+++ b/lib/src/parsers/__spec-examples__/path-params.ts
@@ -33,9 +33,9 @@ class PathParamsClass {
     @pathParams
     paramsWithDuplicateExampleName: {
       /**@example name
-       * 123
+       * "123"
        * @example name
-       * 456
+       * "456"
        */
       property: string;
     },

--- a/lib/src/parsers/path-params-parser.spec.ts
+++ b/lib/src/parsers/path-params-parser.spec.ts
@@ -65,11 +65,11 @@ describe("path params parser", () => {
       examples: [
         {
           name: "property-example-one",
-          value: "123"
+          value: 123
         },
         {
           name: "property-example-two",
-          value: "456"
+          value: 456
         }
       ],
       name: "property-with-examples",
@@ -192,6 +192,16 @@ describe("path params parser", () => {
   test("fails to parse @example decorator with a different example type", () => {
     const err = parsePathParams(
       method.getParameterOrThrow("paramsWithNonMatchingExampleType"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse @example decorator with unquoted example string", () => {
+    const err = parsePathParams(
+      method.getParameterOrThrow("paramsWithUnquotedStringExample"),
       typeTable,
       lociTable
     ).unwrapErrOrThrow();

--- a/lib/src/parsers/path-params-parser.spec.ts
+++ b/lib/src/parsers/path-params-parser.spec.ts
@@ -68,7 +68,7 @@ describe("path params parser", () => {
       },
       name: "property-with-examples",
       type: {
-        kind: TypeKind.ARRAY
+        kind: TypeKind.INT32
       }
     });
   });

--- a/lib/src/parsers/path-params-parser.spec.ts
+++ b/lib/src/parsers/path-params-parser.spec.ts
@@ -182,4 +182,14 @@ describe("path params parser", () => {
 
     expect(err).toBeInstanceOf(ParserError);
   });
+
+  test("fails to parse @example decorator with a different example type", () => {
+    const err = parsePathParams(
+      method.getParameterOrThrow("paramsWithNonMatchingExampleType"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
+  });
 });

--- a/lib/src/parsers/path-params-parser.spec.ts
+++ b/lib/src/parsers/path-params-parser.spec.ts
@@ -54,7 +54,7 @@ describe("path params parser", () => {
     });
     expect(result[3]).toStrictEqual({
       description: "property-example description",
-      examples: { "property-example": "property-example-value" },
+      examples: [{ name: "property-example", value: "property-example-value" }],
       name: "property-with-example",
       type: {
         kind: TypeKind.STRING
@@ -62,10 +62,16 @@ describe("path params parser", () => {
     });
     expect(result[4]).toStrictEqual({
       description: "property-two-examples description",
-      examples: {
-        "property-example-one": "123",
-        "property-example-two": "456"
-      },
+      examples: [
+        {
+          name: "property-example-one",
+          value: "123"
+        },
+        {
+          name: "property-example-two",
+          value: "456"
+        }
+      ],
       name: "property-with-examples",
       type: {
         kind: TypeKind.INT32

--- a/lib/src/parsers/path-params-parser.spec.ts
+++ b/lib/src/parsers/path-params-parser.spec.ts
@@ -3,6 +3,7 @@ import { LociTable } from "../locations";
 import { createProjectFromExistingSourceFile } from "../spec-helpers/helper";
 import { TypeKind, TypeTable } from "../types";
 import { parsePathParams } from "./path-params-parser";
+import { Type } from "ts-morph";
 
 describe("path params parser", () => {
   const exampleFile = createProjectFromExistingSourceFile(
@@ -26,10 +27,9 @@ describe("path params parser", () => {
       typeTable,
       lociTable
     ).unwrapOrThrow();
-    expect(result).toHaveLength(4);
+    expect(result).toHaveLength(5);
     expect(result[0]).toStrictEqual({
       description: undefined,
-      example: undefined,
       name: "arrayProperty",
       type: {
         kind: TypeKind.ARRAY,
@@ -40,7 +40,6 @@ describe("path params parser", () => {
     });
     expect(result[1]).toStrictEqual({
       description: undefined,
-      example: undefined,
       name: "property",
       type: {
         kind: TypeKind.STRING
@@ -49,17 +48,27 @@ describe("path params parser", () => {
     expect(result[2]).toStrictEqual({
       description: "property description",
       name: "property-with-description",
-      example: undefined,
       type: {
         kind: TypeKind.STRING
       }
     });
     expect(result[3]).toStrictEqual({
-      description: "property description",
-      example: "property-example",
+      description: "property-example description",
+      examples: { "property-example": "property-example-value" },
       name: "property-with-example",
       type: {
         kind: TypeKind.STRING
+      }
+    });
+    expect(result[4]).toStrictEqual({
+      description: "property-two-examples description",
+      examples: {
+        "property-example-one": "property-example-one-value",
+        "property-example-two": "property-example-two-value"
+      },
+      name: "property-with-examples",
+      type: {
+        kind: TypeKind.ARRAY
       }
     });
   });
@@ -147,6 +156,26 @@ describe("path params parser", () => {
   test("fails to parse empty @example decorator", () => {
     const err = parsePathParams(
       method.getParameterOrThrow("paramsWithEmptyExample"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse @example decorator with duplicate name", () => {
+    const err = parsePathParams(
+      method.getParameterOrThrow("paramsWithDuplicateExampleName"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
+  });
+
+  test("fails to parse @example decorator without value", () => {
+    const err = parsePathParams(
+      method.getParameterOrThrow("paramsWithExampleWithoutValue"),
       typeTable,
       lociTable
     ).unwrapErrOrThrow();

--- a/lib/src/parsers/path-params-parser.spec.ts
+++ b/lib/src/parsers/path-params-parser.spec.ts
@@ -63,8 +63,8 @@ describe("path params parser", () => {
     expect(result[4]).toStrictEqual({
       description: "property-two-examples description",
       examples: {
-        "property-example-one": "property-example-one-value",
-        "property-example-two": "property-example-two-value"
+        "property-example-one": "123",
+        "property-example-two": "456"
       },
       name: "property-with-examples",
       type: {

--- a/lib/src/parsers/path-params-parser.spec.ts
+++ b/lib/src/parsers/path-params-parser.spec.ts
@@ -26,9 +26,10 @@ describe("path params parser", () => {
       typeTable,
       lociTable
     ).unwrapOrThrow();
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(4);
     expect(result[0]).toStrictEqual({
       description: undefined,
+      example: undefined,
       name: "arrayProperty",
       type: {
         kind: TypeKind.ARRAY,
@@ -39,6 +40,7 @@ describe("path params parser", () => {
     });
     expect(result[1]).toStrictEqual({
       description: undefined,
+      example: undefined,
       name: "property",
       type: {
         kind: TypeKind.STRING
@@ -47,6 +49,15 @@ describe("path params parser", () => {
     expect(result[2]).toStrictEqual({
       description: "property description",
       name: "property-with-description",
+      example: undefined,
+      type: {
+        kind: TypeKind.STRING
+      }
+    });
+    expect(result[3]).toStrictEqual({
+      description: "property description",
+      example: "property-example",
+      name: "property-with-example",
       type: {
         kind: TypeKind.STRING
       }
@@ -131,5 +142,15 @@ describe("path params parser", () => {
         lociTable
       )
     ).toThrowError("Expected to find decorator named 'pathParams'");
+  });
+
+  test("fails to parse empty @example decorator", () => {
+    const err = parsePathParams(
+      method.getParameterOrThrow("paramsWithEmptyExample"),
+      typeTable,
+      lociTable
+    ).unwrapErrOrThrow();
+
+    expect(err).toBeInstanceOf(ParserError);
   });
 });

--- a/lib/src/parsers/path-params-parser.ts
+++ b/lib/src/parsers/path-params-parser.ts
@@ -70,7 +70,20 @@ function extractPathParam(
 
   const description = getJsDoc(propertySignature)?.getDescription().trim();
 
-  return ok({ name, type, description });
+  const example = getJsDoc(propertySignature)
+    ?.getTags()
+    .find(tag => tag.getTagName() === "example");
+
+  if (example && !example.getComment()) {
+    return err(
+      new ParserError("@pathParams example must not be empty", {
+        file: propertySignature.getSourceFile().getFilePath(),
+        position: propertySignature.getPos()
+      })
+    );
+  }
+
+  return ok({ name, type, description, example: example?.getComment() });
 }
 
 function extractPathParamName(

--- a/lib/src/parsers/path-params-parser.ts
+++ b/lib/src/parsers/path-params-parser.ts
@@ -1,4 +1,4 @@
-import { ParameterDeclaration, PropertySignature, TypeNode } from "ts-morph";
+import { ParameterDeclaration, PropertySignature } from "ts-morph";
 import { Example, PathParam } from "../definitions";
 import { OptionalNotAllowedError, ParserError } from "../errors";
 import { isPathParamTypeSafe } from "../http";


### PR DESCRIPTION
## Description, Motivation and Context

I started with an example tag for pathParms as stated in #711 

I looked at the suggestion in https://github.com/airtasker/spot/issues/711#issuecomment-604226927 : 

```javascript
request(
  @pathParams
  pathParams:  {
     /**
      * An identifier
      *
      * @example <caption>Example 32</caption>
      * 32
      *
      * @example <caption>Example 64</caption>
      * 64
      */
     id: Int32
  }
  // ...
) {}
```

Currently it only accepts one example of type string, still need to improve this. Just created this draft to know if this is the way to go to contribute, since I didn't find a CONTRIBUTE.md or similar.


## Checklist:

- [X] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
