### PR TITLE
Allow header, path and query param parsers to allow interfaces and type references

### DIFF
--- a/lib/src/parsers/__spec-examples__/headers.ts
+++ b/lib/src/parsers/__spec-examples__/headers.ts
@@ -13,6 +13,12 @@ class HeadersClass {
       optionalProperty?: Int64;
     },
     @headers
+    interfaceHeaders: IHeader,
+    @headers
+    typeAliasTypeLiteralHeaders: TypeAliasTypeLiteral,
+    @headers
+    typeAliasTypeReferenceHeaders: TypeAliasTypeReference,
+    @headers
     nonObjectHeaders: string,
     @headers
     headersWithIllegalPropertyName: {
@@ -32,3 +38,15 @@ class HeadersClass {
     }
   ) {}
 }
+
+interface IHeader {
+  /** property description */
+  "property-with-description": string;
+}
+
+type TypeAliasTypeLiteral = {
+  /** property description */
+  "property-with-description": string;
+};
+
+type TypeAliasTypeReference = IHeader;

--- a/lib/src/parsers/__spec-examples__/path-params.ts
+++ b/lib/src/parsers/__spec-examples__/path-params.ts
@@ -13,6 +13,12 @@ class PathParamsClass {
       arrayProperty: string[];
     },
     @pathParams
+    interfacePathParams: IPathParams,
+    @pathParams
+    typeAliasTypeLiteralPathParams: TypeAliasTypeLiteral,
+    @pathParams
+    typeAliasTypeReferencePathParams: TypeAliasTypeReference,
+    @pathParams
     pathParamsWithOptionalProperty: {
       property?: string;
     },
@@ -40,3 +46,15 @@ class PathParamsClass {
     }
   ) {}
 }
+
+interface IPathParams {
+  /** property description */
+  "property-with-description": string;
+}
+
+type TypeAliasTypeLiteral = {
+  /** property description */
+  "property-with-description": string;
+};
+
+type TypeAliasTypeReference = IPathParams;

--- a/lib/src/parsers/__spec-examples__/query-params.ts
+++ b/lib/src/parsers/__spec-examples__/query-params.ts
@@ -17,6 +17,12 @@ class QueryParamsClass {
       arrayProperty: string[];
     },
     @queryParams
+    interfaceQueryParams: IQueryParams,
+    @queryParams
+    typeAliasTypeLiteralQueryParams: TypeAliasTypeLiteral,
+    @queryParams
+    typeAliasTypeReferenceQueryParams: TypeAliasTypeReference,
+    @queryParams
     nonObjectQueryParams: string,
     @queryParams
     queryParamsWithIllegalPropertyName: {
@@ -48,3 +54,15 @@ class QueryParamsClass {
     }
   ) {}
 }
+
+interface IQueryParams {
+  /** property description */
+  "property-with-description": string;
+}
+
+type TypeAliasTypeLiteral = {
+  /** property description */
+  "property-with-description": string;
+};
+
+type TypeAliasTypeReference = IQueryParams;

--- a/lib/src/parsers/headers-parser.spec.ts
+++ b/lib/src/parsers/headers-parser.spec.ts
@@ -53,6 +53,52 @@ describe("headers parser", () => {
     });
   });
 
+  test("parses @headers as interface parameter", () => {
+    const result = parseHeaders(
+      method.getParameterOrThrow("interfaceHeaders"),
+      typeTable,
+      lociTable
+    ).unwrapOrThrow();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toStrictEqual({
+      description: "property description",
+      name: "property-with-description",
+      type: {
+        kind: TypeKind.STRING
+      },
+      optional: false
+    });
+  });
+
+  test("parses @headers as type alias type literal parameter", () => {
+    const result = parseHeaders(
+      method.getParameterOrThrow("typeAliasTypeLiteralHeaders"),
+      typeTable,
+      lociTable
+    ).unwrapOrThrow();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toStrictEqual({
+      description: "property description",
+      name: "property-with-description",
+      type: {
+        kind: TypeKind.STRING
+      },
+      optional: false
+    });
+  });
+
+  test("fails to parse @headers as type alias interface parameters", () => {
+    expect(() =>
+      parseHeaders(
+        method.getParameterOrThrow("typeAliasTypeReferenceHeaders"),
+        typeTable,
+        lociTable
+      )
+    ).toThrowError(
+      "expected parameter value to be an type literal or interface object"
+    );
+  });
+
   test("fails to parse @headers decorated non-object parameter", () => {
     expect(() =>
       parseHeaders(
@@ -60,7 +106,9 @@ describe("headers parser", () => {
         typeTable,
         lociTable
       )
-    ).toThrowError("expected parameter value to be an type literal object");
+    ).toThrowError(
+      "expected parameter value to be an type literal or interface object"
+    );
   });
 
   test("fails to parse optional @headers decorated parameter", () => {

--- a/lib/src/parsers/headers-parser.spec.ts
+++ b/lib/src/parsers/headers-parser.spec.ts
@@ -87,16 +87,21 @@ describe("headers parser", () => {
     });
   });
 
-  test("fails to parse @headers as type alias interface parameters", () => {
-    expect(() =>
-      parseHeaders(
-        method.getParameterOrThrow("typeAliasTypeReferenceHeaders"),
-        typeTable,
-        lociTable
-      )
-    ).toThrowError(
-      "expected parameter value to be an type literal or interface object"
-    );
+  test("parses @headers as type alias interface parameters", () => {
+    const result = parseHeaders(
+      method.getParameterOrThrow("typeAliasTypeReferenceHeaders"),
+      typeTable,
+      lociTable
+    ).unwrapOrThrow();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toStrictEqual({
+      description: "property description",
+      name: "property-with-description",
+      type: {
+        kind: TypeKind.STRING
+      },
+      optional: false
+    });
   });
 
   test("fails to parse @headers decorated non-object parameter", () => {

--- a/lib/src/parsers/headers-parser.ts
+++ b/lib/src/parsers/headers-parser.ts
@@ -1,4 +1,4 @@
-import { ParameterDeclaration, PropertySignature } from "ts-morph";
+import { ParameterDeclaration, PropertySignature, TypeGuards } from "ts-morph";
 import { Header } from "../definitions";
 import { OptionalNotAllowedError, ParserError } from "../errors";
 import { isHeaderTypeSafe } from "../http";
@@ -7,7 +7,7 @@ import { Type, TypeTable } from "../types";
 import { err, ok, Result } from "../util";
 import {
   getJsDoc,
-  getParameterTypeAsTypeLiteralOrThrow,
+  getParameterPropertySignaturesOrThrow,
   getPropertyName
 } from "./parser-helpers";
 import { parseType } from "./type-parser";
@@ -27,10 +27,13 @@ export function parseHeaders(
       })
     );
   }
-  const headerTypeLiteral = getParameterTypeAsTypeLiteralOrThrow(parameter);
+
+  const headerPropertySignatures = getParameterPropertySignaturesOrThrow(
+    parameter
+  );
 
   const headers = [];
-  for (const propertySignature of headerTypeLiteral.getProperties()) {
+  for (const propertySignature of headerPropertySignatures) {
     const nameResult = extractHeaderName(propertySignature);
     if (nameResult.isErr()) return nameResult;
     const name = nameResult.unwrap();

--- a/lib/src/parsers/parser-helpers.ts
+++ b/lib/src/parsers/parser-helpers.ts
@@ -162,26 +162,24 @@ export function getParameterPropertySignaturesOrThrow(
   parameter: ParameterDeclaration
 ): PropertySignature[] {
   const typeNode = parameter.getTypeNodeOrThrow();
-  return extractPropertySignaturesFromTypeNode(typeNode);
+  return parseTypeReferencePropertySignaturesOrThrow(typeNode);
 }
 
 function parseTypeReferencePropertySignaturesOrThrow(
-  typeNode: TypeReferenceNode
+  typeNode: TypeNode
 ): PropertySignature[] {
-  const typeReferenceNode = getTargetDeclarationFromTypeReference(typeNode);
-  if (typeReferenceNode.isErr()) throw typeReferenceNode;
-  const declaration = typeReferenceNode.unwrap();
-  // return early if  this is an interface
-  if (TypeGuards.isInterfaceDeclaration(declaration)) {
-    return declaration.getProperties();
-  }
-  const declarationAliasTypeNode = declaration.getTypeNodeOrThrow();
-  return extractPropertySignaturesFromTypeNode(declarationAliasTypeNode);
-}
-
-function extractPropertySignaturesFromTypeNode(typeNode: TypeNode) {
   if (TypeGuards.isTypeReferenceNode(typeNode)) {
-    return parseTypeReferencePropertySignaturesOrThrow(typeNode);
+    const typeReferenceNode = getTargetDeclarationFromTypeReference(typeNode);
+    if (typeReferenceNode.isErr()) throw typeReferenceNode;
+    const declaration = typeReferenceNode.unwrap();
+    // return early if the declaration is an interface
+    if (TypeGuards.isInterfaceDeclaration(declaration)) {
+      return declaration.getProperties();
+    }
+    const declarationAliasTypeNode = declaration.getTypeNodeOrThrow();
+    return parseTypeReferencePropertySignaturesOrThrow(
+      declarationAliasTypeNode
+    );
   } else if (TypeGuards.isTypeLiteralNode(typeNode)) {
     return typeNode.getProperties();
   }

--- a/lib/src/parsers/path-params-parser.spec.ts
+++ b/lib/src/parsers/path-params-parser.spec.ts
@@ -53,6 +53,50 @@ describe("path params parser", () => {
     });
   });
 
+  test("parses @pathParams as interface parameter", () => {
+    const result = parsePathParams(
+      method.getParameterOrThrow("interfacePathParams"),
+      typeTable,
+      lociTable
+    ).unwrapOrThrow();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toStrictEqual({
+      description: "property description",
+      name: "property-with-description",
+      type: {
+        kind: TypeKind.STRING
+      }
+    });
+  });
+
+  test("parses @pathParams as type alias type literal parameter", () => {
+    const result = parsePathParams(
+      method.getParameterOrThrow("typeAliasTypeLiteralPathParams"),
+      typeTable,
+      lociTable
+    ).unwrapOrThrow();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toStrictEqual({
+      description: "property description",
+      name: "property-with-description",
+      type: {
+        kind: TypeKind.STRING
+      }
+    });
+  });
+
+  test("fails to parse @pathParams as type alias interface parameters", () => {
+    expect(() =>
+      parsePathParams(
+        method.getParameterOrThrow("typeAliasTypeReferencePathParams"),
+        typeTable,
+        lociTable
+      )
+    ).toThrowError(
+      "expected parameter value to be an type literal or interface object"
+    );
+  });
+
   test("fails to parse @pathParams decorated non-object parameter", () => {
     expect(() =>
       parsePathParams(
@@ -60,7 +104,9 @@ describe("path params parser", () => {
         typeTable,
         lociTable
       )
-    ).toThrowError("expected parameter value to be an type literal object");
+    ).toThrowError(
+      "expected parameter value to be an type literal or interface object"
+    );
   });
 
   test("fails to parse @pathParams with optional param", () => {

--- a/lib/src/parsers/path-params-parser.spec.ts
+++ b/lib/src/parsers/path-params-parser.spec.ts
@@ -85,16 +85,20 @@ describe("path params parser", () => {
     });
   });
 
-  test("fails to parse @pathParams as type alias interface parameters", () => {
-    expect(() =>
-      parsePathParams(
-        method.getParameterOrThrow("typeAliasTypeReferencePathParams"),
-        typeTable,
-        lociTable
-      )
-    ).toThrowError(
-      "expected parameter value to be an type literal or interface object"
-    );
+  test("parses @pathParams as type alias interface parameters", () => {
+    const result = parsePathParams(
+      method.getParameterOrThrow("typeAliasTypeReferencePathParams"),
+      typeTable,
+      lociTable
+    ).unwrapOrThrow();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toStrictEqual({
+      description: "property description",
+      name: "property-with-description",
+      type: {
+        kind: TypeKind.STRING
+      }
+    });
   });
 
   test("fails to parse @pathParams decorated non-object parameter", () => {

--- a/lib/src/parsers/path-params-parser.ts
+++ b/lib/src/parsers/path-params-parser.ts
@@ -7,7 +7,7 @@ import { Type, TypeTable } from "../types";
 import { err, ok, Result } from "../util";
 import {
   getJsDoc,
-  getParameterTypeAsTypeLiteralOrThrow,
+  getParameterPropertySignaturesOrThrow,
   getPropertyName
 } from "./parser-helpers";
 import { parseType } from "./type-parser";
@@ -26,10 +26,12 @@ export function parsePathParams(
       })
     );
   }
-  const pathParamTypeLiteral = getParameterTypeAsTypeLiteralOrThrow(parameter);
+  const pathParamPropertySignatures = getParameterPropertySignaturesOrThrow(
+    parameter
+  );
 
   const pathParams = [];
-  for (const propertySignature of pathParamTypeLiteral.getProperties()) {
+  for (const propertySignature of pathParamPropertySignatures) {
     const pathParamResult = extractPathParam(
       propertySignature,
       typeTable,

--- a/lib/src/parsers/query-params-parser.spec.ts
+++ b/lib/src/parsers/query-params-parser.spec.ts
@@ -116,16 +116,21 @@ describe("query params parser", () => {
     });
   });
 
-  test("fails to parse @queryParams as type alias interface parameters", () => {
-    expect(() =>
-      parseQueryParams(
-        method.getParameterOrThrow("typeAliasTypeReferenceQueryParams"),
-        typeTable,
-        lociTable
-      )
-    ).toThrowError(
-      "expected parameter value to be an type literal or interface object"
-    );
+  test("parses @queryParams as type alias interface parameter", () => {
+    const result = parseQueryParams(
+      method.getParameterOrThrow("typeAliasTypeReferenceQueryParams"),
+      typeTable,
+      lociTable
+    ).unwrapOrThrow();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toStrictEqual({
+      description: "property description",
+      name: "property-with-description",
+      type: {
+        kind: TypeKind.STRING
+      },
+      optional: false
+    });
   });
 
   test("fails to parse @queryParams decorated non-object parameter", () => {

--- a/lib/src/parsers/query-params-parser.spec.ts
+++ b/lib/src/parsers/query-params-parser.spec.ts
@@ -82,6 +82,52 @@ describe("query params parser", () => {
     });
   });
 
+  test("parses @queryParams as interface parameter", () => {
+    const result = parseQueryParams(
+      method.getParameterOrThrow("interfaceQueryParams"),
+      typeTable,
+      lociTable
+    ).unwrapOrThrow();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toStrictEqual({
+      description: "property description",
+      name: "property-with-description",
+      type: {
+        kind: TypeKind.STRING
+      },
+      optional: false
+    });
+  });
+
+  test("parses @queryParams as type alias type literal parameter", () => {
+    const result = parseQueryParams(
+      method.getParameterOrThrow("typeAliasTypeLiteralQueryParams"),
+      typeTable,
+      lociTable
+    ).unwrapOrThrow();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toStrictEqual({
+      description: "property description",
+      name: "property-with-description",
+      type: {
+        kind: TypeKind.STRING
+      },
+      optional: false
+    });
+  });
+
+  test("fails to parse @queryParams as type alias interface parameters", () => {
+    expect(() =>
+      parseQueryParams(
+        method.getParameterOrThrow("typeAliasTypeReferenceQueryParams"),
+        typeTable,
+        lociTable
+      )
+    ).toThrowError(
+      "expected parameter value to be an type literal or interface object"
+    );
+  });
+
   test("fails to parse @queryParams decorated non-object parameter", () => {
     expect(() =>
       parseQueryParams(
@@ -89,7 +135,9 @@ describe("query params parser", () => {
         typeTable,
         lociTable
       ).unwrapErrOrThrow()
-    ).toThrowError("expected parameter value to be an type literal object");
+    ).toThrowError(
+      "expected parameter value to be an type literal or interface object"
+    );
   });
 
   test("fails to parse optional @queryParams decorated parameter", () => {

--- a/lib/src/parsers/query-params-parser.ts
+++ b/lib/src/parsers/query-params-parser.ts
@@ -7,7 +7,7 @@ import { Type, TypeTable } from "../types";
 import { err, ok, Result } from "../util";
 import {
   getJsDoc,
-  getParameterTypeAsTypeLiteralOrThrow,
+  getParameterPropertySignaturesOrThrow,
   getPropertyName
 } from "./parser-helpers";
 import { parseType } from "./type-parser";
@@ -26,10 +26,12 @@ export function parseQueryParams(
       })
     );
   }
-  const queryParamTypeLiteral = getParameterTypeAsTypeLiteralOrThrow(parameter);
+  const queryParamPropertySignatures = getParameterPropertySignaturesOrThrow(
+    parameter
+  );
 
   const queryParams = [];
-  for (const propertySignature of queryParamTypeLiteral.getProperties()) {
+  for (const propertySignature of queryParamPropertySignatures) {
     const nameResult = extractQueryParamName(propertySignature);
     if (nameResult.isErr()) return nameResult;
     const name = nameResult.unwrap();

--- a/lib/src/parsers/type-parser.ts
+++ b/lib/src/parsers/type-parser.ts
@@ -596,7 +596,7 @@ function resolveIndexAccessPropertyAccessChain(
  *
  * @param typeReference AST type reference node
  */
-function getTargetDeclarationFromTypeReference(
+export function getTargetDeclarationFromTypeReference(
   typeReference: TypeReferenceNode
 ): Result<TypeAliasDeclaration | InterfaceDeclaration, ParserError> {
   // TODO: check logic


### PR DESCRIPTION
## Description, Motivation, and Context
Resolves: https://github.com/airtasker/spot/issues/1009

Allows the declaration of re-usable interfaces and types for headers and parameters so that the following style can be used
```
    request(
        @headers
        headers: SomeTypeHere,
        @pathParams
        pathParams: SomeOtherTypeHere
    ) {}
```
instead of:
```
    request(
        @headers
        headers: { someString: string; },
        @pathParams
        pathParams: { someOtherString: string; }
    ) {}
```

This was also tested locally by extending the definition in the README to:
```
class CreateUser {
  @request
  request(
    @headers
    headers: IHeader,
    @pathParams
    pathParams: PathParams,
    @body body: CreateUserRequest
  ) {}

  @response({ status: 201 })
  successResponse(@body body: CreateUserResponse) {}
}

interface IHeader {
  /** Header for XYZ ABC Purposes */
  someString: string;
}

type PathParams = {
  /** Extra path params for fun */
  someOtherString: string;
};

```

This resulted in the following spec:
```
post:
      operationId: CreateUser
      parameters:
        - name: someOtherString
          in: path
          description: Extra path params for fun
          required: true
          schema:
            type: string
        - name: someString
          in: header
          description: Header for XYZ ABC Purposes
          required: true
          schema:
            type: string
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/CreateUserRequest'
        required: true
```

Will fail from compiling since as per the AST no property signatures are available at that level

## Checklist:

- [x] I've added/updated tests to cover my changes
- [x] I've created an issue associated with this PR
