### PR TITLE
Allow to add a dot in query parameters

### DIFF
--- a/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
@@ -692,7 +692,7 @@ exports[`OpenAPI 2 generator query params endpoint with query params 1`] = `
             \\"type\\": \\"string\\"
           },
           {
-            \\"name\\": \\"postcode\\",
+            \\"name\\": \\"post.code\\",
             \\"in\\": \\"query\\",
             \\"required\\": false,
             \\"type\\": \\"string\\"

--- a/lib/src/generators/openapi2/__spec-examples__/contract-with-query-params.ts
+++ b/lib/src/generators/openapi2/__spec-examples__/contract-with-query-params.ts
@@ -21,7 +21,7 @@ class EndpointWithQueryParams {
     @queryParams
     queryParams: {
       country: String;
-      postcode?: String;
+      "post.code"?: String;
     }
   ) {}
 

--- a/lib/src/generators/openapi2/openapi2.spec.ts
+++ b/lib/src/generators/openapi2/openapi2.spec.ts
@@ -152,7 +152,7 @@ describe("OpenAPI 2 generator", () => {
           type: expect.anything()
         },
         {
-          name: "postcode",
+          name: "post.code",
           in: "query",
           required: false,
           type: expect.anything()

--- a/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
@@ -885,7 +885,7 @@ exports[`OpenAPI 3 generator query params endpoint with query params 1`] = `
             }
           },
           {
-            \\"name\\": \\"postcode\\",
+            \\"name\\": \\"post.code\\",
             \\"in\\": \\"query\\",
             \\"required\\": false,
             \\"schema\\": {

--- a/lib/src/generators/openapi3/__spec-examples__/contract-with-query-params.ts
+++ b/lib/src/generators/openapi3/__spec-examples__/contract-with-query-params.ts
@@ -21,7 +21,7 @@ class EndpointWithQueryParams {
     @queryParams
     queryParams: {
       country: String;
-      postcode?: String;
+      "post.code"?: String;
     }
   ) {}
 

--- a/lib/src/generators/openapi3/openapi3.spec.ts
+++ b/lib/src/generators/openapi3/openapi3.spec.ts
@@ -170,7 +170,7 @@ describe("OpenAPI 3 generator", () => {
           schema: expect.anything()
         },
         {
-          name: "postcode",
+          name: "post.code",
           in: "query",
           required: false,
           schema: expect.anything()

--- a/lib/src/parsers/__spec-examples__/query-params.ts
+++ b/lib/src/parsers/__spec-examples__/query-params.ts
@@ -27,6 +27,7 @@ class QueryParamsClass {
         objectProp: string;
       };
       arrayProperty: string[];
+      "property.with.dots": string;
     },
     @queryParams
     interfaceQueryParams: IQueryParams,

--- a/lib/src/parsers/query-params-parser.spec.ts
+++ b/lib/src/parsers/query-params-parser.spec.ts
@@ -26,7 +26,7 @@ describe("query params parser", () => {
       typeTable,
       lociTable
     ).unwrapOrThrow();
-    expect(result).toHaveLength(7);
+    expect(result).toHaveLength(8);
     expect(result[0]).toStrictEqual({
       description: undefined,
       examples: undefined,
@@ -112,6 +112,16 @@ describe("query params parser", () => {
       },
       optional: false
     });
+    expect(result[7]).toStrictEqual({
+      description: undefined,
+      examples: undefined,
+      name: "property.with.dots",
+      type: {
+        kind: TypeKind.STRING
+      },
+      optional: false
+    });
+
   });
 
   test("parses @queryParams as interface parameter", () => {

--- a/lib/src/parsers/query-params-parser.spec.ts
+++ b/lib/src/parsers/query-params-parser.spec.ts
@@ -121,7 +121,6 @@ describe("query params parser", () => {
       },
       optional: false
     });
-
   });
 
   test("parses @queryParams as interface parameter", () => {

--- a/lib/src/parsers/query-params-parser.ts
+++ b/lib/src/parsers/query-params-parser.ts
@@ -70,10 +70,10 @@ function extractQueryParamName(
   propertySignature: PropertySignature
 ): Result<string, ParserError> {
   const name = getPropertyName(propertySignature);
-  if (!/^[\w-]*$/.test(name)) {
+  if (!/^[\w-.]*$/.test(name)) {
     return err(
       new ParserError(
-        "@queryParams property name may only contain alphanumeric, underscore and hyphen characters",
+        "@queryParams property name may only contain alphanumeric, underscore, dot and hyphen characters",
         {
           file: propertySignature.getSourceFile().getFilePath(),
           position: propertySignature.getPos()


### PR DESCRIPTION
## Description, Motivation and Context

Please see #1368

Like it's possible to add a dot in HTTP GET parameters, it's allowed in OAS.
It's possible to add it in a query parameter with this Pull request.
The extractQueryParamName regex is extended to .

## Checklist:

- [X] I've added/updated tests to cover my changes
- [X] I've created an issue associated with this PR
