### PR TITLE
remove sorting from the parser

### DIFF
--- a/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
@@ -393,10 +393,10 @@ exports[`OpenAPI 2 generator headers endpoint with response headers 1`] = `
           \\"201\\": {
             \\"description\\": \\"201 response\\",
             \\"headers\\": {
-              \\"Link\\": {
+              \\"Location\\": {
                 \\"type\\": \\"string\\"
               },
-              \\"Location\\": {
+              \\"Link\\": {
                 \\"type\\": \\"string\\"
               }
             },

--- a/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
@@ -430,14 +430,14 @@ exports[`OpenAPI 3 generator headers endpoint with response headers 1`] = `
           \\"201\\": {
             \\"description\\": \\"201 response\\",
             \\"headers\\": {
-              \\"Link\\": {
-                \\"required\\": false,
+              \\"Location\\": {
+                \\"required\\": true,
                 \\"schema\\": {
                   \\"type\\": \\"string\\"
                 }
               },
-              \\"Location\\": {
-                \\"required\\": true,
+              \\"Link\\": {
+                \\"required\\": false,
                 \\"schema\\": {
                   \\"type\\": \\"string\\"
                 }

--- a/lib/src/parsers/contract-parser.ts
+++ b/lib/src/parsers/contract-parser.ts
@@ -171,5 +171,5 @@ function extractEndpoints(
     if (endpointResult.isErr()) return endpointResult;
     endpoints.push(endpointResult.unwrap());
   }
-  return ok(endpoints.sort((a, b) => (b.name > a.name ? -1 : 1)));
+  return ok(endpoints);
 }

--- a/lib/src/parsers/headers-parser.spec.ts
+++ b/lib/src/parsers/headers-parser.spec.ts
@@ -30,22 +30,13 @@ describe("headers parser", () => {
     expect(result[0]).toStrictEqual({
       description: undefined,
       examples: undefined,
-      name: "optionalProperty",
-      type: {
-        kind: TypeKind.INT64
-      },
-      optional: true
-    });
-    expect(result[1]).toStrictEqual({
-      description: undefined,
-      examples: undefined,
       name: "property",
       type: {
         kind: TypeKind.STRING
       },
       optional: false
     });
-    expect(result[2]).toStrictEqual({
+    expect(result[1]).toStrictEqual({
       description: "property description",
       examples: undefined,
       name: "property-with-description",
@@ -54,7 +45,7 @@ describe("headers parser", () => {
       },
       optional: false
     });
-    expect(result[3]).toStrictEqual({
+    expect(result[2]).toStrictEqual({
       description: "property-example description",
       examples: [{ name: "property-example", value: "property-example-value" }],
       name: "property-with-example",
@@ -63,7 +54,7 @@ describe("headers parser", () => {
       },
       optional: false
     });
-    expect(result[4]).toStrictEqual({
+    expect(result[3]).toStrictEqual({
       description: "property-two-examples description",
       examples: [
         {
@@ -80,6 +71,15 @@ describe("headers parser", () => {
         kind: TypeKind.INT32
       },
       optional: false
+    });
+    expect(result[4]).toStrictEqual({
+      description: undefined,
+      examples: undefined,
+      name: "optionalProperty",
+      type: {
+        kind: TypeKind.INT64
+      },
+      optional: true
     });
   });
 

--- a/lib/src/parsers/headers-parser.ts
+++ b/lib/src/parsers/headers-parser.ts
@@ -63,7 +63,7 @@ export function parseHeaders(
     });
   }
 
-  return ok(headers.sort((a, b) => (b.name > a.name ? -1 : 1)));
+  return ok(headers);
 }
 
 function extractHeaderName(

--- a/lib/src/parsers/path-params-parser.spec.ts
+++ b/lib/src/parsers/path-params-parser.spec.ts
@@ -30,28 +30,28 @@ describe("path params parser", () => {
     expect(result[0]).toStrictEqual({
       description: undefined,
       examples: undefined,
+      name: "property",
+      type: {
+        kind: TypeKind.STRING
+      }
+    });
+    expect(result[1]).toStrictEqual({
+      description: "property description",
+      examples: undefined,
+      name: "property-with-description",
+      type: {
+        kind: TypeKind.STRING
+      }
+    });
+    expect(result[2]).toStrictEqual({
+      description: undefined,
+      examples: undefined,
       name: "arrayProperty",
       type: {
         kind: TypeKind.ARRAY,
         elementType: {
           kind: TypeKind.STRING
         }
-      }
-    });
-    expect(result[1]).toStrictEqual({
-      description: undefined,
-      examples: undefined,
-      name: "property",
-      type: {
-        kind: TypeKind.STRING
-      }
-    });
-    expect(result[2]).toStrictEqual({
-      description: "property description",
-      examples: undefined,
-      name: "property-with-description",
-      type: {
-        kind: TypeKind.STRING
       }
     });
     expect(result[3]).toStrictEqual({

--- a/lib/src/parsers/path-params-parser.ts
+++ b/lib/src/parsers/path-params-parser.ts
@@ -42,7 +42,7 @@ export function parsePathParams(
     pathParams.push(pathParamResult.unwrap());
   }
 
-  return ok(pathParams.sort((a, b) => (b.name > a.name ? -1 : 1)));
+  return ok(pathParams);
 }
 
 function extractPathParam(

--- a/lib/src/parsers/query-params-parser.spec.ts
+++ b/lib/src/parsers/query-params-parser.spec.ts
@@ -30,16 +30,58 @@ describe("query params parser", () => {
     expect(result[0]).toStrictEqual({
       description: undefined,
       examples: undefined,
-      name: "arrayProperty",
+      name: "property",
       type: {
-        kind: TypeKind.ARRAY,
-        elementType: {
-          kind: TypeKind.STRING
-        }
+        kind: TypeKind.STRING
       },
       optional: false
     });
     expect(result[1]).toStrictEqual({
+      description: "property description",
+      examples: undefined,
+      name: "property-with-description",
+      type: {
+        kind: TypeKind.STRING
+      },
+      optional: false
+    });
+    expect(result[2]).toStrictEqual({
+      description: "property-example description",
+      examples: [{ name: "property-example", value: "property-example-value" }],
+      name: "property-with-example",
+      type: {
+        kind: TypeKind.STRING
+      },
+      optional: false
+    });
+    expect(result[3]).toStrictEqual({
+      description: "property-two-examples description",
+      examples: [
+        {
+          name: "property-example-one",
+          value: 123
+        },
+        {
+          name: "property-example-two",
+          value: 456
+        }
+      ],
+      name: "property-with-examples",
+      type: {
+        kind: TypeKind.INT32
+      },
+      optional: false
+    });
+    expect(result[4]).toStrictEqual({
+      description: undefined,
+      examples: undefined,
+      name: "optionalProperty",
+      type: {
+        kind: TypeKind.STRING
+      },
+      optional: true
+    });
+    expect(result[5]).toStrictEqual({
       description: undefined,
       examples: undefined,
       name: "objectProperty",
@@ -58,57 +100,15 @@ describe("query params parser", () => {
       },
       optional: false
     });
-    expect(result[2]).toStrictEqual({
-      description: undefined,
-      examples: undefined,
-      name: "optionalProperty",
-      type: {
-        kind: TypeKind.STRING
-      },
-      optional: true
-    });
-    expect(result[3]).toStrictEqual({
-      description: undefined,
-      examples: undefined,
-      name: "property",
-      type: {
-        kind: TypeKind.STRING
-      },
-      optional: false
-    });
-    expect(result[4]).toStrictEqual({
-      description: "property description",
-      examples: undefined,
-      name: "property-with-description",
-      type: {
-        kind: TypeKind.STRING
-      },
-      optional: false
-    });
-    expect(result[5]).toStrictEqual({
-      description: "property-example description",
-      examples: [{ name: "property-example", value: "property-example-value" }],
-      name: "property-with-example",
-      type: {
-        kind: TypeKind.STRING
-      },
-      optional: false
-    });
     expect(result[6]).toStrictEqual({
-      description: "property-two-examples description",
-      examples: [
-        {
-          name: "property-example-one",
-          value: 123
-        },
-        {
-          name: "property-example-two",
-          value: 456
-        }
-      ],
-      name: "property-with-examples",
+      description: undefined,
+      examples: undefined,
+      name: "arrayProperty",
       type: {
-        kind: TypeKind.INT32
+        kind: TypeKind.ARRAY,
+        elementType: {
+          kind: TypeKind.STRING
+        }
       },
       optional: false
     });

--- a/lib/src/parsers/query-params-parser.ts
+++ b/lib/src/parsers/query-params-parser.ts
@@ -63,7 +63,7 @@ export function parseQueryParams(
   }
 
   // TODO: add loci information
-  return ok(queryParams.sort((a, b) => (b.name > a.name ? -1 : 1)));
+  return ok(queryParams);
 }
 
 function extractQueryParamName(

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -552,7 +552,7 @@ export class TypeTable {
     this.typeDefs.forEach((typeDef, key) => {
       arr.push({ name: key, typeDef });
     });
-    return arr.sort((a, b) => (b.name > a.name ? -1 : 1));
+    return arr;
   }
 
   /**


### PR DESCRIPTION
Closes #1135 

This PR removes any sorting (of endpoints, headers, params, types) parser so that the order from the TS code is preserved in the OpenAPI.

## Checklist:

- [x] ~~I've added/updated tests to cover my changes~~ (There were no tests for the order; I did not add any. I have edited tests which relied on the alphabetical order but did not state such requirement explicitly.)
- [x] I've created an issue associated with this PR: #1135 
