### PR TITLE
Remove unused MobX direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "jest": "^26.6.3",
     "jest-junit": "^12.0.0",
     "mini-css-extract-plugin": "^1.3.1",
-    "mobx": "^6.0.4",
     "nock": "^13.0.4",
     "prettier": "^2.1.2",
     "react": "^16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5658,11 +5658,6 @@ mobx-react@^6.2.2:
   dependencies:
     mobx-react-lite "^2.2.0"
 
-mobx@^6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.0.4.tgz#8fc3e3629a3346f8afddf5bd954411974744dad1"
-  integrity sha512-wT2QJT9tW19VSHo9x7RPKU3z/I2Ps6wUS8Kb1OO+kzmg7UY3n4AkcaYG6jq95Lp1R9ohjC/NGYuT2PtuvBjhFg==
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
## Description, Motivation and Context

Spot doesn't depend on `mobx` directly, so it doesn't need to be in package.json.

## Checklist:

- [ ] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
