### PR TITLE
Allow usage of Intersection Types for spec generation

### DIFF
--- a/lib/src/generators/json-schema/__snapshots__/json-schema.spec.ts.snap
+++ b/lib/src/generators/json-schema/__snapshots__/json-schema.spec.ts.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`JSON Schema generator evaluates intersection type 1`] = `
+Object {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": Object {
+    "IntersectionResponse": Object {
+      "allOf": Array [
+        Object {
+          "additionalProperties": true,
+          "properties": Object {
+            "id": Object {
+              "type": "string",
+            },
+          },
+          "required": Array [
+            "id",
+          ],
+          "type": "object",
+        },
+        Object {
+          "additionalProperties": true,
+          "properties": Object {
+            "name": Object {
+              "type": "string",
+            },
+          },
+          "required": Array [
+            "name",
+          ],
+          "type": "object",
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`JSON Schema generator produces definitions 1`] = `
 Object {
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/lib/src/generators/json-schema/__spec-examples__/contract-with-intersection-types.ts
+++ b/lib/src/generators/json-schema/__spec-examples__/contract-with-intersection-types.ts
@@ -9,7 +9,7 @@ class Contract {}
 })
 class IntersectionType {
   @response({ status: 200 })
-  successResponse(@body body: IntersectionResponse ) {}
+  successResponse(@body body: IntersectionResponse) {}
 }
 
-type IntersectionResponse = { id: String; } & { name: String; }
+type IntersectionResponse = { id: String } & { name: String };

--- a/lib/src/generators/json-schema/__spec-examples__/contract-with-intersection-types.ts
+++ b/lib/src/generators/json-schema/__spec-examples__/contract-with-intersection-types.ts
@@ -1,0 +1,15 @@
+import { api, body, endpoint, response, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class IntersectionType {
+  @response({ status: 200 })
+  successResponse(@body body: IntersectionResponse ) {}
+}
+
+type IntersectionResponse = { id: String; } & { name: String; }

--- a/lib/src/generators/json-schema/json-schema-specification.ts
+++ b/lib/src/generators/json-schema/json-schema-specification.ts
@@ -9,6 +9,7 @@ export type JsonSchemaType =
   | JsonSchemaObject
   | JsonSchemaArray
   | JsonSchemaOneOf
+  | JsonSchemaAllOf
   | JsonSchemaNull
   | JsonSchemaString
   | JsonSchemaNumber
@@ -38,6 +39,10 @@ export interface JsonSchemaOneOf {
       [value: string]: JsonSchemaType;
     };
   };
+}
+
+export interface JsonSchemaAllOf {
+  allOf: JsonSchemaType[];
 }
 
 export interface JsonSchemaNull {

--- a/lib/src/generators/json-schema/json-schema-type-util.spec.ts
+++ b/lib/src/generators/json-schema/json-schema-type-util.spec.ts
@@ -9,6 +9,7 @@ import {
   floatType,
   int32Type,
   int64Type,
+  intersectionType,
   intLiteralType,
   nullType,
   objectType,
@@ -405,6 +406,41 @@ describe("JSON schema generator", () => {
       const result = typeToJsonSchemaType(referenceType("CustomType"));
       expect(result).toEqual({
         $ref: "#/definitions/CustomType"
+      });
+    });
+  });
+
+  describe("intersectionType", () => {
+    test("converts to an allOf schema object", () => {
+      const result = typeToJsonSchemaType(
+        intersectionType([
+          objectType([
+            { name: "type", type: stringLiteralType("a"), optional: false },
+            { name: "a", type: stringType(), optional: false }
+          ]),
+          referenceType("CustomObjectTypeB")
+        ])
+      );
+      expect(result).toEqual({
+        allOf: [
+          {
+            additionalProperties: true,
+            properties: {
+              a: {
+                type: "string"
+              },
+              type: {
+                const: "a",
+                type: "string"
+              }
+            },
+            required: ["type", "a"],
+            type: "object"
+          },
+          {
+            $ref: "#/definitions/CustomObjectTypeB"
+          }
+        ]
       });
     });
   });

--- a/lib/src/generators/json-schema/json-schema-type-util.ts
+++ b/lib/src/generators/json-schema/json-schema-type-util.ts
@@ -153,6 +153,16 @@ export function typeToJsonSchemaType(
       return {
         $ref: `#/definitions/${type.name}`
       };
+    case TypeKind.INTERSECTION: {
+      const elements = type.types;
+      if (elements.length === 1) return typeToJsonSchemaType(elements[0]);
+
+      return {
+        allOf: elements
+          .filter(isNotLiteralType)
+          .map(t => typeToJsonSchemaType(t, objectAdditionalProperties))
+      };
+    }
     default:
       throw assertNever(type);
   }

--- a/lib/src/generators/json-schema/json-schema.spec.ts
+++ b/lib/src/generators/json-schema/json-schema.spec.ts
@@ -39,4 +39,17 @@ describe("JSON Schema generator", () => {
     const spectralResult = await spectral.run(result);
     expect(spectralResult).toHaveLength(0);
   });
+
+  test("evaluates intersection type", async () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/contract-with-intersection-types.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+    const result = generateJsonSchema(contract);
+
+    expect(result).toMatchSnapshot();
+    const spectralResult = await spectral.run(result);
+    expect(spectralResult).toHaveLength(0);
+  });
 });

--- a/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
@@ -423,6 +423,60 @@ exports[`OpenAPI 2 generator headers endpoint with response headers 1`] = `
 }"
 `;
 
+exports[`OpenAPI 2 generator intersection types evaluates intersection type 1`] = `
+"{
+  \\"swagger\\": \\"2.0\\",
+  \\"info\\": {
+    \\"title\\": \\"contract\\",
+    \\"version\\": \\"0.0.0\\"
+  },
+  \\"consumes\\": [
+    \\"application/json\\"
+  ],
+  \\"produces\\": [
+    \\"application/json\\"
+  ],
+  \\"paths\\": {
+    \\"/users\\": {
+      \\"get\\": {
+        \\"operationId\\": \\"IntersectionType\\",
+        \\"responses\\": {
+          \\"200\\": {
+            \\"description\\": \\"200 response\\",
+            \\"schema\\": {
+              \\"allOf\\": [
+                {
+                  \\"type\\": \\"object\\",
+                  \\"properties\\": {
+                    \\"id\\": {
+                      \\"type\\": \\"string\\"
+                    }
+                  },
+                  \\"required\\": [
+                    \\"id\\"
+                  ]
+                },
+                {
+                  \\"type\\": \\"object\\",
+                  \\"properties\\": {
+                    \\"name\\": {
+                      \\"type\\": \\"string\\"
+                    }
+                  },
+                  \\"required\\": [
+                    \\"name\\"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`OpenAPI 2 generator minimal contract produces minimal OpenAPI 2 1`] = `
 "{
   \\"swagger\\": \\"2.0\\",

--- a/lib/src/generators/openapi2/__spec-examples__/contract-with-intersection-types.ts
+++ b/lib/src/generators/openapi2/__spec-examples__/contract-with-intersection-types.ts
@@ -9,5 +9,5 @@ class Contract {}
 })
 class IntersectionType {
   @response({ status: 200 })
-  successResponse(@body body: { id: String; } & { name: String }) {}
+  successResponse(@body body: { id: String } & { name: String }) {}
 }

--- a/lib/src/generators/openapi2/__spec-examples__/contract-with-intersection-types.ts
+++ b/lib/src/generators/openapi2/__spec-examples__/contract-with-intersection-types.ts
@@ -1,0 +1,13 @@
+import { api, body, endpoint, response, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class IntersectionType {
+  @response({ status: 200 })
+  successResponse(@body body: { id: String; } & { name: String }) {}
+}

--- a/lib/src/generators/openapi2/openapi2-parameter-util.ts
+++ b/lib/src/generators/openapi2/openapi2-parameter-util.ts
@@ -134,6 +134,10 @@ function basicTypeToParameterBasicTypeObject(
       throw new Error("Object is not supported for parameters in OpenAPI 2");
     case TypeKind.UNION:
       throw new Error("Unions are not supported for parameters in OpenAPI 2");
+    case TypeKind.INTERSECTION:
+      throw new Error(
+        "Intersections are not supported for parameters in OpenAPI 2"
+      );
     default:
       assertNever(type);
   }

--- a/lib/src/generators/openapi2/openapi2-type-util.spec.ts
+++ b/lib/src/generators/openapi2/openapi2-type-util.spec.ts
@@ -9,6 +9,7 @@ import {
   floatType,
   int32Type,
   int64Type,
+  intersectionType,
   intLiteralType,
   nullType,
   objectType,
@@ -506,6 +507,44 @@ describe("OpenAPI 2 type util", () => {
       const result = typeToSchemaObject(referenceType("CustomType"), typeTable);
       expect(result).toEqual({
         $ref: "#/definitions/CustomType"
+      });
+    });
+  });
+
+  describe("intersectionType", () => {
+    test("converts to an allOf schema object", () => {
+      const typeTable = new TypeTable();
+      typeTable.add("CustomType", { type: stringType() });
+
+      const result = typeToSchemaObject(
+        intersectionType([
+          objectType([
+            { name: "type", type: stringLiteralType("a"), optional: false },
+            { name: "a", type: stringType(), optional: false }
+          ]),
+          referenceType("CustomObjectTypeB")
+        ]),
+        typeTable
+      );
+      expect(result).toEqual({
+        allOf: [
+          {
+            properties: {
+              a: {
+                type: "string"
+              },
+              type: {
+                enum: ["a"],
+                type: "string"
+              }
+            },
+            required: ["type", "a"],
+            type: "object"
+          },
+          {
+            $ref: "#/definitions/CustomObjectTypeB"
+          }
+        ]
       });
     });
   });

--- a/lib/src/generators/openapi2/openapi2.spec.ts
+++ b/lib/src/generators/openapi2/openapi2.spec.ts
@@ -298,7 +298,6 @@ describe("OpenAPI 2 generator", () => {
       expect(spectralResult).toHaveLength(0);
     });
   });
-
 });
 
 /**

--- a/lib/src/generators/openapi2/openapi2.spec.ts
+++ b/lib/src/generators/openapi2/openapi2.spec.ts
@@ -284,6 +284,21 @@ describe("OpenAPI 2 generator", () => {
       expect(spectralResult).toHaveLength(0);
     });
   });
+
+  describe("intersection types", () => {
+    test("evaluates intersection type", async () => {
+      const contract = generateContract("contract-with-intersection-types.ts");
+      const result = generateOpenAPI2(contract);
+
+      expect(result.paths["/users"]).toMatchObject({
+        get: expect.anything()
+      });
+      expect(JSON.stringify(result, null, 2)).toMatchSnapshot();
+      const spectralResult = await spectral.run(result);
+      expect(spectralResult).toHaveLength(0);
+    });
+  });
+
 });
 
 /**

--- a/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
@@ -470,6 +470,58 @@ exports[`OpenAPI 3 generator headers endpoint with response headers 1`] = `
 }"
 `;
 
+exports[`OpenAPI 3 generator intersection types evaluates intersection type 1`] = `
+"{
+  \\"openapi\\": \\"3.0.2\\",
+  \\"info\\": {
+    \\"title\\": \\"contract\\",
+    \\"version\\": \\"0.0.0\\"
+  },
+  \\"paths\\": {
+    \\"/users\\": {
+      \\"get\\": {
+        \\"operationId\\": \\"IntersectionType\\",
+        \\"responses\\": {
+          \\"200\\": {
+            \\"description\\": \\"200 response\\",
+            \\"content\\": {
+              \\"application/json\\": {
+                \\"schema\\": {
+                  \\"allOf\\": [
+                    {
+                      \\"type\\": \\"object\\",
+                      \\"properties\\": {
+                        \\"id\\": {
+                          \\"type\\": \\"string\\"
+                        }
+                      },
+                      \\"required\\": [
+                        \\"id\\"
+                      ]
+                    },
+                    {
+                      \\"type\\": \\"object\\",
+                      \\"properties\\": {
+                        \\"name\\": {
+                          \\"type\\": \\"string\\"
+                        }
+                      },
+                      \\"required\\": [
+                        \\"name\\"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`OpenAPI 3 generator minimal contract produces minimal OpenAPI 3 1`] = `
 "{
   \\"openapi\\": \\"3.0.2\\",

--- a/lib/src/generators/openapi3/__spec-examples__/contract-with-intersection-types.ts
+++ b/lib/src/generators/openapi3/__spec-examples__/contract-with-intersection-types.ts
@@ -9,5 +9,5 @@ class Contract {}
 })
 class IntersectionType {
   @response({ status: 200 })
-  successResponse(@body body: { id: String; } & { name: String }) {}
+  successResponse(@body body: { id: String } & { name: String }) {}
 }

--- a/lib/src/generators/openapi3/__spec-examples__/contract-with-intersection-types.ts
+++ b/lib/src/generators/openapi3/__spec-examples__/contract-with-intersection-types.ts
@@ -1,0 +1,13 @@
+import { api, body, endpoint, response, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class IntersectionType {
+  @response({ status: 200 })
+  successResponse(@body body: { id: String; } & { name: String }) {}
+}

--- a/lib/src/generators/openapi3/openapi3-type-util.spec.ts
+++ b/lib/src/generators/openapi3/openapi3-type-util.spec.ts
@@ -9,6 +9,7 @@ import {
   floatType,
   int32Type,
   int64Type,
+  intersectionType,
   intLiteralType,
   nullType,
   objectType,
@@ -704,6 +705,44 @@ describe("OpenAPI 3 type util", () => {
       );
       expect(result).toEqual({
         $ref: "#/components/schemas/CustomType"
+      });
+    });
+  });
+
+  describe("intersectionType", () => {
+    test("converts to an allOf schema object", () => {
+      const typeTable = new TypeTable();
+      typeTable.add("CustomType", { type: stringType() });
+
+      const result = typeToSchemaOrReferenceObject(
+        intersectionType([
+          objectType([
+            { name: "type", type: stringLiteralType("a"), optional: false },
+            { name: "a", type: stringType(), optional: false }
+          ]),
+          referenceType("CustomObjectTypeB")
+        ]),
+        typeTable
+      );
+      expect(result).toEqual({
+        allOf: [
+          {
+            properties: {
+              a: {
+                type: "string"
+              },
+              type: {
+                enum: ["a"],
+                type: "string"
+              }
+            },
+            required: ["type", "a"],
+            type: "object"
+          },
+          {
+            $ref: "#/components/schemas/CustomObjectTypeB"
+          }
+        ]
       });
     });
   });

--- a/lib/src/generators/openapi3/openapi3-type-util.ts
+++ b/lib/src/generators/openapi3/openapi3-type-util.ts
@@ -17,7 +17,9 @@ import {
   Type,
   TypeKind,
   TypeTable,
-  UnionType
+  UnionType,
+  possibleRootTypes,
+  ObjectPropertiesType
 } from "../../types";
 import {
   ArraySchemaObject,
@@ -254,9 +256,15 @@ function unionTypeToDiscrimintorObject(
   const nonNullTypes = unionType.types.filter(isNotNullType);
 
   // Discriminator mapping is only supported for reference types
-  const objectReferenceOnly = nonNullTypes.every(
-    t => isReferenceType(t) && isObjectType(dereferenceType(t, typeTable))
-  );
+  // however reference can even point to union or
+  // intersection types. This ensures those also meet the
+  // requirement
+  const objectReferenceOnly = nonNullTypes.every(t => {
+    return (
+      isReferenceType(t) && possibleRootTypes(t, typeTable).every(isObjectType)
+    );
+  });
+
   if (!objectReferenceOnly) return { propertyName: unionType.discriminator };
 
   const mapping = nonNullTypes.reduce<{ [key: string]: string }>((acc, t) => {
@@ -265,18 +273,33 @@ function unionTypeToDiscrimintorObject(
       throw new Error("Unexpected error: expected reference type");
     }
 
-    const concreteType = dereferenceType(t, typeTable);
+    const concreteTypes = possibleRootTypes(t, typeTable);
 
     // Sanity check and type cast
-    if (!isObjectType(concreteType)) {
+    if (!concreteTypes.every(isObjectType)) {
       throw new Error("Unexpected error: expected object reference type");
     }
 
     // Retrieve the discriminator property
     // Discriminator properties cannot be optional - we assume this is handled by the type parser
-    const discriminatorProp = concreteType.properties.find(
+    // We first determine the object which contains the discriminator
+    // followed by which we identify the prop itself.
+    // This helps us identify discriminators even if one of the unions is an intersection or is
+    // a union of unions
+    const discriminatorObject = concreteTypes.find(object => {
+      return object.properties.find(p => p.name === unionType.discriminator);
+    });
+
+    if (discriminatorObject === undefined) {
+      throw new Error(
+        "Unexpected error: could not find expected discriminator property in objects"
+      );
+    }
+
+    const discriminatorProp = discriminatorObject.properties.find(
       p => p.name === unionType.discriminator
     );
+
     if (discriminatorProp === undefined) {
       throw new Error(
         "Unexpected error: could not find expected discriminator property"

--- a/lib/src/generators/openapi3/openapi3.spec.ts
+++ b/lib/src/generators/openapi3/openapi3.spec.ts
@@ -349,6 +349,20 @@ describe("OpenAPI 3 generator", () => {
       expect(spectralResult).toHaveLength(0);
     });
   });
+
+  describe("intersection types", () => {
+    test("evaluates intersection type", async () => {
+      const contract = generateContract("contract-with-intersection-types.ts");
+      const result = generateOpenAPI3(contract);
+
+      expect(result.paths["/users"]).toMatchObject({
+        get: expect.anything()
+      });
+      expect(JSON.stringify(result, null, 2)).toMatchSnapshot();
+      const spectralResult = await spectral.run(result);
+      expect(spectralResult).toHaveLength(0);
+    });
+  });
 });
 
 /**

--- a/lib/src/http.ts
+++ b/lib/src/http.ts
@@ -28,6 +28,7 @@ export function isPathParamTypeSafe(type: Type, typeTable: TypeTable): boolean {
     case TypeKind.ARRAY:
       return isParamArrayElementTypeSafe(type.elementType, typeTable);
     case TypeKind.UNION:
+    case TypeKind.INTERSECTION:
       return type.types.every(t => isPathParamTypeSafe(t, typeTable));
     case TypeKind.REFERENCE:
       return isPathParamTypeSafe(dereferenceType(type, typeTable), typeTable);
@@ -69,6 +70,7 @@ export function isQueryParamTypeSafe(
         isParamObjectPropertyTypeSafe(p.type, typeTable)
       );
     case TypeKind.UNION:
+    case TypeKind.INTERSECTION:
       return type.types.every(t => isQueryParamTypeSafe(t, typeTable));
     case TypeKind.REFERENCE:
       return isQueryParamTypeSafe(dereferenceType(type, typeTable), typeTable);
@@ -103,6 +105,7 @@ export function isHeaderTypeSafe(type: Type, typeTable: TypeTable): boolean {
     case TypeKind.OBJECT:
       return false;
     case TypeKind.UNION:
+    case TypeKind.INTERSECTION:
       return type.types.every(t => isHeaderTypeSafe(t, typeTable));
     case TypeKind.REFERENCE:
       return isHeaderTypeSafe(dereferenceType(type, typeTable), typeTable);
@@ -140,6 +143,7 @@ function isParamObjectPropertyTypeSafe(
     case TypeKind.OBJECT:
       return false;
     case TypeKind.UNION:
+    case TypeKind.INTERSECTION:
       return type.types.every(t => isParamObjectPropertyTypeSafe(t, typeTable));
     case TypeKind.REFERENCE:
       return isParamObjectPropertyTypeSafe(
@@ -180,6 +184,7 @@ function isParamArrayElementTypeSafe(
     case TypeKind.OBJECT:
       return false;
     case TypeKind.UNION:
+    case TypeKind.INTERSECTION:
       return type.types.every(t => isParamArrayElementTypeSafe(t, typeTable));
     case TypeKind.REFERENCE:
       return isParamArrayElementTypeSafe(

--- a/lib/src/linting/rules/has-discriminator.ts
+++ b/lib/src/linting/rules/has-discriminator.ts
@@ -126,7 +126,6 @@ function findDisriminatorViolations(
     case TypeKind.INT_LITERAL:
     case TypeKind.DATE:
     case TypeKind.DATE_TIME:
-    case TypeKind.INTERSECTION:
       return [];
     case TypeKind.OBJECT:
       return type.properties.reduce<string[]>((acc, prop) => {
@@ -144,6 +143,12 @@ function findDisriminatorViolations(
         typeTable,
         typePath.concat("[]")
       );
+    case TypeKind.INTERSECTION:
+      return type.types.reduce<string[]>((acc, t) => {
+        return acc.concat(
+          findDisriminatorViolations(t, typeTable, typePath.concat())
+        );
+      }, []);
     case TypeKind.UNION: {
       const violationsInUnionTypes = type.types.reduce<string[]>((acc, t) => {
         return acc.concat(

--- a/lib/src/linting/rules/has-discriminator.ts
+++ b/lib/src/linting/rules/has-discriminator.ts
@@ -126,6 +126,7 @@ function findDisriminatorViolations(
     case TypeKind.INT_LITERAL:
     case TypeKind.DATE:
     case TypeKind.DATE_TIME:
+    case TypeKind.INTERSECTION:
       return [];
     case TypeKind.OBJECT:
       return type.properties.reduce<string[]>((acc, prop) => {

--- a/lib/src/linting/rules/no-inline-objects-within-unions.ts
+++ b/lib/src/linting/rules/no-inline-objects-within-unions.ts
@@ -156,6 +156,7 @@ function findInlineObjectInUnionViolations(
         typeTable,
         typePath.concat("[]")
       );
+    case TypeKind.INTERSECTION:
     case TypeKind.UNION: {
       const violationsInUnionTypes = type.types.reduce<string[]>((acc, t) => {
         return acc.concat(

--- a/lib/src/linting/rules/no-nullable-arrays.ts
+++ b/lib/src/linting/rules/no-nullable-arrays.ts
@@ -143,6 +143,7 @@ function findNullableArrayViolations(
         typeTable,
         typePath.concat("[]")
       );
+    case TypeKind.INTERSECTION:
     case TypeKind.UNION: {
       const violationsInUnionTypes = type.types.reduce<string[]>((acc, t) => {
         return acc.concat(

--- a/lib/src/linting/rules/no-nullable-fields-within-request-bodies.ts
+++ b/lib/src/linting/rules/no-nullable-fields-within-request-bodies.ts
@@ -75,6 +75,7 @@ function findNullableFieldViolation(
         typeTable,
         typePath.concat("[]")
       );
+    case TypeKind.INTERSECTION:
     case TypeKind.UNION:
       return type.types.reduce<string[]>((acc, t) => {
         return acc.concat(

--- a/lib/src/linting/rules/no-omittable-fields-within-response-bodies.ts
+++ b/lib/src/linting/rules/no-omittable-fields-within-response-bodies.ts
@@ -100,6 +100,7 @@ function findOmittableFieldViolation(
         typeTable,
         typePath.concat("[]")
       );
+    case TypeKind.INTERSECTION:
     case TypeKind.UNION:
       return type.types.reduce<string[]>((acc, t) => {
         return acc.concat(

--- a/lib/src/mock-server/dummy.ts
+++ b/lib/src/mock-server/dummy.ts
@@ -51,6 +51,8 @@ export function generateData(types: TypeTable, type: Type): any {
       }
       return array;
     }
+    case TypeKind.INTERSECTION:
+      return type.types.map(type => generateData(types, type));
     case TypeKind.UNION:
       return generateData(
         types,

--- a/lib/src/parser.ts
+++ b/lib/src/parser.ts
@@ -34,6 +34,7 @@ function createProject(): Project {
     strictFunctionTypes: true,
     strictPropertyInitialization: true,
     noImplicitThis: true,
+    resolveJsonModule: true,
     alwaysStrict: true,
     noImplicitReturns: true,
     noFallthroughCasesInSwitch: true,

--- a/lib/src/parsers/__spec-examples__/body.ts
+++ b/lib/src/parsers/__spec-examples__/body.ts
@@ -6,6 +6,19 @@ class BodyClass {
     @body body: string,
     /** Body description */
     @body bodyWithDescription: string,
+    @body intersectionTypeBody: TypeAliasIntersection,
     @body optionalBody?: string
   ) {}
 }
+
+type TypeAliasTypeLiteral = {
+  /** property description */
+  "property-with-description": string;
+};
+
+type TypeAliasTypeLiteral2 = {
+  /** property description */
+  "property-2-with-description": string;
+};
+
+type TypeAliasIntersection = TypeAliasTypeLiteral & TypeAliasTypeLiteral2;

--- a/lib/src/parsers/__spec-examples__/path-params.ts
+++ b/lib/src/parsers/__spec-examples__/path-params.ts
@@ -60,6 +60,10 @@ class PathParamsClass {
     @pathParams
     interfacePathParams: IPathParams,
     @pathParams
+    typeAliasIntersectionPathParams: TypeAliasIntersection,
+    @pathParams
+    typeAliasAndLiteralIntersectionPathParams: TypeAliasAndLiteralIntersection,
+    @pathParams
     typeAliasTypeLiteralPathParams: TypeAliasTypeLiteral,
     @pathParams
     typeAliasTypeReferencePathParams: TypeAliasTypeReference,
@@ -109,4 +113,15 @@ type TypeAliasTypeLiteral = {
   "property-with-description": string;
 };
 
+type TypeAliasTypeLiteral2 = {
+  /** property description */
+  "property-2-with-description": string;
+};
+
 type TypeAliasTypeReference = IPathParams;
+
+type TypeAliasIntersection = TypeAliasTypeLiteral & TypeAliasTypeLiteral2;
+type TypeAliasAndLiteralIntersection = TypeAliasTypeLiteral & {
+  /** property description */
+  "property-2-with-description": string;
+};

--- a/lib/src/parsers/__spec-examples__/types.ts
+++ b/lib/src/parsers/__spec-examples__/types.ts
@@ -50,6 +50,11 @@ interface TypeInterface {
   } & {
     typeB: boolean;
   };
+  illegalIntersection: {
+    typeA: string;
+  } & {
+    typeA: boolean;
+  };
   interface: Interface;
   interfaceWithDescription: InterfaceWithDescription;
   interfaceExtends: InterfaceExtends;

--- a/lib/src/parsers/__spec-examples__/types.ts
+++ b/lib/src/parsers/__spec-examples__/types.ts
@@ -45,6 +45,11 @@ interface TypeInterface {
   aliasString: AliasString;
   aliasArray: AliasArray;
   aliasWithDescription: AliasWithDescription;
+  intersectionType: {
+    typeA: string;
+  } & {
+    typeB: boolean;
+  };
   interface: Interface;
   interfaceWithDescription: InterfaceWithDescription;
   interfaceExtends: InterfaceExtends;

--- a/lib/src/parsers/body-parser.spec.ts
+++ b/lib/src/parsers/body-parser.spec.ts
@@ -57,7 +57,8 @@ describe("body parser", () => {
 
     expect(result).toStrictEqual({
       type: {
-        kind: TypeKind.STRING
+        kind: "reference",
+        name: "TypeAliasIntersection"
       }
     });
   });

--- a/lib/src/parsers/body-parser.spec.ts
+++ b/lib/src/parsers/body-parser.spec.ts
@@ -48,6 +48,20 @@ describe("body parser", () => {
     });
   });
 
+  test("parses @body decorated parameter with intersection type", () => {
+    const result = parseBody(
+      method.getParameterOrThrow("intersectionTypeBody"),
+      typeTable,
+      lociTable
+    ).unwrapOrThrow();
+
+    expect(result).toStrictEqual({
+      type: {
+        kind: TypeKind.STRING
+      }
+    });
+  });
+
   test("fails to parse optional @body decorated parameter", () => {
     expect(
       parseBody(

--- a/lib/src/parsers/parser-helpers.ts
+++ b/lib/src/parsers/parser-helpers.ts
@@ -177,6 +177,11 @@ export function parseTypeReferencePropertySignaturesOrThrow(
     );
   } else if (TypeGuards.isTypeLiteralNode(typeNode)) {
     return typeNode.getProperties();
+  } else if (TypeGuards.isIntersectionTypeNode(typeNode)) {
+    return typeNode
+      .getTypeNodes()
+      .map(parseTypeReferencePropertySignaturesOrThrow)
+      .flat();
   }
   throw new Error(
     "expected parameter value to be an type literal or interface object"

--- a/lib/src/parsers/path-params-parser.spec.ts
+++ b/lib/src/parsers/path-params-parser.spec.ts
@@ -115,6 +115,56 @@ describe("path params parser", () => {
     });
   });
 
+  test("parses @pathParams as type alias intersection parameter", () => {
+    const result = parsePathParams(
+      method.getParameterOrThrow("typeAliasIntersectionPathParams"),
+      typeTable,
+      lociTable
+    ).unwrapOrThrow();
+    expect(result).toHaveLength(2);
+    expect(result[1]).toEqual({
+      description: "property description",
+      examples: undefined,
+      name: "property-with-description",
+      type: {
+        kind: TypeKind.STRING
+      }
+    });
+    expect(result[0]).toEqual({
+      description: "property description",
+      examples: undefined,
+      name: "property-2-with-description",
+      type: {
+        kind: TypeKind.STRING
+      }
+    });
+  });
+
+  test("parses @pathParams as type alias and literal intersection parameter", () => {
+    const result = parsePathParams(
+      method.getParameterOrThrow("typeAliasAndLiteralIntersectionPathParams"),
+      typeTable,
+      lociTable
+    ).unwrapOrThrow();
+    expect(result).toHaveLength(2);
+    expect(result[1]).toEqual({
+      description: "property description",
+      examples: undefined,
+      name: "property-with-description",
+      type: {
+        kind: TypeKind.STRING
+      }
+    });
+    expect(result[0]).toEqual({
+      description: "property description",
+      examples: undefined,
+      name: "property-2-with-description",
+      type: {
+        kind: TypeKind.STRING
+      }
+    });
+  });
+
   test("parses @pathParams as type alias interface parameters", () => {
     const result = parsePathParams(
       method.getParameterOrThrow("typeAliasTypeReferencePathParams"),

--- a/lib/src/parsers/type-parser.spec.ts
+++ b/lib/src/parsers/type-parser.spec.ts
@@ -541,7 +541,6 @@ describe("type parser", () => {
     expect(parseType(type, typeTable, lociTable).unwrapOrThrow()).toStrictEqual(
       {
         kind: "intersection",
-        discriminator: undefined,
         types: [
           {
             kind: TypeKind.OBJECT,

--- a/lib/src/parsers/type-parser.spec.ts
+++ b/lib/src/parsers/type-parser.spec.ts
@@ -574,6 +574,16 @@ describe("type parser", () => {
     );
   });
 
+  test("fails when intersection type definition is an illegal", () => {
+    const type = interphace
+      .getPropertyOrThrow("illegalIntersection")
+      .getTypeNodeOrThrow();
+
+    expect(
+      parseType(type, typeTable, lociTable).unwrapErrOrThrow()
+    ).toBeInstanceOf(TypeNotAllowedError);
+  });
+
   test("fails to parse inlined indexed accessing", () => {
     const type = interphace
       .getPropertyOrThrow("indexedAccessInline")

--- a/lib/src/parsers/type-parser.spec.ts
+++ b/lib/src/parsers/type-parser.spec.ts
@@ -533,6 +533,46 @@ describe("type parser", () => {
     ).toStrictEqual({ kind: "boolean" });
   });
 
+  test("parses intersection type", () => {
+    const type = interphace
+      .getPropertyOrThrow("intersectionType")
+      .getTypeNodeOrThrow();
+
+    expect(parseType(type, typeTable, lociTable).unwrapOrThrow()).toStrictEqual(
+      {
+        kind: "intersection",
+        types: [
+          {
+            kind: TypeKind.OBJECT,
+            properties: [
+              {
+                description: undefined,
+                name: "typeA",
+                optional: false,
+                type: {
+                  kind: TypeKind.STRING
+                }
+              }
+            ]
+          },
+          {
+            kind: TypeKind.OBJECT,
+            properties: [
+              {
+                description: undefined,
+                name: "typeB",
+                optional: false,
+                type: {
+                  kind: TypeKind.BOOLEAN
+                }
+              }
+            ]
+          }
+        ]
+      }
+    );
+  });
+
   test("fails to parse inlined indexed accessing", () => {
     const type = interphace
       .getPropertyOrThrow("indexedAccessInline")

--- a/lib/src/parsers/type-parser.spec.ts
+++ b/lib/src/parsers/type-parser.spec.ts
@@ -541,6 +541,7 @@ describe("type parser", () => {
     expect(parseType(type, typeTable, lociTable).unwrapOrThrow()).toStrictEqual(
       {
         kind: "intersection",
+        discriminator: undefined,
         types: [
           {
             kind: TypeKind.OBJECT,

--- a/lib/src/parsers/type-parser.ts
+++ b/lib/src/parsers/type-parser.ts
@@ -52,7 +52,10 @@ import {
   NullType,
   intersectionType,
   isPrimitiveType,
-  isArrayType, doesInterfaceEvaluatesToNever, possibleRootTypes, isObjectType
+  isArrayType,
+  doesInterfaceEvaluatesToNever,
+  possibleRootTypes,
+  isObjectType
 } from "../types";
 import { err, ok, Result } from "../util";
 import { getJsDoc, getPropertyName } from "./parser-helpers";

--- a/lib/src/parsers/type-parser.ts
+++ b/lib/src/parsers/type-parser.ts
@@ -51,12 +51,9 @@ import {
   unionType,
   NullType,
   intersectionType,
-  isPrimitiveType,
-  isArrayType,
   doesInterfaceEvaluatesToNever,
   possibleRootTypes,
-  isObjectType,
-  resolveStringIntersectionToNarrowestType
+  isObjectType
 } from "../types";
 import { err, ok, Result } from "../util";
 import { getJsDoc, getPropertyName } from "./parser-helpers";

--- a/lib/src/parsers/type-parser.ts
+++ b/lib/src/parsers/type-parser.ts
@@ -55,7 +55,8 @@ import {
   isArrayType,
   doesInterfaceEvaluatesToNever,
   possibleRootTypes,
-  isObjectType
+  isObjectType,
+  resolveStringIntersectionToNarrowestType
 } from "../types";
 import { err, ok, Result } from "../util";
 import { getJsDoc, getPropertyName } from "./parser-helpers";

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -268,12 +268,10 @@ export function unionType(
   };
 }
 
-export function intersectionType(
-  intersectionTypes: Type[],
-): IntersectionType {
+export function intersectionType(intersectionTypes: Type[]): IntersectionType {
   return {
     kind: TypeKind.INTERSECTION,
-    types: intersectionTypes,
+    types: intersectionTypes
   };
 }
 
@@ -478,7 +476,7 @@ export function possibleRootTypes(
         }
       ];
     }
-    throw new Error('Intersection type does not evaluate only object types')
+    throw new Error("Intersection type does not evaluate only object types");
   }
   return [type];
 }
@@ -562,7 +560,6 @@ export function inferDiscriminator(
     : undefined;
 }
 
-
 /**
  * Given a list of types, try to find if the intersection evaluates to
  * a `never` type
@@ -574,7 +571,6 @@ export function doesInterfaceEvaluatesToNever(
   types: Array<Type>,
   typeTable: TypeTable
 ): boolean {
-
   // the types on an intersection will always be an object at its root
   // this way we make sure we get an Object Type
   const concreteRootTypesExcludingNull = types
@@ -584,18 +580,12 @@ export function doesInterfaceEvaluatesToNever(
     .filter(isNotNullType)
     .filter(isObjectType);
 
-  const possibleDiscriminators = new Map<
-    string,
-    Type[]
-    >();
+  const possibleDiscriminators = new Map<string, Type[]>();
 
   for (const type of concreteRootTypesExcludingNull) {
     for (const property of type.properties) {
       const current = possibleDiscriminators.get(property.name);
-      possibleDiscriminators.set(
-        property.name,
-        (current ?? []).concat(type)
-      );
+      possibleDiscriminators.set(property.name, (current ?? []).concat(type));
     }
   }
 
@@ -609,7 +599,6 @@ export function doesInterfaceEvaluatesToNever(
 
   return false;
 }
-
 
 /**
  * Loci table is a lookup table for types.

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -17,7 +17,8 @@ export enum TypeKind {
   OBJECT = "object",
   ARRAY = "array",
   UNION = "union",
-  REFERENCE = "reference"
+  REFERENCE = "reference",
+  INTERSECTION = "intersection"
 }
 
 export type Type =
@@ -37,7 +38,8 @@ export type Type =
   | ObjectType
   | ArrayType
   | UnionType
-  | ReferenceType;
+  | ReferenceType
+  | IntersectionType;
 
 /**
  * A concrete type is any type that is not a union of types or reference to a type.
@@ -132,6 +134,11 @@ export interface UnionType {
   kind: TypeKind.UNION;
   types: Type[];
   discriminator?: string;
+}
+
+export interface IntersectionType {
+  kind: TypeKind.INTERSECTION;
+  types: Type[];
 }
 
 export interface ReferenceType {
@@ -252,6 +259,13 @@ export function unionType(
     kind: TypeKind.UNION,
     types: unionTypes,
     discriminator
+  };
+}
+
+export function intersectionType(intersectionTypes: Type[]): IntersectionType {
+  return {
+    kind: TypeKind.INTERSECTION,
+    types: intersectionTypes
   };
 }
 
@@ -386,6 +400,7 @@ export function isPrimitiveType(type: Type): type is PrimitiveType {
     case TypeKind.ARRAY:
     case TypeKind.UNION:
     case TypeKind.REFERENCE:
+    case TypeKind.INTERSECTION:
       return false;
     default:
       throw assertNever(type);

--- a/lib/src/validation-server/verifications/string-validator.ts
+++ b/lib/src/validation-server/verifications/string-validator.ts
@@ -31,6 +31,7 @@ export class StringValidator {
       case TypeKind.INT64:
       case TypeKind.DATE:
       case TypeKind.DATE_TIME:
+      case TypeKind.INTERSECTION:
         return `"${input}" should be ${type.kind}`;
       case TypeKind.BOOLEAN_LITERAL:
       case TypeKind.STRING_LITERAL:
@@ -108,6 +109,7 @@ export class StringValidator {
         return this.validateObject(input, type);
       case TypeKind.ARRAY:
         return this.validateArray(input, type);
+      case TypeKind.INTERSECTION:
       case TypeKind.UNION:
         // eslint-disable-next-line no-case-declarations
         const anyValid = type.types.some(t => {


### PR DESCRIPTION
## Description, Motivation and Context
Resolves: https://github.com/airtasker/spot/issues/1123

This PR allows for the usage of `intersection` types in contract definitions

Sample Contract:
```
import {
  api,
  endpoint,
  request,
  queryParams,
  body,
  response
} from "../lib/src/syntax";

@api({
  name: "My API"
})
class Api {}

@endpoint({
  method: "POST",
  path: "/users"
})
class CreateUser {
  @request
  request(
    @queryParams
    queryParams: LimitParams & OffsetParam,
    @body body: CreateUserResponse
  ) {}

  @response({ status: 201 })
  successResponse(@body body: bodyType) {}
}

type bodyType = CreateUserResponse & OffsetParam;

interface LimitParams {
  limit?: number;
}

interface OffsetParam {
  offset: string;
}

interface CreateUserResponse {
  firstName: string;
  lastName: string;
  role: string;
}
```

Sample Spec:
```
openapi: 3.0.2
info:
  title: My API
  version: 0.0.0
paths:
  /users:
    post:
      operationId: CreateUser
      parameters:
        - name: limit
          in: query
          required: false
          schema:
            type: number
            format: float
        - name: offset
          in: query
          required: true
          schema:
            type: string
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/CreateUserResponse'
        required: true
      responses:
        '201':
          description: 201 response
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/bodyType'
components:
  schemas:
    CreateUserResponse:
      type: object
      properties:
        firstName:
          type: string
        lastName:
          type: string
        role:
          type: string
      required:
        - firstName
        - lastName
        - role
    OffsetParam:
      type: object
      properties:
        offset:
          type: string
      required:
        - offset
    bodyType:
      allOf:
        - $ref: '#/components/schemas/CreateUserResponse'
        - $ref: '#/components/schemas/OffsetParam'
```

## Checklist:

- [x] I've added/updated tests to cover my changes
- [x] I've created an issue associated with this PR
