### PR TITLE
@oaSchemaProp example fails with numerical strings, Date, DateTime, Object, Array, Union or Intersection

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ EXAMPLE
   $ spot checksum api.ts
 ```
 
-_See code: [build/cli/src/commands/checksum.js](https://github.com/airtasker/spot/blob/v1.5.0/build/cli/src/commands/checksum.js)_
+_See code: [build/cli/src/commands/checksum.js](https://github.com/airtasker/spot/blob/v1.6.0/build/cli/src/commands/checksum.js)_
 
 ## `spot docs SPOT_CONTRACT`
 
@@ -190,7 +190,7 @@ EXAMPLE
   $ spot docs api.ts
 ```
 
-_See code: [build/cli/src/commands/docs.js](https://github.com/airtasker/spot/blob/v1.5.0/build/cli/src/commands/docs.js)_
+_See code: [build/cli/src/commands/docs.js](https://github.com/airtasker/spot/blob/v1.6.0/build/cli/src/commands/docs.js)_
 
 ## `spot generate`
 
@@ -211,7 +211,7 @@ EXAMPLE
   $ spot generate --contract api.ts --language yaml --generator openapi3 --out output/
 ```
 
-_See code: [build/cli/src/commands/generate.js](https://github.com/airtasker/spot/blob/v1.5.0/build/cli/src/commands/generate.js)_
+_See code: [build/cli/src/commands/generate.js](https://github.com/airtasker/spot/blob/v1.6.0/build/cli/src/commands/generate.js)_
 
 ## `spot help [COMMAND]`
 
@@ -249,7 +249,7 @@ EXAMPLE
   - package.json
 ```
 
-_See code: [build/cli/src/commands/init.js](https://github.com/airtasker/spot/blob/v1.5.0/build/cli/src/commands/init.js)_
+_See code: [build/cli/src/commands/init.js](https://github.com/airtasker/spot/blob/v1.6.0/build/cli/src/commands/init.js)_
 
 ## `spot lint SPOT_CONTRACT`
 
@@ -269,7 +269,7 @@ EXAMPLE
   $ spot lint api.ts
 ```
 
-_See code: [build/cli/src/commands/lint.js](https://github.com/airtasker/spot/blob/v1.5.0/build/cli/src/commands/lint.js)_
+_See code: [build/cli/src/commands/lint.js](https://github.com/airtasker/spot/blob/v1.6.0/build/cli/src/commands/lint.js)_
 
 ## `spot mock SPOT_CONTRACT`
 
@@ -294,7 +294,7 @@ EXAMPLE
   $ spot mock api.ts
 ```
 
-_See code: [build/cli/src/commands/mock.js](https://github.com/airtasker/spot/blob/v1.5.0/build/cli/src/commands/mock.js)_
+_See code: [build/cli/src/commands/mock.js](https://github.com/airtasker/spot/blob/v1.6.0/build/cli/src/commands/mock.js)_
 
 ## `spot validate SPOT_CONTRACT`
 
@@ -314,7 +314,7 @@ EXAMPLE
   $ spot validate api.ts
 ```
 
-_See code: [build/cli/src/commands/validate.js](https://github.com/airtasker/spot/blob/v1.5.0/build/cli/src/commands/validate.js)_
+_See code: [build/cli/src/commands/validate.js](https://github.com/airtasker/spot/blob/v1.6.0/build/cli/src/commands/validate.js)_
 
 ## `spot validation-server SPOT_CONTRACT`
 
@@ -335,5 +335,5 @@ EXAMPLE
   $ spot validation-server api.ts
 ```
 
-_See code: [build/cli/src/commands/validation-server.js](https://github.com/airtasker/spot/blob/v1.5.0/build/cli/src/commands/validation-server.js)_
+_See code: [build/cli/src/commands/validation-server.js](https://github.com/airtasker/spot/blob/v1.6.0/build/cli/src/commands/validation-server.js)_
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ EXAMPLE
   $ spot checksum api.ts
 ```
 
-_See code: [build/cli/src/commands/checksum.js](https://github.com/airtasker/spot/blob/v1.6.0/build/cli/src/commands/checksum.js)_
+_See code: [build/cli/src/commands/checksum.js](https://github.com/airtasker/spot/blob/v1.7.0/build/cli/src/commands/checksum.js)_
 
 ## `spot docs SPOT_CONTRACT`
 
@@ -190,7 +190,7 @@ EXAMPLE
   $ spot docs api.ts
 ```
 
-_See code: [build/cli/src/commands/docs.js](https://github.com/airtasker/spot/blob/v1.6.0/build/cli/src/commands/docs.js)_
+_See code: [build/cli/src/commands/docs.js](https://github.com/airtasker/spot/blob/v1.7.0/build/cli/src/commands/docs.js)_
 
 ## `spot generate`
 
@@ -211,7 +211,7 @@ EXAMPLE
   $ spot generate --contract api.ts --language yaml --generator openapi3 --out output/
 ```
 
-_See code: [build/cli/src/commands/generate.js](https://github.com/airtasker/spot/blob/v1.6.0/build/cli/src/commands/generate.js)_
+_See code: [build/cli/src/commands/generate.js](https://github.com/airtasker/spot/blob/v1.7.0/build/cli/src/commands/generate.js)_
 
 ## `spot help [COMMAND]`
 
@@ -249,7 +249,7 @@ EXAMPLE
   - package.json
 ```
 
-_See code: [build/cli/src/commands/init.js](https://github.com/airtasker/spot/blob/v1.6.0/build/cli/src/commands/init.js)_
+_See code: [build/cli/src/commands/init.js](https://github.com/airtasker/spot/blob/v1.7.0/build/cli/src/commands/init.js)_
 
 ## `spot lint SPOT_CONTRACT`
 
@@ -269,7 +269,7 @@ EXAMPLE
   $ spot lint api.ts
 ```
 
-_See code: [build/cli/src/commands/lint.js](https://github.com/airtasker/spot/blob/v1.6.0/build/cli/src/commands/lint.js)_
+_See code: [build/cli/src/commands/lint.js](https://github.com/airtasker/spot/blob/v1.7.0/build/cli/src/commands/lint.js)_
 
 ## `spot mock SPOT_CONTRACT`
 
@@ -294,7 +294,7 @@ EXAMPLE
   $ spot mock api.ts
 ```
 
-_See code: [build/cli/src/commands/mock.js](https://github.com/airtasker/spot/blob/v1.6.0/build/cli/src/commands/mock.js)_
+_See code: [build/cli/src/commands/mock.js](https://github.com/airtasker/spot/blob/v1.7.0/build/cli/src/commands/mock.js)_
 
 ## `spot validate SPOT_CONTRACT`
 
@@ -314,7 +314,7 @@ EXAMPLE
   $ spot validate api.ts
 ```
 
-_See code: [build/cli/src/commands/validate.js](https://github.com/airtasker/spot/blob/v1.6.0/build/cli/src/commands/validate.js)_
+_See code: [build/cli/src/commands/validate.js](https://github.com/airtasker/spot/blob/v1.7.0/build/cli/src/commands/validate.js)_
 
 ## `spot validation-server SPOT_CONTRACT`
 
@@ -335,5 +335,5 @@ EXAMPLE
   $ spot validation-server api.ts
 ```
 
-_See code: [build/cli/src/commands/validation-server.js](https://github.com/airtasker/spot/blob/v1.6.0/build/cli/src/commands/validation-server.js)_
+_See code: [build/cli/src/commands/validation-server.js](https://github.com/airtasker/spot/blob/v1.7.0/build/cli/src/commands/validation-server.js)_
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ EXAMPLE
   $ spot checksum api.ts
 ```
 
-_See code: [build/cli/src/commands/checksum.js](https://github.com/airtasker/spot/blob/v1.7.0/build/cli/src/commands/checksum.js)_
+_See code: [build/cli/src/commands/checksum.js](https://github.com/airtasker/spot/blob/v1.8.0/build/cli/src/commands/checksum.js)_
 
 ## `spot docs SPOT_CONTRACT`
 
@@ -190,7 +190,7 @@ EXAMPLE
   $ spot docs api.ts
 ```
 
-_See code: [build/cli/src/commands/docs.js](https://github.com/airtasker/spot/blob/v1.7.0/build/cli/src/commands/docs.js)_
+_See code: [build/cli/src/commands/docs.js](https://github.com/airtasker/spot/blob/v1.8.0/build/cli/src/commands/docs.js)_
 
 ## `spot generate`
 
@@ -211,7 +211,7 @@ EXAMPLE
   $ spot generate --contract api.ts --language yaml --generator openapi3 --out output/
 ```
 
-_See code: [build/cli/src/commands/generate.js](https://github.com/airtasker/spot/blob/v1.7.0/build/cli/src/commands/generate.js)_
+_See code: [build/cli/src/commands/generate.js](https://github.com/airtasker/spot/blob/v1.8.0/build/cli/src/commands/generate.js)_
 
 ## `spot help [COMMAND]`
 
@@ -249,7 +249,7 @@ EXAMPLE
   - package.json
 ```
 
-_See code: [build/cli/src/commands/init.js](https://github.com/airtasker/spot/blob/v1.7.0/build/cli/src/commands/init.js)_
+_See code: [build/cli/src/commands/init.js](https://github.com/airtasker/spot/blob/v1.8.0/build/cli/src/commands/init.js)_
 
 ## `spot lint SPOT_CONTRACT`
 
@@ -269,7 +269,7 @@ EXAMPLE
   $ spot lint api.ts
 ```
 
-_See code: [build/cli/src/commands/lint.js](https://github.com/airtasker/spot/blob/v1.7.0/build/cli/src/commands/lint.js)_
+_See code: [build/cli/src/commands/lint.js](https://github.com/airtasker/spot/blob/v1.8.0/build/cli/src/commands/lint.js)_
 
 ## `spot mock SPOT_CONTRACT`
 
@@ -294,7 +294,7 @@ EXAMPLE
   $ spot mock api.ts
 ```
 
-_See code: [build/cli/src/commands/mock.js](https://github.com/airtasker/spot/blob/v1.7.0/build/cli/src/commands/mock.js)_
+_See code: [build/cli/src/commands/mock.js](https://github.com/airtasker/spot/blob/v1.8.0/build/cli/src/commands/mock.js)_
 
 ## `spot validate SPOT_CONTRACT`
 
@@ -314,7 +314,7 @@ EXAMPLE
   $ spot validate api.ts
 ```
 
-_See code: [build/cli/src/commands/validate.js](https://github.com/airtasker/spot/blob/v1.7.0/build/cli/src/commands/validate.js)_
+_See code: [build/cli/src/commands/validate.js](https://github.com/airtasker/spot/blob/v1.8.0/build/cli/src/commands/validate.js)_
 
 ## `spot validation-server SPOT_CONTRACT`
 
@@ -335,5 +335,5 @@ EXAMPLE
   $ spot validation-server api.ts
 ```
 
-_See code: [build/cli/src/commands/validation-server.js](https://github.com/airtasker/spot/blob/v1.7.0/build/cli/src/commands/validation-server.js)_
+_See code: [build/cli/src/commands/validation-server.js](https://github.com/airtasker/spot/blob/v1.8.0/build/cli/src/commands/validation-server.js)_
 <!-- commandsstop -->

--- a/lib/src/definitions.ts
+++ b/lib/src/definitions.ts
@@ -28,6 +28,7 @@ export interface SecurityHeader {
 export interface Endpoint {
   name: string;
   description?: string;
+  summary?: string;
   tags: string[];
   method: HttpMethod;
   path: string;

--- a/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
@@ -855,6 +855,152 @@ exports[`OpenAPI 2 generator responses endpoint specific and default responses 1
 }"
 `;
 
+exports[`OpenAPI 2 generator schemaprops contract with schemaprops parses correctly to an openapi specification 1`] = `
+"{
+  \\"swagger\\": \\"2.0\\",
+  \\"info\\": {
+    \\"title\\": \\"contract\\",
+    \\"version\\": \\"0.0.0\\"
+  },
+  \\"consumes\\": [
+    \\"application/json\\"
+  ],
+  \\"produces\\": [
+    \\"application/json\\"
+  ],
+  \\"paths\\": {
+    \\"/users\\": {
+      \\"get\\": {
+        \\"operationId\\": \\"EndpointWithSchemaPropsOnHeaders\\",
+        \\"parameters\\": [
+          {
+            \\"name\\": \\"status\\",
+            \\"in\\": \\"header\\",
+            \\"description\\": \\"property-schemaprop description for string\\",
+            \\"required\\": true,
+            \\"type\\": \\"string\\",
+            \\"minLength\\": 12,
+            \\"maxLength\\": 20,
+            \\"pattern\\": \\"^[0-9a-z_]+$\\"
+          },
+          {
+            \\"name\\": \\"size\\",
+            \\"in\\": \\"header\\",
+            \\"description\\": \\"property-schemaprop description for integer\\",
+            \\"required\\": true,
+            \\"type\\": \\"integer\\",
+            \\"format\\": \\"int32\\",
+            \\"minimum\\": 1,
+            \\"default\\": 42
+          }
+        ],
+        \\"responses\\": {
+          \\"200\\": {
+            \\"description\\": \\"200 response\\",
+            \\"schema\\": {
+              \\"type\\": \\"array\\",
+              \\"items\\": {
+                \\"type\\": \\"object\\",
+                \\"properties\\": {
+                  \\"id\\": {
+                    \\"type\\": \\"string\\"
+                  },
+                  \\"name\\": {
+                    \\"type\\": \\"string\\"
+                  },
+                  \\"element\\": {
+                    \\"type\\": \\"object\\",
+                    \\"properties\\": {
+                      \\"price\\": {
+                        \\"type\\": \\"number\\",
+                        \\"format\\": \\"float\\",
+                        \\"example\\": 12,
+                        \\"maximum\\": 99.95,
+                        \\"multipleOf\\": 4,
+                        \\"description\\": \\"property-schemaprop description for float inner object\\"
+                      }
+                    },
+                    \\"required\\": [
+                      \\"price\\"
+                    ],
+                    \\"minProperties\\": 1,
+                    \\"maxProperties\\": 100,
+                    \\"description\\": \\"property-schemaprop description for object\\"
+                  },
+                  \\"currencies\\": {
+                    \\"type\\": \\"array\\",
+                    \\"items\\": {
+                      \\"type\\": \\"string\\"
+                    },
+                    \\"minItems\\": 1,
+                    \\"maxItems\\": 5,
+                    \\"uniqueItems\\": true,
+                    \\"description\\": \\"property-schemaprop description for array\\"
+                  },
+                  \\"code\\": {
+                    \\"type\\": \\"string\\",
+                    \\"enum\\": [
+                      \\"VALID\\",
+                      \\"NOT_VALID\\",
+                      \\"WAITING\\",
+                      \\"APPROVED\\"
+                    ],
+                    \\"title\\": \\"process-code\\",
+                    \\"description\\": \\"property-schemaprop description for union\\"
+                  },
+                  \\"inheritance\\": {
+                    \\"allOf\\": [
+                      {
+                        \\"type\\": \\"object\\",
+                        \\"properties\\": {
+                          \\"inheritId\\": {
+                            \\"type\\": \\"number\\",
+                            \\"format\\": \\"double\\",
+                            \\"example\\": 12,
+                            \\"maximum\\": 99.95,
+                            \\"multipleOf\\": 4,
+                            \\"description\\": \\"property-schemaprop description for double inner intersection\\"
+                          }
+                        },
+                        \\"required\\": [
+                          \\"inheritId\\"
+                        ]
+                      },
+                      {
+                        \\"type\\": \\"object\\",
+                        \\"properties\\": {
+                          \\"inheritName\\": {
+                            \\"type\\": \\"integer\\",
+                            \\"format\\": \\"int64\\",
+                            \\"minimum\\": 1,
+                            \\"default\\": 42,
+                            \\"description\\": \\"property-schemaprop description for long inner intersection\\"
+                          }
+                        },
+                        \\"required\\": [
+                          \\"inheritName\\"
+                        ]
+                      }
+                    ],
+                    \\"title\\": \\"process-code\\",
+                    \\"description\\": \\"property-schemaprop description for intersection\\"
+                  }
+                },
+                \\"required\\": [
+                  \\"id\\",
+                  \\"name\\",
+                  \\"element\\"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`OpenAPI 2 generator security contract with security header 1`] = `
 "{
   \\"swagger\\": \\"2.0\\",

--- a/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
@@ -934,6 +934,9 @@ exports[`OpenAPI 2 generator schemaprops contract with schemaprops parses correc
                     ],
                     \\"minProperties\\": 1,
                     \\"maxProperties\\": 100,
+                    \\"example\\": {
+                      \\"price\\": 3.14
+                    },
                     \\"description\\": \\"property-schemaprop description for object\\"
                   },
                   \\"currencies\\": {
@@ -955,6 +958,7 @@ exports[`OpenAPI 2 generator schemaprops contract with schemaprops parses correc
                       \\"APPROVED\\"
                     ],
                     \\"title\\": \\"process-code\\",
+                    \\"example\\": \\"WAITING\\",
                     \\"description\\": \\"property-schemaprop description for union\\"
                   },
                   \\"inheritance\\": {
@@ -992,6 +996,10 @@ exports[`OpenAPI 2 generator schemaprops contract with schemaprops parses correc
                       }
                     ],
                     \\"title\\": \\"process-code\\",
+                    \\"example\\": {
+                      \\"inheritId\\": 3.14,
+                      \\"inheritName\\": 42
+                    },
                     \\"description\\": \\"property-schemaprop description for intersection\\"
                   }
                 },

--- a/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
@@ -692,7 +692,7 @@ exports[`OpenAPI 2 generator query params endpoint with query params 1`] = `
             \\"type\\": \\"string\\"
           },
           {
-            \\"name\\": \\"postcode\\",
+            \\"name\\": \\"post.code\\",
             \\"in\\": \\"query\\",
             \\"required\\": false,
             \\"type\\": \\"string\\"

--- a/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
@@ -884,6 +884,15 @@ exports[`OpenAPI 2 generator schemaprops contract with schemaprops parses correc
             \\"pattern\\": \\"^[0-9a-z_]+$\\"
           },
           {
+            \\"name\\": \\"start-time\\",
+            \\"in\\": \\"header\\",
+            \\"description\\": \\"property-schemaprop description for date-time\\",
+            \\"required\\": false,
+            \\"type\\": \\"string\\",
+            \\"format\\": \\"date-time\\",
+            \\"default\\": \\"1990-12-31T15:59:60-08:00\\"
+          },
+          {
             \\"name\\": \\"size\\",
             \\"in\\": \\"header\\",
             \\"description\\": \\"property-schemaprop description for integer\\",

--- a/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
@@ -294,6 +294,51 @@ exports[`OpenAPI 2 generator contract with version produces a versioned OpenAPI 
 }"
 `;
 
+exports[`OpenAPI 2 generator endpoint metadata contract with endpoint metadata description and summary 1`] = `
+"{
+  \\"swagger\\": \\"2.0\\",
+  \\"info\\": {
+    \\"title\\": \\"contract\\",
+    \\"version\\": \\"0.0.0\\"
+  },
+  \\"consumes\\": [
+    \\"application/json\\"
+  ],
+  \\"produces\\": [
+    \\"application/json\\"
+  ],
+  \\"paths\\": {
+    \\"/users\\": {
+      \\"get\\": {
+        \\"description\\": \\"My description\\",
+        \\"summary\\": \\"My summary\\",
+        \\"operationId\\": \\"GetEndpoint\\",
+        \\"responses\\": {
+          \\"200\\": {
+            \\"description\\": \\"200 response\\",
+            \\"schema\\": {
+              \\"type\\": \\"object\\",
+              \\"properties\\": {
+                \\"id\\": {
+                  \\"type\\": \\"string\\"
+                },
+                \\"name\\": {
+                  \\"type\\": \\"string\\"
+                }
+              },
+              \\"required\\": [
+                \\"id\\",
+                \\"name\\"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`OpenAPI 2 generator headers endpoint with request headers 1`] = `
 "{
   \\"swagger\\": \\"2.0\\",

--- a/lib/src/generators/openapi2/__spec-examples__/contract-with-endpoint-metadata.ts
+++ b/lib/src/generators/openapi2/__spec-examples__/contract-with-endpoint-metadata.ts
@@ -1,0 +1,19 @@
+import { api, endpoint, response, String, body } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+/**
+ * My description
+ *
+ * @summary
+ * My summary
+ */
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class GetEndpoint {
+  @response({ status: 200 })
+  successResponse(@body body: { id: String; name: String }) {}
+}

--- a/lib/src/generators/openapi2/__spec-examples__/contract-with-query-params.ts
+++ b/lib/src/generators/openapi2/__spec-examples__/contract-with-query-params.ts
@@ -21,7 +21,7 @@ class EndpointWithQueryParams {
     @queryParams
     queryParams: {
       country: String;
-      postcode?: String;
+      "post.code"?: String;
     }
   ) {}
 

--- a/lib/src/generators/openapi2/__spec-examples__/contract-with-schemaprops.ts
+++ b/lib/src/generators/openapi2/__spec-examples__/contract-with-schemaprops.ts
@@ -59,6 +59,8 @@ class EndpointWithSchemaPropsOnHeaders {
        * 1
        * @oaSchemaProp maxProperties
        * 100
+       * @oaSchemaProp example
+       * {"price":3.14}
        *  */
       element: {
         /** property-schemaprop description for float inner object
@@ -83,11 +85,15 @@ class EndpointWithSchemaPropsOnHeaders {
       /** property-schemaprop description for union
        * @oaSchemaProp title
        * "process-code"
+       * @oaSchemaProp example
+       * "WAITING"
        *  */
       code?: "VALID" | "NOT_VALID" | "WAITING" | "APPROVED";
       /** property-schemaprop description for intersection
        * @oaSchemaProp title
        * "process-code"
+       * @oaSchemaProp example
+       * {"inheritId":3.14, "inheritName":42}
        *  */
       inheritance?: {
         /** property-schemaprop description for double inner intersection

--- a/lib/src/generators/openapi2/__spec-examples__/contract-with-schemaprops.ts
+++ b/lib/src/generators/openapi2/__spec-examples__/contract-with-schemaprops.ts
@@ -6,6 +6,7 @@ import {
   request,
   response,
   String,
+  DateTime,
   Integer,
   Float,
   Int64,
@@ -33,6 +34,11 @@ class EndpointWithSchemaPropsOnHeaders {
        * "^[0-9a-z_]+$"
        *  */
       status: String;
+      /** property-schemaprop description for date-time
+       * @default
+       * "1990-12-31T15:59:60-08:00"
+       *  */
+      "start-time"?: DateTime;
       /** property-schemaprop description for integer
        * @oaSchemaProp minimum
        * 1

--- a/lib/src/generators/openapi2/__spec-examples__/contract-with-schemaprops.ts
+++ b/lib/src/generators/openapi2/__spec-examples__/contract-with-schemaprops.ts
@@ -1,0 +1,106 @@
+import {
+  api,
+  body,
+  endpoint,
+  headers,
+  request,
+  response,
+  String,
+  Integer,
+  Float,
+  Int64,
+  Double
+} from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class EndpointWithSchemaPropsOnHeaders {
+  @request
+  request(
+    @headers
+    headers: {
+      /** property-schemaprop description for string
+       * @oaSchemaProp minLength
+       * 12
+       * @oaSchemaProp maxLength
+       * 20
+       * @oaSchemaProp pattern
+       * "^[0-9a-z_]+$"
+       *  */
+      status: String;
+      /** property-schemaprop description for integer
+       * @oaSchemaProp minimum
+       * 1
+       * @default 42
+       *  */
+      size: Integer;
+    }
+  ) {}
+
+  @response({ status: 200 })
+  successResponse(
+    @body
+    body: {
+      id: String;
+      name: String;
+      /** property-schemaprop description for object
+       * @oaSchemaProp minProperties
+       * 1
+       * @oaSchemaProp maxProperties
+       * 100
+       *  */
+      element: {
+        /** property-schemaprop description for float inner object
+         * @oaSchemaProp example
+         * 12.0
+         * @oaSchemaProp maximum
+         * 99.95
+         * @oaSchemaProp multipleOf
+         * 4
+         *  */
+        price: Float;
+      };
+      /** property-schemaprop description for array
+       * @oaSchemaProp minItems
+       * 1
+       * @oaSchemaProp maxItems
+       * 5
+       * @oaSchemaProp uniqueItems
+       * true
+       *  */
+      currencies?: String[];
+      /** property-schemaprop description for union
+       * @oaSchemaProp title
+       * "process-code"
+       *  */
+      code?: "VALID" | "NOT_VALID" | "WAITING" | "APPROVED";
+      /** property-schemaprop description for intersection
+       * @oaSchemaProp title
+       * "process-code"
+       *  */
+      inheritance?: {
+        /** property-schemaprop description for double inner intersection
+         * @oaSchemaProp example
+         * 12.0
+         * @oaSchemaProp maximum
+         * 99.95
+         * @oaSchemaProp multipleOf
+         * 4
+         *  */
+        inheritId: Double;
+      } & {
+        /** property-schemaprop description for long inner intersection
+         * @oaSchemaProp minimum
+         * 1
+         * @default 42
+         *  */
+        inheritName: Int64;
+      };
+    }[]
+  ) {}
+}

--- a/lib/src/generators/openapi2/openapi2-parameter-util.ts
+++ b/lib/src/generators/openapi2/openapi2-parameter-util.ts
@@ -5,6 +5,7 @@ import {
   dereferenceType,
   isArrayType,
   ReferenceType,
+  SchemaProp,
   Type,
   TypeKind,
   TypeTable
@@ -22,6 +23,7 @@ import {
   QueryParameterObject,
   StringParameterObject
 } from "./openapi2-specification";
+import { schemaPropToObject } from "./openapi2-type-util";
 
 export function pathParamToPathParameterObject(
   pathParam: PathParam,
@@ -101,35 +103,61 @@ function basicTypeToParameterBasicTypeObject(
     case TypeKind.NULL:
       throw new Error("Null is not supported for parameters in OpenAPI 2");
     case TypeKind.BOOLEAN:
-      return booleanParameterObject();
+      return booleanParameterObject({ schemaProps: type.schemaProps });
     case TypeKind.BOOLEAN_LITERAL:
-      return booleanParameterObject({ values: [type.value] });
+      return booleanParameterObject({
+        values: [type.value],
+        schemaProps: type.schemaProps
+      });
     case TypeKind.STRING:
-      return stringParameterObject();
+      return stringParameterObject({ schemaProps: type.schemaProps });
     case TypeKind.STRING_LITERAL:
-      return stringParameterObject({ values: [type.value] });
+      return stringParameterObject({
+        values: [type.value],
+        schemaProps: type.schemaProps
+      });
     case TypeKind.FLOAT:
-      return numberParameterObject({ format: "float" });
+      return numberParameterObject({
+        format: "float",
+        schemaProps: type.schemaProps
+      });
     case TypeKind.DOUBLE:
-      return numberParameterObject({ format: "double" });
+      return numberParameterObject({
+        format: "double",
+        schemaProps: type.schemaProps
+      });
     case TypeKind.FLOAT_LITERAL:
       return numberParameterObject({
         values: [type.value],
-        format: "float"
+        format: "float",
+        schemaProps: type.schemaProps
       });
     case TypeKind.INT32:
-      return integerParameterObject({ format: "int32" });
+      return integerParameterObject({
+        format: "int32",
+        schemaProps: type.schemaProps
+      });
     case TypeKind.INT64:
-      return integerParameterObject({ format: "int64" });
+      return integerParameterObject({
+        format: "int64",
+        schemaProps: type.schemaProps
+      });
     case TypeKind.INT_LITERAL:
       return integerParameterObject({
         values: [type.value],
-        format: "int32"
+        format: "int32",
+        schemaProps: type.schemaProps
       });
     case TypeKind.DATE:
-      return stringParameterObject({ format: "date" });
+      return stringParameterObject({
+        format: "date",
+        schemaProps: type.schemaProps
+      });
     case TypeKind.DATE_TIME:
-      return stringParameterObject({ format: "date-time" });
+      return stringParameterObject({
+        format: "date-time",
+        schemaProps: type.schemaProps
+      });
     case TypeKind.OBJECT:
       throw new Error("Object is not supported for parameters in OpenAPI 2");
     case TypeKind.UNION:
@@ -144,11 +172,14 @@ function basicTypeToParameterBasicTypeObject(
 }
 
 function booleanParameterObject(
-  opts: { values?: boolean[] } = {}
+  opts: { values?: boolean[]; schemaProps?: SchemaProp[] } = {}
 ): BooleanParameterObjectType {
   return {
-    type: "boolean",
-    enum: opts.values
+    ...{
+      type: "boolean",
+      enum: opts.values
+    },
+    ...(<BooleanParameterObjectType>schemaPropToObject(opts.schemaProps))
   };
 }
 
@@ -156,12 +187,16 @@ function stringParameterObject(
   opts: {
     values?: string[];
     format?: StringParameterObject["format"];
+    schemaProps?: SchemaProp[];
   } = {}
 ): StringParameterObject {
   return {
-    type: "string",
-    enum: opts.values,
-    format: opts.format
+    ...{
+      type: "string",
+      enum: opts.values,
+      format: opts.format
+    },
+    ...(<StringParameterObject>schemaPropToObject(opts.schemaProps))
   };
 }
 
@@ -169,12 +204,16 @@ function numberParameterObject(
   opts: {
     values?: number[];
     format?: NumberParameterObjectType["format"];
+    schemaProps?: SchemaProp[];
   } = {}
 ): NumberParameterObjectType {
   return {
-    type: "number",
-    enum: opts.values,
-    format: opts.format
+    ...{
+      type: "number",
+      enum: opts.values,
+      format: opts.format
+    },
+    ...(<NumberParameterObjectType>schemaPropToObject(opts.schemaProps))
   };
 }
 
@@ -182,12 +221,16 @@ function integerParameterObject(
   opts: {
     values?: number[];
     format?: IntegerParameterObjectType["format"];
+    schemaProps?: SchemaProp[];
   } = {}
 ): IntegerParameterObjectType {
   return {
-    type: "integer",
-    enum: opts.values,
-    format: opts.format
+    ...{
+      type: "integer",
+      enum: opts.values,
+      format: opts.format
+    },
+    ...(<IntegerParameterObjectType>schemaPropToObject(opts.schemaProps))
   };
 }
 

--- a/lib/src/generators/openapi2/openapi2.spec.ts
+++ b/lib/src/generators/openapi2/openapi2.spec.ts
@@ -303,6 +303,15 @@ describe("OpenAPI 2 generator", () => {
           pattern: "^[0-9a-z_]+$"
         },
         {
+          description: "property-schemaprop description for date-time",
+          name: "start-time",
+          in: "header",
+          required: false,
+          type: "string",
+          format: "date-time",
+          default: "1990-12-31T15:59:60-08:00"
+        },
+        {
           description: "property-schemaprop description for integer",
           name: "size",
           in: "header",

--- a/lib/src/generators/openapi2/openapi2.spec.ts
+++ b/lib/src/generators/openapi2/openapi2.spec.ts
@@ -152,7 +152,7 @@ describe("OpenAPI 2 generator", () => {
           type: expect.anything()
         },
         {
-          name: "postcode",
+          name: "post.code",
           in: "query",
           required: false,
           type: expect.anything()

--- a/lib/src/generators/openapi2/openapi2.spec.ts
+++ b/lib/src/generators/openapi2/openapi2.spec.ts
@@ -332,6 +332,7 @@ describe("OpenAPI 2 generator", () => {
                   description: "property-schemaprop description for object",
                   maxProperties: 100,
                   minProperties: 1,
+                  example: { price: 3.14 },
                   properties: {
                     price: {
                       description:
@@ -366,6 +367,7 @@ describe("OpenAPI 2 generator", () => {
                   description: "property-schemaprop description for union",
                   enum: ["VALID", "NOT_VALID", "WAITING", "APPROVED"],
                   title: "process-code",
+                  example: "WAITING",
                   type: "string"
                 },
                 inheritance: {
@@ -400,6 +402,10 @@ describe("OpenAPI 2 generator", () => {
                       type: "object"
                     }
                   ],
+                  example: {
+                    inheritId: 3.14,
+                    inheritName: 42
+                  },
                   description:
                     "property-schemaprop description for intersection",
                   title: "process-code"

--- a/lib/src/generators/openapi2/openapi2.spec.ts
+++ b/lib/src/generators/openapi2/openapi2.spec.ts
@@ -3,6 +3,7 @@ import { Contract } from "../../definitions";
 import { parseContract } from "../../parsers/contract-parser";
 import { createProjectFromExistingSourceFile } from "../../spec-helpers/helper";
 import { generateOpenAPI2 } from "./openapi2";
+import { generateOpenAPI3 } from "../openapi3";
 
 describe("OpenAPI 2 generator", () => {
   const spectral = new Spectral();
@@ -292,6 +293,22 @@ describe("OpenAPI 2 generator", () => {
 
       expect(result.paths["/users"]).toMatchObject({
         get: expect.anything()
+      });
+      expect(JSON.stringify(result, null, 2)).toMatchSnapshot();
+      const spectralResult = await spectral.run(result);
+      expect(spectralResult).toHaveLength(0);
+    });
+  });
+  describe("endpoint metadata", () => {
+    test("contract with endpoint metadata description and summary", async () => {
+      const contract = generateContract("contract-with-endpoint-metadata.ts");
+      const result = generateOpenAPI2(contract);
+
+      expect(result.paths["/users"]).toMatchObject({
+        get: {
+          description: "My description",
+          summary: "My summary"
+        }
       });
       expect(JSON.stringify(result, null, 2)).toMatchSnapshot();
       const spectralResult = await spectral.run(result);

--- a/lib/src/generators/openapi2/openapi2.ts
+++ b/lib/src/generators/openapi2/openapi2.ts
@@ -137,6 +137,7 @@ function endpointToOperationObject(
   return {
     tags: endpoint.tags.length > 0 ? endpoint.tags : undefined,
     description: endpoint.description,
+    summary: endpoint.summary,
     operationId: endpoint.name,
     parameters:
       endpointRequest &&

--- a/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
@@ -1060,6 +1060,164 @@ exports[`OpenAPI 3 generator responses endpoint specific and default responses 1
 }"
 `;
 
+exports[`OpenAPI 3 generator schemaprops contract with schemaprops parses correctly to an openapi specification 1`] = `
+"{
+  \\"openapi\\": \\"3.0.2\\",
+  \\"info\\": {
+    \\"title\\": \\"contract\\",
+    \\"version\\": \\"0.0.0\\"
+  },
+  \\"paths\\": {
+    \\"/users\\": {
+      \\"get\\": {
+        \\"operationId\\": \\"EndpointWithSchemaPropsOnHeaders\\",
+        \\"parameters\\": [
+          {
+            \\"name\\": \\"status\\",
+            \\"in\\": \\"header\\",
+            \\"description\\": \\"property-schemaprop description for string\\",
+            \\"required\\": true,
+            \\"schema\\": {
+              \\"type\\": \\"string\\",
+              \\"title\\": \\"status-title\\",
+              \\"minLength\\": 12,
+              \\"maxLength\\": 20,
+              \\"pattern\\": \\"^[0-9a-z_]+$\\"
+            }
+          },
+          {
+            \\"name\\": \\"size\\",
+            \\"in\\": \\"header\\",
+            \\"description\\": \\"property-schemaprop description for integer\\",
+            \\"required\\": true,
+            \\"schema\\": {
+              \\"type\\": \\"integer\\",
+              \\"format\\": \\"int32\\",
+              \\"minimum\\": 1,
+              \\"exclusiveMaximum\\": true,
+              \\"deprecated\\": true,
+              \\"default\\": 42
+            }
+          }
+        ],
+        \\"responses\\": {
+          \\"200\\": {
+            \\"description\\": \\"200 response\\",
+            \\"content\\": {
+              \\"application/json\\": {
+                \\"schema\\": {
+                  \\"type\\": \\"array\\",
+                  \\"items\\": {
+                    \\"type\\": \\"object\\",
+                    \\"properties\\": {
+                      \\"id\\": {
+                        \\"type\\": \\"string\\"
+                      },
+                      \\"name\\": {
+                        \\"type\\": \\"string\\"
+                      },
+                      \\"element\\": {
+                        \\"type\\": \\"object\\",
+                        \\"properties\\": {
+                          \\"price\\": {
+                            \\"type\\": \\"number\\",
+                            \\"format\\": \\"float\\",
+                            \\"example\\": 12,
+                            \\"maximum\\": 99.95,
+                            \\"exclusiveMinimum\\": false,
+                            \\"multipleOf\\": 4,
+                            \\"description\\": \\"property-schemaprop description for float inner object\\"
+                          }
+                        },
+                        \\"required\\": [
+                          \\"price\\"
+                        ],
+                        \\"minProperties\\": 1,
+                        \\"maxProperties\\": 100,
+                        \\"additionalProperties\\": true,
+                        \\"description\\": \\"property-schemaprop description for object\\"
+                      },
+                      \\"currencies\\": {
+                        \\"type\\": \\"array\\",
+                        \\"items\\": {
+                          \\"type\\": \\"string\\"
+                        },
+                        \\"minItems\\": 1,
+                        \\"maxItems\\": 5,
+                        \\"uniqueItems\\": true,
+                        \\"description\\": \\"property-schemaprop description for array\\"
+                      },
+                      \\"code\\": {
+                        \\"type\\": \\"string\\",
+                        \\"enum\\": [
+                          \\"VALID\\",
+                          \\"NOT_VALID\\",
+                          \\"WAITING\\",
+                          \\"APPROVED\\"
+                        ],
+                        \\"title\\": \\"process-code\\",
+                        \\"deprecated\\": false,
+                        \\"description\\": \\"property-schemaprop description for union\\"
+                      },
+                      \\"inheritance\\": {
+                        \\"allOf\\": [
+                          {
+                            \\"type\\": \\"object\\",
+                            \\"properties\\": {
+                              \\"inheritId\\": {
+                                \\"type\\": \\"number\\",
+                                \\"format\\": \\"double\\",
+                                \\"example\\": 12,
+                                \\"maximum\\": 99.95,
+                                \\"exclusiveMinimum\\": false,
+                                \\"multipleOf\\": 4,
+                                \\"description\\": \\"property-schemaprop description for double inner intersection\\"
+                              }
+                            },
+                            \\"required\\": [
+                              \\"inheritId\\"
+                            ]
+                          },
+                          {
+                            \\"type\\": \\"object\\",
+                            \\"properties\\": {
+                              \\"inheritName\\": {
+                                \\"type\\": \\"integer\\",
+                                \\"format\\": \\"int64\\",
+                                \\"minimum\\": 1,
+                                \\"exclusiveMaximum\\": true,
+                                \\"deprecated\\": true,
+                                \\"default\\": 42,
+                                \\"description\\": \\"property-schemaprop description for long inner intersection\\"
+                              }
+                            },
+                            \\"required\\": [
+                              \\"inheritName\\"
+                            ]
+                          }
+                        ],
+                        \\"title\\": \\"process-code\\",
+                        \\"deprecated\\": true,
+                        \\"description\\": \\"property-schemaprop description for intersection\\"
+                      }
+                    },
+                    \\"required\\": [
+                      \\"id\\",
+                      \\"name\\",
+                      \\"element\\"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`OpenAPI 3 generator security contract with security header 1`] = `
 "{
   \\"openapi\\": \\"3.0.2\\",

--- a/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
@@ -1086,6 +1086,18 @@ exports[`OpenAPI 3 generator schemaprops contract with schemaprops parses correc
             }
           },
           {
+            \\"name\\": \\"start-time\\",
+            \\"in\\": \\"header\\",
+            \\"description\\": \\"property-schemaprop description for date-time\\",
+            \\"required\\": false,
+            \\"schema\\": {
+              \\"type\\": \\"string\\",
+              \\"format\\": \\"date-time\\",
+              \\"title\\": \\"date-time-title\\",
+              \\"default\\": \\"1990-12-31T15:59:60-08:00\\"
+            }
+          },
+          {
             \\"name\\": \\"size\\",
             \\"in\\": \\"header\\",
             \\"description\\": \\"property-schemaprop description for integer\\",

--- a/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
@@ -355,6 +355,49 @@ exports[`OpenAPI 3 generator contract with one server OpenAPI 3 1`] = `
 }"
 `;
 
+exports[`OpenAPI 3 generator endpoint metadata contract with endpoint metadata description and summary 1`] = `
+"{
+  \\"openapi\\": \\"3.0.2\\",
+  \\"info\\": {
+    \\"title\\": \\"contract\\",
+    \\"version\\": \\"0.0.0\\"
+  },
+  \\"paths\\": {
+    \\"/users\\": {
+      \\"get\\": {
+        \\"description\\": \\"My description\\",
+        \\"summary\\": \\"My summary\\",
+        \\"operationId\\": \\"GetEndpoint\\",
+        \\"responses\\": {
+          \\"200\\": {
+            \\"description\\": \\"200 response\\",
+            \\"content\\": {
+              \\"application/json\\": {
+                \\"schema\\": {
+                  \\"type\\": \\"object\\",
+                  \\"properties\\": {
+                    \\"id\\": {
+                      \\"type\\": \\"string\\"
+                    },
+                    \\"name\\": {
+                      \\"type\\": \\"string\\"
+                    }
+                  },
+                  \\"required\\": [
+                    \\"id\\",
+                    \\"name\\"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`OpenAPI 3 generator examples contract with examples parses correctly to an openapi specification 1`] = `
 "{
   \\"openapi\\": \\"3.0.2\\",

--- a/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
@@ -1169,6 +1169,7 @@ exports[`OpenAPI 3 generator schemaprops contract with schemaprops parses correc
                         ],
                         \\"title\\": \\"process-code\\",
                         \\"deprecated\\": false,
+                        \\"example\\": \\"WAITING\\",
                         \\"description\\": \\"property-schemaprop description for union\\"
                       },
                       \\"inheritance\\": {
@@ -1210,6 +1211,10 @@ exports[`OpenAPI 3 generator schemaprops contract with schemaprops parses correc
                         ],
                         \\"title\\": \\"process-code\\",
                         \\"deprecated\\": true,
+                        \\"example\\": {
+                          \\"inheritId\\": 3.14,
+                          \\"inheritName\\": 42
+                        },
                         \\"description\\": \\"property-schemaprop description for intersection\\"
                       }
                     },

--- a/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
@@ -1147,6 +1147,9 @@ exports[`OpenAPI 3 generator schemaprops contract with schemaprops parses correc
                         \\"minProperties\\": 1,
                         \\"maxProperties\\": 100,
                         \\"additionalProperties\\": true,
+                        \\"example\\": {
+                          \\"price\\": 3.14
+                        },
                         \\"description\\": \\"property-schemaprop description for object\\"
                       },
                       \\"currencies\\": {

--- a/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
@@ -885,7 +885,7 @@ exports[`OpenAPI 3 generator query params endpoint with query params 1`] = `
             }
           },
           {
-            \\"name\\": \\"postcode\\",
+            \\"name\\": \\"post.code\\",
             \\"in\\": \\"query\\",
             \\"required\\": false,
             \\"schema\\": {

--- a/lib/src/generators/openapi3/__spec-examples__/contract-with-endpoint-metadata.ts
+++ b/lib/src/generators/openapi3/__spec-examples__/contract-with-endpoint-metadata.ts
@@ -1,0 +1,19 @@
+import { api, endpoint, response, String, body } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+/**
+ * My description
+ *
+ * @summary
+ * My summary
+ */
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class GetEndpoint {
+  @response({ status: 200 })
+  successResponse(@body body: { id: String; name: String }) {}
+}

--- a/lib/src/generators/openapi3/__spec-examples__/contract-with-query-params.ts
+++ b/lib/src/generators/openapi3/__spec-examples__/contract-with-query-params.ts
@@ -21,7 +21,7 @@ class EndpointWithQueryParams {
     @queryParams
     queryParams: {
       country: String;
-      postcode?: String;
+      "post.code"?: String;
     }
   ) {}
 

--- a/lib/src/generators/openapi3/__spec-examples__/contract-with-schemaprops.ts
+++ b/lib/src/generators/openapi3/__spec-examples__/contract-with-schemaprops.ts
@@ -69,6 +69,8 @@ class EndpointWithSchemaPropsOnHeaders {
        * 100
        * @oaSchemaProp additionalProperties
        * true
+       * @oaSchemaProp example
+       * {"price":3.14}
        *  */
       element: {
         /** property-schemaprop description for float inner object

--- a/lib/src/generators/openapi3/__spec-examples__/contract-with-schemaprops.ts
+++ b/lib/src/generators/openapi3/__spec-examples__/contract-with-schemaprops.ts
@@ -97,6 +97,8 @@ class EndpointWithSchemaPropsOnHeaders {
        * "process-code"
        * @oaSchemaProp deprecated
        * false
+       * @oaSchemaProp example
+       * "WAITING"
        *  */
       code?: "VALID" | "NOT_VALID" | "WAITING" | "APPROVED";
       /** property-schemaprop description for intersection
@@ -104,6 +106,8 @@ class EndpointWithSchemaPropsOnHeaders {
        * "process-code"
        * @oaSchemaProp deprecated
        * true
+       * @oaSchemaProp example
+       * {"inheritId":3.14, "inheritName":42}
        *  */
       inheritance?: {
         /** property-schemaprop description for double inner intersection

--- a/lib/src/generators/openapi3/__spec-examples__/contract-with-schemaprops.ts
+++ b/lib/src/generators/openapi3/__spec-examples__/contract-with-schemaprops.ts
@@ -6,6 +6,7 @@ import {
   request,
   response,
   String,
+  DateTime,
   Integer,
   Float,
   Int64,
@@ -35,6 +36,13 @@ class EndpointWithSchemaPropsOnHeaders {
        * "^[0-9a-z_]+$"
        *  */
       status: String;
+      /** property-schemaprop description for date-time
+       * @oaSchemaProp title
+       * "date-time-title"
+       * @default
+       * "1990-12-31T15:59:60-08:00"
+       *  */
+      "start-time"?: DateTime;
       /** property-schemaprop description for integer
        * @oaSchemaProp minimum
        * 1

--- a/lib/src/generators/openapi3/__spec-examples__/contract-with-schemaprops.ts
+++ b/lib/src/generators/openapi3/__spec-examples__/contract-with-schemaprops.ts
@@ -1,0 +1,126 @@
+import {
+  api,
+  body,
+  endpoint,
+  headers,
+  request,
+  response,
+  String,
+  Integer,
+  Float,
+  Int64,
+  Double
+} from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class EndpointWithSchemaPropsOnHeaders {
+  @request
+  request(
+    @headers
+    headers: {
+      /** property-schemaprop description for string
+       * @oaSchemaProp title
+       * "status-title"
+       * @oaSchemaProp minLength
+       * 12
+       * @oaSchemaProp maxLength
+       * 20
+       * @oaSchemaProp pattern
+       * "^[0-9a-z_]+$"
+       *  */
+      status: String;
+      /** property-schemaprop description for integer
+       * @oaSchemaProp minimum
+       * 1
+       * @oaSchemaProp exclusiveMaximum
+       * true
+       * @oaSchemaProp deprecated
+       * true
+       * @default 42
+       *  */
+      size: Integer;
+    }
+  ) {}
+
+  @response({ status: 200 })
+  successResponse(
+    @body
+    body: {
+      id: String;
+      name: String;
+      /** property-schemaprop description for object
+       * @oaSchemaProp minProperties
+       * 1
+       * @oaSchemaProp maxProperties
+       * 100
+       * @oaSchemaProp additionalProperties
+       * true
+       *  */
+      element: {
+        /** property-schemaprop description for float inner object
+         * @oaSchemaProp example
+         * 12.0
+         * @oaSchemaProp maximum
+         * 99.95
+         * @oaSchemaProp exclusiveMinimum
+         * false
+         * @oaSchemaProp multipleOf
+         * 4
+         *  */
+        price: Float;
+      };
+      /** property-schemaprop description for array
+       * @oaSchemaProp minItems
+       * 1
+       * @oaSchemaProp maxItems
+       * 5
+       * @oaSchemaProp uniqueItems
+       * true
+       *  */
+      currencies?: String[];
+      /** property-schemaprop description for union
+       * @oaSchemaProp title
+       * "process-code"
+       * @oaSchemaProp deprecated
+       * false
+       *  */
+      code?: "VALID" | "NOT_VALID" | "WAITING" | "APPROVED";
+      /** property-schemaprop description for intersection
+       * @oaSchemaProp title
+       * "process-code"
+       * @oaSchemaProp deprecated
+       * true
+       *  */
+      inheritance?: {
+        /** property-schemaprop description for double inner intersection
+         * @oaSchemaProp example
+         * 12.0
+         * @oaSchemaProp maximum
+         * 99.95
+         * @oaSchemaProp exclusiveMinimum
+         * false
+         * @oaSchemaProp multipleOf
+         * 4
+         *  */
+        inheritId: Double;
+      } & {
+        /** property-schemaprop description for long inner intersection
+         * @oaSchemaProp minimum
+         * 1
+         * @oaSchemaProp exclusiveMaximum
+         * true
+         * @oaSchemaProp deprecated
+         * true
+         * @default 42
+         *  */
+        inheritName: Int64;
+      };
+    }[]
+  ) {}
+}

--- a/lib/src/generators/openapi3/openapi3.spec.ts
+++ b/lib/src/generators/openapi3/openapi3.spec.ts
@@ -381,6 +381,23 @@ describe("OpenAPI 3 generator", () => {
       expect(spectralResult).toHaveLength(0);
     });
   });
+
+  describe("endpoint metadata", () => {
+    test("contract with endpoint metadata description and summary", async () => {
+      const contract = generateContract("contract-with-endpoint-metadata.ts");
+      const result = generateOpenAPI3(contract);
+
+      expect(result.paths["/users"]).toMatchObject({
+        get: {
+          description: "My description",
+          summary: "My summary"
+        }
+      });
+      expect(JSON.stringify(result, null, 2)).toMatchSnapshot();
+      const spectralResult = await spectral.run(result);
+      expect(spectralResult).toHaveLength(0);
+    });
+  });
 });
 
 /**

--- a/lib/src/generators/openapi3/openapi3.spec.ts
+++ b/lib/src/generators/openapi3/openapi3.spec.ts
@@ -170,7 +170,7 @@ describe("OpenAPI 3 generator", () => {
           schema: expect.anything()
         },
         {
-          name: "postcode",
+          name: "post.code",
           in: "query",
           required: false,
           schema: expect.anything()

--- a/lib/src/generators/openapi3/openapi3.spec.ts
+++ b/lib/src/generators/openapi3/openapi3.spec.ts
@@ -462,6 +462,7 @@ describe("OpenAPI 3 generator", () => {
                       description: "property-schemaprop description for union",
                       enum: ["VALID", "NOT_VALID", "WAITING", "APPROVED"],
                       title: "process-code",
+                      example: "WAITING",
                       deprecated: false,
                       type: "string"
                     },
@@ -501,6 +502,10 @@ describe("OpenAPI 3 generator", () => {
                         }
                       ],
                       deprecated: true,
+                      example: {
+                        inheritId: 3.14,
+                        inheritName: 42
+                      },
                       description:
                         "property-schemaprop description for intersection",
                       title: "process-code"

--- a/lib/src/generators/openapi3/openapi3.spec.ts
+++ b/lib/src/generators/openapi3/openapi3.spec.ts
@@ -388,6 +388,18 @@ describe("OpenAPI 3 generator", () => {
           }
         },
         {
+          description: "property-schemaprop description for date-time",
+          in: "header",
+          name: "start-time",
+          required: false,
+          schema: {
+            title: "date-time-title",
+            type: "string",
+            format: "date-time",
+            default: "1990-12-31T15:59:60-08:00"
+          }
+        },
+        {
           description: "property-schemaprop description for integer",
           name: "size",
           in: "header",

--- a/lib/src/generators/openapi3/openapi3.spec.ts
+++ b/lib/src/generators/openapi3/openapi3.spec.ts
@@ -427,6 +427,7 @@ describe("OpenAPI 3 generator", () => {
                       maxProperties: 100,
                       minProperties: 1,
                       additionalProperties: true,
+                      example: { price: 3.14 },
                       properties: {
                         price: {
                           description:

--- a/lib/src/generators/openapi3/openapi3.spec.ts
+++ b/lib/src/generators/openapi3/openapi3.spec.ts
@@ -368,6 +368,147 @@ describe("OpenAPI 3 generator", () => {
     });
   });
 
+  describe("schemaprops", () => {
+    test("contract with schemaprops parses correctly to an openapi specification", async () => {
+      const contract = generateContract("contract-with-schemaprops.ts");
+      const result = generateOpenAPI3(contract);
+
+      expect(result.paths["/users"].get).toHaveProperty("parameters", [
+        {
+          description: "property-schemaprop description for string",
+          name: "status",
+          in: "header",
+          required: true,
+          schema: {
+            title: "status-title",
+            type: "string",
+            minLength: 12,
+            maxLength: 20,
+            pattern: "^[0-9a-z_]+$"
+          }
+        },
+        {
+          description: "property-schemaprop description for integer",
+          name: "size",
+          in: "header",
+          required: true,
+          schema: {
+            format: "int32",
+            type: "integer",
+            minimum: 1,
+            exclusiveMaximum: true,
+            deprecated: true,
+            default: 42
+          }
+        }
+      ]);
+      expect(result.paths["/users"].get).toHaveProperty("responses", {
+        "200": {
+          description: expect.anything(),
+          content: {
+            "application/json": {
+              schema: {
+                items: {
+                  properties: {
+                    element: {
+                      description: "property-schemaprop description for object",
+                      maxProperties: 100,
+                      minProperties: 1,
+                      additionalProperties: true,
+                      properties: {
+                        price: {
+                          description:
+                            "property-schemaprop description for float inner object",
+                          format: "float",
+                          type: "number",
+                          example: 12,
+                          maximum: 99.95,
+                          multipleOf: 4,
+                          exclusiveMinimum: false
+                        }
+                      },
+                      required: ["price"],
+                      type: "object"
+                    },
+                    id: {
+                      type: "string"
+                    },
+                    name: {
+                      type: "string"
+                    },
+                    currencies: {
+                      description: "property-schemaprop description for array",
+                      items: {
+                        type: "string"
+                      },
+                      maxItems: 5,
+                      minItems: 1,
+                      type: "array",
+                      uniqueItems: true
+                    },
+                    code: {
+                      description: "property-schemaprop description for union",
+                      enum: ["VALID", "NOT_VALID", "WAITING", "APPROVED"],
+                      title: "process-code",
+                      deprecated: false,
+                      type: "string"
+                    },
+                    inheritance: {
+                      allOf: [
+                        {
+                          properties: {
+                            inheritId: {
+                              description:
+                                "property-schemaprop description for double inner intersection",
+                              type: "number",
+                              format: "double",
+                              example: 12,
+                              exclusiveMinimum: false,
+                              maximum: 99.95,
+                              multipleOf: 4
+                            }
+                          },
+                          required: ["inheritId"],
+                          type: "object"
+                        },
+                        {
+                          properties: {
+                            inheritName: {
+                              description:
+                                "property-schemaprop description for long inner intersection",
+                              type: "integer",
+                              format: "int64",
+                              default: 42,
+                              deprecated: true,
+                              exclusiveMaximum: true,
+                              minimum: 1
+                            }
+                          },
+                          required: ["inheritName"],
+                          type: "object"
+                        }
+                      ],
+                      deprecated: true,
+                      description:
+                        "property-schemaprop description for intersection",
+                      title: "process-code"
+                    }
+                  },
+                  required: ["id", "name", "element"],
+                  type: "object"
+                },
+                type: "array"
+              }
+            }
+          }
+        }
+      });
+      expect(JSON.stringify(result, null, 2)).toMatchSnapshot();
+      const spectralResult = await spectral.run(result);
+      expect(spectralResult).toHaveLength(0);
+    });
+  });
+
   describe("intersection types", () => {
     test("evaluates intersection type", async () => {
       const contract = generateContract("contract-with-intersection-types.ts");

--- a/lib/src/generators/openapi3/openapi3.ts
+++ b/lib/src/generators/openapi3/openapi3.ts
@@ -310,7 +310,8 @@ function headerToHeaderObject(
   return {
     description: header.description,
     required: !header.optional,
-    schema: typeToSchemaOrReferenceObject(header.type, typeTable)
+    schema: typeToSchemaOrReferenceObject(header.type, typeTable),
+    examples: exampleToOpenApiExampleSet(header.examples)
   };
 }
 

--- a/lib/src/generators/openapi3/openapi3.ts
+++ b/lib/src/generators/openapi3/openapi3.ts
@@ -135,6 +135,7 @@ function endpointToOperationObject(
   return {
     tags: endpoint.tags.length > 0 ? endpoint.tags : undefined,
     description: endpoint.description,
+    summary: endpoint.summary,
     operationId: endpoint.name,
     parameters:
       endpointRequest &&

--- a/lib/src/parsers/__spec-examples__/endpoint.ts
+++ b/lib/src/parsers/__spec-examples__/endpoint.ts
@@ -133,3 +133,15 @@ class EndpointWithDuplicateResponseStatus {
   })
   responseTwo() {}
 }
+
+/**
+ * My description
+ *
+ * @summary
+ * My summary
+ */
+@endpoint({
+  method: "GET",
+  path: "/path"
+})
+class MinimalEndpointWithSummaryClass {}

--- a/lib/src/parsers/__spec-examples__/path-params.ts
+++ b/lib/src/parsers/__spec-examples__/path-params.ts
@@ -14,6 +14,8 @@ class PathParamsClass {
       /** property-example description
        * @example property-example
        * "property-example-value"
+       * @oaSchemaProp example
+       * "property-example-schema"
        *  */
       "property-with-example": string;
       /** property-two-examples description
@@ -21,6 +23,7 @@ class PathParamsClass {
        * 123
        * @example property-example-two
        * 456
+       * @default 12
        * */
       "property-with-examples": Integer;
     },

--- a/lib/src/parsers/__spec-examples__/query-params.ts
+++ b/lib/src/parsers/__spec-examples__/query-params.ts
@@ -27,6 +27,7 @@ class QueryParamsClass {
         objectProp: string;
       };
       arrayProperty: string[];
+      "property.with.dots": string;
     },
     @queryParams
     interfaceQueryParams: IQueryParams,

--- a/lib/src/parsers/__spec-examples__/schemaprops.ts
+++ b/lib/src/parsers/__spec-examples__/schemaprops.ts
@@ -1,4 +1,4 @@
-import { Date, Integer } from "../../syntax";
+import { Date, Integer, String } from "../../syntax";
 
 type SchemaPropTests = {
   /** property-schemaprop description
@@ -6,6 +6,11 @@ type SchemaPropTests = {
    * "property-schemaprop-value"
    *  */
   "property-with-schemaprop": string;
+   /**
+   * @oaSchemaProp example
+   * "123.3"
+   */
+  "property-with-string": String;
   /** property-two-schemaprops description
    * @oaSchemaProp minimum
    * 123

--- a/lib/src/parsers/__spec-examples__/schemaprops.ts
+++ b/lib/src/parsers/__spec-examples__/schemaprops.ts
@@ -22,6 +22,11 @@ type SchemaPropTests = {
    * "1990-12-31"
    *  */
   "property-with-date": Date;
+  /** property-schemaprop array of integer
+   * @oaSchemaProp example
+   * [1990,12,31]
+   *  */
+  "property-with-array": Integer[];
   /**
    * @oaSchemaProp example
    * This_is_not_an_integer

--- a/lib/src/parsers/__spec-examples__/schemaprops.ts
+++ b/lib/src/parsers/__spec-examples__/schemaprops.ts
@@ -1,4 +1,4 @@
-import { Integer } from "../../syntax";
+import { Date, Integer } from "../../syntax";
 
 type SchemaPropTests = {
   /** property-schemaprop description
@@ -17,6 +17,11 @@ type SchemaPropTests = {
    * false
    *  */
   "property-with-boolean": boolean;
+  /** property-schemaprop date
+   * @oaSchemaProp example
+   * "1990-12-31"
+   *  */
+  "property-with-date": Date;
   /**
    * @oaSchemaProp example
    * This_is_not_an_integer

--- a/lib/src/parsers/__spec-examples__/schemaprops.ts
+++ b/lib/src/parsers/__spec-examples__/schemaprops.ts
@@ -6,7 +6,7 @@ type SchemaPropTests = {
    * "property-schemaprop-value"
    *  */
   "property-with-schemaprop": string;
-   /**
+  /**
    * @oaSchemaProp example
    * "123.3"
    */

--- a/lib/src/parsers/__spec-examples__/schemaprops.ts
+++ b/lib/src/parsers/__spec-examples__/schemaprops.ts
@@ -1,0 +1,30 @@
+import { Integer } from "../../syntax";
+
+type SchemaPropTests = {
+  /** property-schemaprop description
+   * @oaSchemaProp pattern
+   * "property-schemaprop-value"
+   *  */
+  "property-with-schemaprop": string;
+  /** property-two-schemaprops description
+   * @oaSchemaProp minimum
+   * 123
+   * @default 456
+   * */
+  "property-with-schemaprops": Integer;
+  /** property-schemaprop description
+   * @oaSchemaProp example
+   * false
+   *  */
+  "property-with-boolean": boolean;
+  /**
+   * @oaSchemaProp example
+   * This_is_not_an_integer
+   */
+  "property-with-mistyped-schemaprop": Integer;
+  /**
+   * @oaSchemaProp example
+   * This_is_not_a_string_in_quotes
+   */
+  "property-with-no-string-in-quotes": string;
+};

--- a/lib/src/parsers/__spec-examples__/types.ts
+++ b/lib/src/parsers/__spec-examples__/types.ts
@@ -30,7 +30,10 @@ interface TypeInterface {
   Date: Date;
   DateTime: DateTime;
   literalObject: {
-    /** Property description */
+    /** Property description
+     * @oaSchemaProp maxLength
+     * 42
+     */
     propertyA: string;
     propertyB?: boolean;
   };
@@ -83,7 +86,10 @@ type AliasString = string;
 
 type AliasArray = string[];
 
-/** Alias description */
+/** Alias description
+ * @oaSchemaProp pattern
+ * "^[a-z]+$"
+ */
 type AliasWithDescription = string;
 
 interface Interface {
@@ -92,6 +98,10 @@ interface Interface {
 
 /** Interface description */
 interface InterfaceWithDescription {
+  /** InterfaceProperty description
+   * @oaSchemaProp example
+   * true
+   */
   interfaceProperty: boolean;
 }
 

--- a/lib/src/parsers/default-response-parser.spec.ts
+++ b/lib/src/parsers/default-response-parser.spec.ts
@@ -35,7 +35,7 @@ describe("default response parser", () => {
           examples: undefined,
           name: "property",
           optional: false,
-          type: { kind: TypeKind.STRING }
+          type: { kind: TypeKind.STRING, schemaProps: undefined }
         }
       ]
     });

--- a/lib/src/parsers/endpoint-parser.spec.ts
+++ b/lib/src/parsers/endpoint-parser.spec.ts
@@ -41,6 +41,7 @@ describe("endpoint parser", () => {
         ]
       },
       description: "endpoint description",
+      summary: undefined,
       draft: false,
       method: "POST",
       name: "EndpointClass",
@@ -108,6 +109,7 @@ describe("endpoint parser", () => {
     expect(result).toStrictEqual({
       defaultResponse: undefined,
       description: undefined,
+      summary: undefined,
       draft: false,
       method: "GET",
       name: "MinimalEndpointClass",
@@ -128,6 +130,7 @@ describe("endpoint parser", () => {
     expect(result).toStrictEqual({
       defaultResponse: undefined,
       description: undefined,
+      summary: undefined,
       draft: true,
       method: "GET",
       name: "DraftEndpointClass",
@@ -206,5 +209,26 @@ describe("endpoint parser", () => {
         lociTable
       )
     ).toThrowError("Expected to find decorator named 'endpoint'");
+  });
+
+  test("parses minimal @endpoint decorated class with summary field", () => {
+    const result = parseEndpoint(
+      exampleFile.getClassOrThrow("MinimalEndpointWithSummaryClass"),
+      typeTable,
+      lociTable
+    ).unwrapOrThrow();
+
+    expect(result).toStrictEqual({
+      defaultResponse: undefined,
+      description: "My description",
+      summary: "My summary",
+      draft: false,
+      method: "GET",
+      name: "MinimalEndpointWithSummaryClass",
+      path: "/path",
+      request: undefined,
+      responses: [],
+      tags: []
+    });
   });
 });

--- a/lib/src/parsers/endpoint-parser.spec.ts
+++ b/lib/src/parsers/endpoint-parser.spec.ts
@@ -36,7 +36,7 @@ describe("endpoint parser", () => {
             examples: undefined,
             name: "property",
             optional: false,
-            type: { kind: TypeKind.STRING }
+            type: { kind: TypeKind.STRING, schemaProps: undefined }
           }
         ]
       },
@@ -56,7 +56,7 @@ describe("endpoint parser", () => {
             examples: undefined,
             name: "property",
             optional: false,
-            type: { kind: TypeKind.STRING }
+            type: { kind: TypeKind.STRING, schemaProps: undefined }
           }
         ],
         pathParams: [
@@ -64,7 +64,7 @@ describe("endpoint parser", () => {
             description: undefined,
             examples: undefined,
             name: "pathParam",
-            type: { kind: TypeKind.STRING }
+            type: { kind: TypeKind.STRING, schemaProps: undefined }
           }
         ],
         queryParams: [
@@ -73,7 +73,7 @@ describe("endpoint parser", () => {
             examples: undefined,
             name: "property",
             optional: false,
-            type: { kind: TypeKind.STRING }
+            type: { kind: TypeKind.STRING, schemaProps: undefined }
           }
         ]
       },
@@ -89,7 +89,7 @@ describe("endpoint parser", () => {
               examples: undefined,
               name: "property",
               optional: false,
-              type: { kind: TypeKind.STRING }
+              type: { kind: TypeKind.STRING, schemaProps: undefined }
             }
           ],
           status: 200

--- a/lib/src/parsers/endpoint-parser.ts
+++ b/lib/src/parsers/endpoint-parser.ts
@@ -51,7 +51,15 @@ export function parseEndpoint(
   const tags = tagsResult.unwrap();
 
   // Handle jsdoc
-  const description = getJsDoc(klass)?.getDescription().trim();
+  const jsDocNode = getJsDoc(klass);
+  const description = jsDocNode?.getDescription().trim();
+
+  // Handle summary
+  const summaryNode = jsDocNode
+    ?.getTags()
+    .find(tag => tag.getTagName() === "summary");
+
+  const summary = summaryNode?.getComment();
 
   // Handle draft
   const draft = klass.getDecorator("draft") !== undefined;
@@ -131,6 +139,7 @@ export function parseEndpoint(
   return ok({
     name,
     description,
+    summary,
     tags,
     method,
     path,

--- a/lib/src/parsers/headers-parser.spec.ts
+++ b/lib/src/parsers/headers-parser.spec.ts
@@ -32,7 +32,8 @@ describe("headers parser", () => {
       examples: undefined,
       name: "property",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       },
       optional: false
     });
@@ -41,7 +42,8 @@ describe("headers parser", () => {
       examples: undefined,
       name: "property-with-description",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       },
       optional: false
     });
@@ -50,7 +52,8 @@ describe("headers parser", () => {
       examples: [{ name: "property-example", value: "property-example-value" }],
       name: "property-with-example",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       },
       optional: false
     });
@@ -68,7 +71,8 @@ describe("headers parser", () => {
       ],
       name: "property-with-examples",
       type: {
-        kind: TypeKind.INT32
+        kind: TypeKind.INT32,
+        schemaProps: undefined
       },
       optional: false
     });
@@ -77,7 +81,8 @@ describe("headers parser", () => {
       examples: undefined,
       name: "optionalProperty",
       type: {
-        kind: TypeKind.INT64
+        kind: TypeKind.INT64,
+        schemaProps: undefined
       },
       optional: true
     });
@@ -95,7 +100,8 @@ describe("headers parser", () => {
       examples: undefined,
       name: "property-with-description",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       },
       optional: false
     });
@@ -113,7 +119,8 @@ describe("headers parser", () => {
       examples: undefined,
       name: "property-with-description",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       },
       optional: false
     });
@@ -131,7 +138,8 @@ describe("headers parser", () => {
       examples: undefined,
       name: "property-with-description",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       },
       optional: false
     });

--- a/lib/src/parsers/headers-parser.ts
+++ b/lib/src/parsers/headers-parser.ts
@@ -3,7 +3,7 @@ import { Header } from "../definitions";
 import { OptionalNotAllowedError, ParserError } from "../errors";
 import { isHeaderTypeSafe } from "../http";
 import { LociTable } from "../locations";
-import { Type, TypeTable } from "../types";
+import { isSchemaPropAllowedType, Type, TypeTable } from "../types";
 import { err, ok, Result } from "../util";
 import {
   getJsDoc,
@@ -12,6 +12,7 @@ import {
 } from "./parser-helpers";
 import { parseType } from "./type-parser";
 import { extractJSDocExamples } from "./example-parser";
+import { extractJSDocSchemaProps } from "./schemaprop-parser";
 
 export function parseHeaders(
   parameter: ParameterDeclaration,
@@ -53,6 +54,12 @@ export function parseHeaders(
     const examples = extractJSDocExamples(jsDocNode, type);
     if (examples && examples.isErr()) return examples;
     const optional = propertySignature.hasQuestionToken();
+
+    const schemaProps = extractJSDocSchemaProps(jsDocNode, type);
+    if (schemaProps && schemaProps.isErr()) return schemaProps;
+    if (isSchemaPropAllowedType(type)) {
+      type.schemaProps = schemaProps?.unwrap();
+    }
 
     headers.push({
       name,

--- a/lib/src/parsers/path-params-parser.spec.ts
+++ b/lib/src/parsers/path-params-parser.spec.ts
@@ -32,7 +32,8 @@ describe("path params parser", () => {
       examples: undefined,
       name: "property",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       }
     });
     expect(result[1]).toStrictEqual({
@@ -40,7 +41,8 @@ describe("path params parser", () => {
       examples: undefined,
       name: "property-with-description",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       }
     });
     expect(result[2]).toStrictEqual({
@@ -51,7 +53,8 @@ describe("path params parser", () => {
         kind: TypeKind.ARRAY,
         elementType: {
           kind: TypeKind.STRING
-        }
+        },
+        schemaProps: undefined
       }
     });
     expect(result[3]).toStrictEqual({
@@ -59,7 +62,13 @@ describe("path params parser", () => {
       examples: [{ name: "property-example", value: "property-example-value" }],
       name: "property-with-example",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: [
+          {
+            name: "example",
+            value: "property-example-schema"
+          }
+        ]
       }
     });
     expect(result[4]).toStrictEqual({
@@ -76,7 +85,13 @@ describe("path params parser", () => {
       ],
       name: "property-with-examples",
       type: {
-        kind: TypeKind.INT32
+        kind: TypeKind.INT32,
+        schemaProps: [
+          {
+            name: "default",
+            value: 12
+          }
+        ]
       }
     });
   });
@@ -93,7 +108,8 @@ describe("path params parser", () => {
       examples: undefined,
       name: "property-with-description",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       }
     });
   });
@@ -110,7 +126,8 @@ describe("path params parser", () => {
       examples: undefined,
       name: "property-with-description",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       }
     });
   });
@@ -177,7 +194,8 @@ describe("path params parser", () => {
       examples: undefined,
       name: "property-with-description",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       }
     });
   });

--- a/lib/src/parsers/path-params-parser.ts
+++ b/lib/src/parsers/path-params-parser.ts
@@ -3,7 +3,7 @@ import { PathParam } from "../definitions";
 import { OptionalNotAllowedError, ParserError } from "../errors";
 import { isPathParamTypeSafe } from "../http";
 import { LociTable } from "../locations";
-import { Type, TypeTable } from "../types";
+import { isSchemaPropAllowedType, Type, TypeTable } from "../types";
 import { err, ok, Result } from "../util";
 import {
   getJsDoc,
@@ -12,6 +12,7 @@ import {
 } from "./parser-helpers";
 import { parseType } from "./type-parser";
 import { extractJSDocExamples } from "./example-parser";
+import { extractJSDocSchemaProps } from "./schemaprop-parser";
 
 export function parsePathParams(
   parameter: ParameterDeclaration,
@@ -76,6 +77,12 @@ function extractPathParam(
 
   const examples = extractJSDocExamples(jsDocNode, type);
   if (examples && examples.isErr()) return examples;
+
+  const schemaProps = extractJSDocSchemaProps(jsDocNode, type);
+  if (schemaProps && schemaProps.isErr()) return schemaProps;
+  if (isSchemaPropAllowedType(type)) {
+    type.schemaProps = schemaProps?.unwrap();
+  }
 
   return ok({
     name,

--- a/lib/src/parsers/query-params-parser.spec.ts
+++ b/lib/src/parsers/query-params-parser.spec.ts
@@ -32,7 +32,8 @@ describe("query params parser", () => {
       examples: undefined,
       name: "property",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       },
       optional: false
     });
@@ -41,7 +42,8 @@ describe("query params parser", () => {
       examples: undefined,
       name: "property-with-description",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       },
       optional: false
     });
@@ -50,7 +52,8 @@ describe("query params parser", () => {
       examples: [{ name: "property-example", value: "property-example-value" }],
       name: "property-with-example",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       },
       optional: false
     });
@@ -68,7 +71,8 @@ describe("query params parser", () => {
       ],
       name: "property-with-examples",
       type: {
-        kind: TypeKind.INT32
+        kind: TypeKind.INT32,
+        schemaProps: undefined
       },
       optional: false
     });
@@ -77,7 +81,8 @@ describe("query params parser", () => {
       examples: undefined,
       name: "optionalProperty",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       },
       optional: true
     });
@@ -87,13 +92,15 @@ describe("query params parser", () => {
       name: "objectProperty",
       type: {
         kind: TypeKind.OBJECT,
+        schemaProps: undefined,
         properties: [
           {
             description: undefined,
             name: "objectProp",
             optional: false,
             type: {
-              kind: TypeKind.STRING
+              kind: TypeKind.STRING,
+              schemaProps: undefined
             }
           }
         ]
@@ -108,7 +115,8 @@ describe("query params parser", () => {
         kind: TypeKind.ARRAY,
         elementType: {
           kind: TypeKind.STRING
-        }
+        },
+        schemaProps: undefined
       },
       optional: false
     });
@@ -135,7 +143,8 @@ describe("query params parser", () => {
       examples: undefined,
       name: "property-with-description",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       },
       optional: false
     });
@@ -153,7 +162,8 @@ describe("query params parser", () => {
       examples: undefined,
       name: "property-with-description",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       },
       optional: false
     });
@@ -171,7 +181,8 @@ describe("query params parser", () => {
       examples: undefined,
       name: "property-with-description",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       },
       optional: false
     });

--- a/lib/src/parsers/query-params-parser.spec.ts
+++ b/lib/src/parsers/query-params-parser.spec.ts
@@ -26,7 +26,7 @@ describe("query params parser", () => {
       typeTable,
       lociTable
     ).unwrapOrThrow();
-    expect(result).toHaveLength(7);
+    expect(result).toHaveLength(8);
     expect(result[0]).toStrictEqual({
       description: undefined,
       examples: undefined,
@@ -109,6 +109,15 @@ describe("query params parser", () => {
         elementType: {
           kind: TypeKind.STRING
         }
+      },
+      optional: false
+    });
+    expect(result[7]).toStrictEqual({
+      description: undefined,
+      examples: undefined,
+      name: "property.with.dots",
+      type: {
+        kind: TypeKind.STRING
       },
       optional: false
     });

--- a/lib/src/parsers/query-params-parser.spec.ts
+++ b/lib/src/parsers/query-params-parser.spec.ts
@@ -125,7 +125,8 @@ describe("query params parser", () => {
       examples: undefined,
       name: "property.with.dots",
       type: {
-        kind: TypeKind.STRING
+        kind: TypeKind.STRING,
+        schemaProps: undefined
       },
       optional: false
     });

--- a/lib/src/parsers/query-params-parser.ts
+++ b/lib/src/parsers/query-params-parser.ts
@@ -70,10 +70,10 @@ function extractQueryParamName(
   propertySignature: PropertySignature
 ): Result<string, ParserError> {
   const name = getPropertyName(propertySignature);
-  if (!/^[\w-]*$/.test(name)) {
+  if (!/^[\w-.]*$/.test(name)) {
     return err(
       new ParserError(
-        "@queryParams property name may only contain alphanumeric, underscore and hyphen characters",
+        "@queryParams property name may only contain alphanumeric, underscore, dot and hyphen characters",
         {
           file: propertySignature.getSourceFile().getFilePath(),
           position: propertySignature.getPos()

--- a/lib/src/parsers/query-params-parser.ts
+++ b/lib/src/parsers/query-params-parser.ts
@@ -3,7 +3,7 @@ import { QueryParam } from "../definitions";
 import { OptionalNotAllowedError, ParserError } from "../errors";
 import { isQueryParamTypeSafe } from "../http";
 import { LociTable } from "../locations";
-import { Type, TypeTable } from "../types";
+import { isSchemaPropAllowedType, Type, TypeTable } from "../types";
 import { err, ok, Result } from "../util";
 import {
   getJsDoc,
@@ -12,6 +12,7 @@ import {
 } from "./parser-helpers";
 import { parseType } from "./type-parser";
 import { extractJSDocExamples } from "./example-parser";
+import { extractJSDocSchemaProps } from "./schemaprop-parser";
 
 export function parseQueryParams(
   parameter: ParameterDeclaration,
@@ -52,6 +53,12 @@ export function parseQueryParams(
     if (examples && examples.isErr()) return examples;
 
     const optional = propertySignature.hasQuestionToken();
+
+    const schemaProps = extractJSDocSchemaProps(jsDocNode, type);
+    if (schemaProps && schemaProps.isErr()) return schemaProps;
+    if (isSchemaPropAllowedType(type)) {
+      type.schemaProps = schemaProps?.unwrap();
+    }
 
     queryParams.push({
       name,

--- a/lib/src/parsers/request-parser.spec.ts
+++ b/lib/src/parsers/request-parser.spec.ts
@@ -34,7 +34,7 @@ describe("request parser", () => {
           examples: undefined,
           name: "property",
           optional: false,
-          type: { kind: TypeKind.STRING }
+          type: { kind: TypeKind.STRING, schemaProps: undefined }
         }
       ],
       pathParams: [
@@ -42,7 +42,7 @@ describe("request parser", () => {
           description: undefined,
           examples: undefined,
           name: "property",
-          type: { kind: TypeKind.STRING }
+          type: { kind: TypeKind.STRING, schemaProps: undefined }
         }
       ],
       queryParams: [
@@ -51,7 +51,7 @@ describe("request parser", () => {
           examples: undefined,
           name: "property",
           optional: false,
-          type: { kind: TypeKind.STRING }
+          type: { kind: TypeKind.STRING, schemaProps: undefined }
         }
       ]
     });

--- a/lib/src/parsers/response-parser.spec.ts
+++ b/lib/src/parsers/response-parser.spec.ts
@@ -35,7 +35,7 @@ describe("response parser", () => {
           examples: undefined,
           name: "property",
           optional: false,
-          type: { kind: TypeKind.STRING }
+          type: { kind: TypeKind.STRING, schemaProps: undefined }
         }
       ],
       status: 200

--- a/lib/src/parsers/schemaprop-parser.spec.ts
+++ b/lib/src/parsers/schemaprop-parser.spec.ts
@@ -1,0 +1,113 @@
+import { extractJSDocSchemaProps } from "./schemaprop-parser";
+import { createProjectFromExistingSourceFile } from "../spec-helpers/helper";
+import {
+  getJsDoc,
+  parseTypeReferencePropertySignaturesOrThrow
+} from "./parser-helpers";
+import { JSDoc, PropertySignature } from "ts-morph";
+import { TypeKind } from "../types";
+
+function getJsDocsFromPropertySignatures(
+  propertySignatures: PropertySignature[],
+  propertyName: string
+): JSDoc | undefined {
+  const property = propertySignatures.find(p => p.getName() === propertyName);
+  if (!property) {
+    throw new Error(`PropertySignature "${propertyName}" not found`);
+  }
+  return getJsDoc(property);
+}
+
+describe("schemaprop-parser", () => {
+  describe("extractJSDocSchemaProps", () => {
+    const sourceFile = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/schemaprops.ts`
+    ).file;
+    const typeAlias = sourceFile.getTypeAlias("SchemaPropTests");
+    if (!typeAlias) {
+      throw new Error('TypeAlias "SchemaPropTests" not found');
+    }
+    const properties = parseTypeReferencePropertySignaturesOrThrow(
+      typeAlias.getTypeNodeOrThrow()
+    );
+
+    test("successfully parses string schemaprops on properties on type ParsedSchemaProps", () => {
+      const stringSchemaPropNode = getJsDocsFromPropertySignatures(
+        properties,
+        '"property-with-schemaprop"'
+      );
+      const retrieveStringSchemaProp = extractJSDocSchemaProps(
+        stringSchemaPropNode,
+        {
+          kind: TypeKind.STRING
+        }
+      );
+      expect(retrieveStringSchemaProp).toBeDefined();
+      expect(retrieveStringSchemaProp!.isOk).toBeTruthy();
+      expect(retrieveStringSchemaProp!.unwrapOrThrow()).toStrictEqual([
+        { name: "pattern", value: "property-schemaprop-value" }
+      ]);
+    });
+
+    test("successfully parses integer schemaprops on properties on type ParsedSchemaProps", () => {
+      const integerSchemaPropNode = getJsDocsFromPropertySignatures(
+        properties,
+        '"property-with-schemaprops"'
+      );
+      const retrieveIntegerSchemaProp = extractJSDocSchemaProps(
+        integerSchemaPropNode,
+        {
+          kind: TypeKind.INT32
+        }
+      );
+      expect(retrieveIntegerSchemaProp).toBeDefined();
+      expect(retrieveIntegerSchemaProp!.isOk).toBeTruthy();
+      expect(retrieveIntegerSchemaProp!.unwrapOrThrow()).toStrictEqual([
+        { name: "minimum", value: 123 },
+        { name: "default", value: 456 }
+      ]);
+    });
+
+    test("successfully parses boolean schemaprops on properties on type ParsedSchemaProps", () => {
+      const booleanSchemaPropNode = getJsDocsFromPropertySignatures(
+        properties,
+        '"property-with-boolean"'
+      );
+      const retrieveBooleanSchemaProp = extractJSDocSchemaProps(
+        booleanSchemaPropNode,
+        {
+          kind: TypeKind.BOOLEAN
+        }
+      );
+      expect(retrieveBooleanSchemaProp).toBeDefined();
+      expect(retrieveBooleanSchemaProp!.isOk).toBeTruthy();
+      expect(retrieveBooleanSchemaProp!.unwrapOrThrow()).toStrictEqual([
+        { name: "example", value: false }
+      ]);
+    });
+
+    test("errors schemaprops on properties on type MismatchedSchemaPropAndIntegerType", () => {
+      const integerSchemaPropNode = getJsDocsFromPropertySignatures(
+        properties,
+        '"property-with-mistyped-schemaprop"'
+      );
+      expect(
+        extractJSDocSchemaProps(integerSchemaPropNode, {
+          kind: TypeKind.INT32
+        })!.unwrapErrOrThrow().message
+      ).toEqual("could not parse schemaProp");
+    });
+
+    test("errors schemaprops on properties on type MismatchedSchemaPropAndStringWithQuotesType", () => {
+      const stringSchemaPropNode = getJsDocsFromPropertySignatures(
+        properties,
+        '"property-with-no-string-in-quotes"'
+      );
+      expect(
+        extractJSDocSchemaProps(stringSchemaPropNode, {
+          kind: TypeKind.STRING
+        })!.unwrapErrOrThrow().message
+      ).toEqual("example schemaProp must be quoted");
+    });
+  });
+});

--- a/lib/src/parsers/schemaprop-parser.spec.ts
+++ b/lib/src/parsers/schemaprop-parser.spec.ts
@@ -49,6 +49,24 @@ describe("schemaprop-parser", () => {
       ]);
     });
 
+    test("successfully parses string example schemaprops on properties on type ParsedSchemaProps", () => {
+      const stringSchemaPropNode = getJsDocsFromPropertySignatures(
+        properties,
+        '"property-with-string"'
+      );
+      const retrieveStringSchemaProp = extractJSDocSchemaProps(
+        stringSchemaPropNode,
+        {
+          kind: TypeKind.STRING
+        }
+      );
+      expect(retrieveStringSchemaProp).toBeDefined();
+      expect(retrieveStringSchemaProp!.isOk).toBeTruthy();
+      expect(retrieveStringSchemaProp!.unwrapOrThrow()).toStrictEqual([
+        { name: "example", value: "123.3" }
+      ]);
+    });
+
     test("successfully parses integer schemaprops on properties on type ParsedSchemaProps", () => {
       const integerSchemaPropNode = getJsDocsFromPropertySignatures(
         properties,

--- a/lib/src/parsers/schemaprop-parser.spec.ts
+++ b/lib/src/parsers/schemaprop-parser.spec.ts
@@ -86,6 +86,25 @@ describe("schemaprop-parser", () => {
       ]);
     });
 
+    test("successfully parses array schemaprops on properties on type ParsedSchemaProps", () => {
+      const booleanSchemaPropNode = getJsDocsFromPropertySignatures(
+        properties,
+        '"property-with-array"'
+      );
+      const retrieveBooleanSchemaProp = extractJSDocSchemaProps(
+        booleanSchemaPropNode,
+        {
+          kind: TypeKind.ARRAY,
+          elementType: { kind: TypeKind.INT32 }
+        }
+      );
+      expect(retrieveBooleanSchemaProp).toBeDefined();
+      expect(retrieveBooleanSchemaProp!.isOk).toBeTruthy();
+      expect(retrieveBooleanSchemaProp!.unwrapOrThrow()).toStrictEqual([
+        { name: "example", value: [1990, 12, 31] }
+      ]);
+    });
+
     test("successfully parses date schemaprops on properties on type ParsedSchemaProps", () => {
       const booleanSchemaPropNode = getJsDocsFromPropertySignatures(
         properties,

--- a/lib/src/parsers/schemaprop-parser.spec.ts
+++ b/lib/src/parsers/schemaprop-parser.spec.ts
@@ -86,6 +86,24 @@ describe("schemaprop-parser", () => {
       ]);
     });
 
+    test("successfully parses date schemaprops on properties on type ParsedSchemaProps", () => {
+      const booleanSchemaPropNode = getJsDocsFromPropertySignatures(
+        properties,
+        '"property-with-date"'
+      );
+      const retrieveBooleanSchemaProp = extractJSDocSchemaProps(
+        booleanSchemaPropNode,
+        {
+          kind: TypeKind.DATE
+        }
+      );
+      expect(retrieveBooleanSchemaProp).toBeDefined();
+      expect(retrieveBooleanSchemaProp!.isOk).toBeTruthy();
+      expect(retrieveBooleanSchemaProp!.unwrapOrThrow()).toStrictEqual([
+        { name: "example", value: "1990-12-31" }
+      ]);
+    });
+
     test("errors schemaprops on properties on type MismatchedSchemaPropAndIntegerType", () => {
       const integerSchemaPropNode = getJsDocsFromPropertySignatures(
         properties,

--- a/lib/src/parsers/schemaprop-parser.ts
+++ b/lib/src/parsers/schemaprop-parser.ts
@@ -52,6 +52,19 @@ export function extractJSDocSchemaProps(
     const typeSpecified: TypeKind | "number" =
       spotTypesToJSTypesMap.get(type.kind) || type.kind;
 
+    let subTypeSpecified = typeSpecified;
+    if (type.kind === TypeKind.UNION || type.kind === TypeKind.INTERSECTION) {
+      const referenceType: TypeKind = type.types[0].kind;
+      if (
+        type.types.every(subType => {
+          return subType.kind === referenceType;
+        })
+      ) {
+        subTypeSpecified =
+          spotTypesToJSTypesMap.get(referenceType) || referenceType;
+      }
+    }
+
     rawSchemaProps.every(schemaProp => {
       const schemaPropName = schemaProp?.split("\n")[0]?.trim();
       const schemaPropValue = schemaProp?.split("\n")[1]?.trim();
@@ -148,7 +161,7 @@ export function extractJSDocSchemaProps(
       schemaProps.some(
         schemaProp =>
           (propTypeMap.get(schemaProp.name)?.type === "any" &&
-            typeOf(schemaProp.value) !== typeSpecified) ||
+            typeOf(schemaProp.value) !== subTypeSpecified) ||
           (propTypeMap.get(schemaProp.name)?.type !== "any" &&
             propTypeMap.get(schemaProp.name)?.type !== typeOf(schemaProp.value))
       )

--- a/lib/src/parsers/schemaprop-parser.ts
+++ b/lib/src/parsers/schemaprop-parser.ts
@@ -1,0 +1,262 @@
+import { JSDoc } from "ts-morph";
+import { SchemaProp, Type, TypeKind } from "../types";
+import { err, ok, Result } from "../util";
+import { ParserError } from "../errors";
+
+export function extractJSDocSchemaProps(
+  jsDoc: JSDoc | undefined,
+  type: Type
+): Result<SchemaProp[], ParserError> | undefined {
+  // return early if there is no jsDoc available
+  if (!jsDoc) {
+    return;
+  }
+
+  const rawDefaults = jsDoc
+    .getTags()
+    .filter(tag => tag.getTagName() === "default")
+    .map(schemaProp => schemaProp.getComment());
+  const parentJsDocNode = jsDoc.getParent();
+  if (rawDefaults && rawDefaults.indexOf(undefined) !== -1) {
+    return err(
+      new ParserError("Default must not be empty", {
+        file: parentJsDocNode.getSourceFile().getFilePath(),
+        position: parentJsDocNode.getPos()
+      })
+    );
+  }
+
+  const rawSchemaProps = jsDoc
+    .getTags()
+    .filter(tag => tag.getTagName() === "oaSchemaProp")
+    .map(schemaProp => schemaProp.getComment());
+  if (rawSchemaProps && rawSchemaProps.indexOf(undefined) !== -1) {
+    return err(
+      new ParserError("schemaProp must not be empty", {
+        file: parentJsDocNode.getSourceFile().getFilePath(),
+        position: parentJsDocNode.getPos()
+      })
+    );
+  }
+
+  if (rawDefaults && rawDefaults.length > 0) {
+    rawDefaults.every(defaultValue => {
+      rawSchemaProps.push("default\n" + defaultValue);
+    });
+  }
+
+  if (rawSchemaProps && rawSchemaProps.length > 0) {
+    const schemaProps: SchemaProp[] = [];
+    let schemaPropError;
+
+    rawSchemaProps.every(schemaProp => {
+      const schemaPropName = schemaProp?.split("\n")[0]?.trim();
+      const schemaPropValue = schemaProp?.split("\n")[1]?.trim();
+
+      if (!schemaPropName || !schemaPropValue) {
+        schemaPropError = err(
+          new ParserError("malformed schemaProp", {
+            file: parentJsDocNode.getSourceFile().getFilePath(),
+            position: parentJsDocNode.getPos()
+          })
+        );
+        return false;
+      } else {
+        if (schemaProps.some(ex => ex.name === schemaPropName)) {
+          schemaPropError = err(
+            new ParserError(
+              "duplicate " + schemaPropName + " schemaProp name",
+              {
+                file: parentJsDocNode.getSourceFile().getFilePath(),
+                position: parentJsDocNode.getPos()
+              }
+            )
+          );
+          return false;
+        }
+
+        if (
+          (propTypeMap.get(schemaPropName)?.type === "string" ||
+            (type.kind === TypeKind.STRING &&
+              propTypeMap.get(schemaPropName)?.type === "any")) &&
+          (!schemaPropValue.startsWith('"') || !schemaPropValue.endsWith('"'))
+        ) {
+          schemaPropError = err(
+            new ParserError(schemaPropName + " schemaProp must be quoted", {
+              file: parentJsDocNode.getSourceFile().getFilePath(),
+              position: parentJsDocNode.getPos()
+            })
+          );
+          return false;
+        }
+
+        try {
+          const parsedValue = JSON.parse(schemaPropValue);
+          schemaProps.push({ name: schemaPropName, value: parsedValue });
+        } catch (e) {
+          schemaPropError = err(
+            new ParserError("could not parse schemaProp", {
+              file: parentJsDocNode.getSourceFile().getFilePath(),
+              position: parentJsDocNode.getPos()
+            })
+          );
+          return false;
+        }
+
+        return true;
+      }
+    });
+    if (schemaPropError) {
+      return schemaPropError;
+    }
+
+    const typeOf = (value: any): "string" | "number" | "boolean" => {
+      if (/^-?\d+(\.\d+)?$/.test(value)) {
+        return "number";
+      }
+
+      if (typeof value === "boolean") {
+        return "boolean";
+      }
+
+      return "string";
+    };
+
+    const nameSchemaProps: string[] = schemaProps.map(ex => {
+      return ex.name;
+    });
+
+    const spotTypesToJSTypesMap = new Map();
+    spotTypesToJSTypesMap.set(TypeKind.INT32, "number");
+    spotTypesToJSTypesMap.set(TypeKind.INT64, "number");
+    spotTypesToJSTypesMap.set(TypeKind.INT_LITERAL, "number");
+    spotTypesToJSTypesMap.set(TypeKind.FLOAT, "number");
+    spotTypesToJSTypesMap.set(TypeKind.FLOAT_LITERAL, "number");
+    spotTypesToJSTypesMap.set(TypeKind.DOUBLE, "number");
+    spotTypesToJSTypesMap.set(TypeKind.BOOLEAN_LITERAL, "boolean");
+    spotTypesToJSTypesMap.set(TypeKind.STRING_LITERAL, "string");
+
+    const typeSpecified: TypeKind | "number" =
+      spotTypesToJSTypesMap.get(type.kind) || type.kind;
+
+    if (
+      schemaProps.some(
+        schemaProp =>
+          (propTypeMap.get(schemaProp.name)?.type === "any" &&
+            typeOf(schemaProp.value) !== typeSpecified) ||
+          (propTypeMap.get(schemaProp.name)?.type !== "any" &&
+            propTypeMap.get(schemaProp.name)?.type !== typeOf(schemaProp.value))
+      )
+    ) {
+      return err(
+        new ParserError("property type is wrong or property not allowed", {
+          file: parentJsDocNode.getSourceFile().getFilePath(),
+          position: parentJsDocNode.getPos()
+        })
+      );
+    }
+
+    if (
+      nameSchemaProps.some(
+        nameSchemaProp =>
+          !propTypeMap
+            .get(nameSchemaProp)
+            ?.targetTypes.find(targetType => targetType === typeSpecified)
+      )
+    ) {
+      return err(
+        new ParserError(
+          "property must be compliant with " + typeSpecified + " type",
+          {
+            file: parentJsDocNode.getSourceFile().getFilePath(),
+            position: parentJsDocNode.getPos()
+          }
+        )
+      );
+    }
+
+    return ok(schemaProps);
+  }
+  return;
+}
+
+export const propTypeMap = new Map<
+  string,
+  {
+    type: "string" | "number" | "boolean" | "any";
+    targetTypes: (TypeKind | "number")[];
+  }
+>([
+  ["additionalProperties", { type: "boolean", targetTypes: [TypeKind.OBJECT] }],
+  [
+    "default",
+    {
+      type: "any",
+      targetTypes: [
+        "number",
+        TypeKind.STRING,
+        TypeKind.BOOLEAN,
+        TypeKind.ARRAY,
+        TypeKind.OBJECT
+      ]
+    }
+  ],
+  [
+    "deprecated",
+    {
+      type: "boolean",
+      targetTypes: [
+        "number",
+        TypeKind.STRING,
+        TypeKind.BOOLEAN,
+        TypeKind.ARRAY,
+        TypeKind.OBJECT,
+        TypeKind.UNION,
+        TypeKind.INTERSECTION
+      ]
+    }
+  ],
+  [
+    "example",
+    {
+      type: "any",
+      targetTypes: [
+        "number",
+        TypeKind.STRING,
+        TypeKind.BOOLEAN,
+        TypeKind.ARRAY,
+        TypeKind.OBJECT,
+        TypeKind.UNION,
+        TypeKind.INTERSECTION
+      ]
+    }
+  ],
+  ["exclusiveMaximum", { type: "boolean", targetTypes: ["number"] }],
+  ["exclusiveMinimum", { type: "boolean", targetTypes: ["number"] }],
+  ["maximum", { type: "number", targetTypes: ["number"] }],
+  ["maxItems", { type: "number", targetTypes: [TypeKind.ARRAY] }],
+  ["maxLength", { type: "number", targetTypes: [TypeKind.STRING] }],
+  ["maxProperties", { type: "number", targetTypes: [TypeKind.OBJECT] }],
+  ["minimum", { type: "number", targetTypes: ["number"] }],
+  ["minItems", { type: "number", targetTypes: [TypeKind.ARRAY] }],
+  ["minLength", { type: "number", targetTypes: [TypeKind.STRING] }],
+  ["minProperties", { type: "number", targetTypes: [TypeKind.OBJECT] }],
+  ["multipleOf", { type: "number", targetTypes: ["number"] }],
+  ["pattern", { type: "string", targetTypes: [TypeKind.STRING] }],
+  [
+    "title",
+    {
+      type: "string",
+      targetTypes: [
+        "number",
+        TypeKind.STRING,
+        TypeKind.BOOLEAN,
+        TypeKind.ARRAY,
+        TypeKind.OBJECT,
+        TypeKind.UNION,
+        TypeKind.INTERSECTION
+      ]
+    }
+  ],
+  ["uniqueItems", { type: "boolean", targetTypes: [TypeKind.ARRAY] }]
+]);

--- a/lib/src/parsers/type-parser.spec.ts
+++ b/lib/src/parsers/type-parser.spec.ts
@@ -223,7 +223,13 @@ describe("type parser", () => {
             name: "propertyA",
             optional: false,
             type: {
-              kind: TypeKind.STRING
+              kind: TypeKind.STRING,
+              schemaProps: [
+                {
+                  name: "maxLength",
+                  value: 42
+                }
+              ]
             }
           },
           {
@@ -231,7 +237,8 @@ describe("type parser", () => {
             name: "propertyB",
             optional: true,
             type: {
-              kind: TypeKind.BOOLEAN
+              kind: TypeKind.BOOLEAN,
+              schemaProps: undefined
             }
           }
         ]
@@ -268,7 +275,8 @@ describe("type parser", () => {
               name: "a",
               optional: false,
               type: {
-                kind: TypeKind.BOOLEAN
+                kind: TypeKind.BOOLEAN,
+                schemaProps: undefined
               }
             }
           ]
@@ -362,7 +370,7 @@ describe("type parser", () => {
     expect(typeTable.size).toBe(1);
     expect(typeTable.getOrError("AliasString")).toStrictEqual({
       description: undefined,
-      type: { kind: TypeKind.STRING }
+      type: { kind: TypeKind.STRING, schemaProps: undefined }
     });
   });
 
@@ -382,7 +390,8 @@ describe("type parser", () => {
       description: undefined,
       type: {
         kind: TypeKind.ARRAY,
-        elementType: { kind: TypeKind.STRING }
+        elementType: { kind: TypeKind.STRING },
+        schemaProps: undefined
       }
     });
   });
@@ -401,7 +410,15 @@ describe("type parser", () => {
     expect(typeTable.size).toBe(1);
     expect(typeTable.getOrError("AliasWithDescription")).toStrictEqual({
       description: "Alias description",
-      type: { kind: TypeKind.STRING }
+      type: {
+        kind: TypeKind.STRING,
+        schemaProps: [
+          {
+            name: "pattern",
+            value: "^[a-z]+$"
+          }
+        ]
+      }
     });
   });
 
@@ -421,13 +438,15 @@ describe("type parser", () => {
       description: undefined,
       type: {
         kind: TypeKind.OBJECT,
+        schemaProps: undefined,
         properties: [
           {
             description: undefined,
             name: "interfaceProperty",
             optional: false,
             type: {
-              kind: TypeKind.BOOLEAN
+              kind: TypeKind.BOOLEAN,
+              schemaProps: undefined
             }
           }
         ]
@@ -451,13 +470,20 @@ describe("type parser", () => {
       description: "Interface description",
       type: {
         kind: TypeKind.OBJECT,
+        schemaProps: undefined,
         properties: [
           {
-            description: undefined,
+            description: "InterfaceProperty description",
             name: "interfaceProperty",
             optional: false,
             type: {
-              kind: TypeKind.BOOLEAN
+              kind: TypeKind.BOOLEAN,
+              schemaProps: [
+                {
+                  name: "example",
+                  value: true
+                }
+              ]
             }
           }
         ]
@@ -481,13 +507,15 @@ describe("type parser", () => {
       description: undefined,
       type: {
         kind: TypeKind.OBJECT,
+        schemaProps: undefined,
         properties: [
           {
             description: undefined,
             name: "interfaceExtendsProperty",
             optional: false,
             type: {
-              kind: TypeKind.BOOLEAN
+              kind: TypeKind.BOOLEAN,
+              schemaProps: undefined
             }
           },
           {
@@ -495,7 +523,8 @@ describe("type parser", () => {
             name: "interfaceProperty",
             optional: false,
             type: {
-              kind: TypeKind.BOOLEAN
+              kind: TypeKind.BOOLEAN,
+              schemaProps: undefined
             }
           }
         ]
@@ -510,7 +539,7 @@ describe("type parser", () => {
 
     expect(
       parseType(type, typeTable, lociTable).unwrapOrThrow()
-    ).toStrictEqual({ kind: "boolean" });
+    ).toStrictEqual({ kind: "boolean", schemaProps: undefined });
   });
 
   test("parses nested indexed accessing", () => {
@@ -520,7 +549,7 @@ describe("type parser", () => {
 
     expect(
       parseType(type, typeTable, lociTable).unwrapOrThrow()
-    ).toStrictEqual({ kind: "boolean" });
+    ).toStrictEqual({ kind: "boolean", schemaProps: undefined });
   });
 
   test("parses indexed indexed accessing", () => {
@@ -530,7 +559,7 @@ describe("type parser", () => {
 
     expect(
       parseType(type, typeTable, lociTable).unwrapOrThrow()
-    ).toStrictEqual({ kind: "boolean" });
+    ).toStrictEqual({ kind: "boolean", schemaProps: undefined });
   });
 
   test("parses intersection type", () => {
@@ -550,7 +579,8 @@ describe("type parser", () => {
                 name: "typeA",
                 optional: false,
                 type: {
-                  kind: TypeKind.STRING
+                  kind: TypeKind.STRING,
+                  schemaProps: undefined
                 }
               }
             ]
@@ -563,7 +593,8 @@ describe("type parser", () => {
                 name: "typeB",
                 optional: false,
                 type: {
-                  kind: TypeKind.BOOLEAN
+                  kind: TypeKind.BOOLEAN,
+                  schemaProps: undefined
                 }
               }
             ]

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -56,6 +56,11 @@ export type PrimitiveType = Exclude<
   ObjectType | ArrayType | UnionType | ReferenceType | IntersectionType
 >;
 
+export interface SchemaProp {
+  name: string;
+  value: boolean | number | string;
+}
+
 export type LiteralType =
   | BooleanLiteralType
   | StringLiteralType
@@ -68,54 +73,66 @@ export interface NullType {
 
 export interface BooleanType {
   kind: TypeKind.BOOLEAN;
+  schemaProps?: SchemaProp[];
 }
 
 export interface BooleanLiteralType {
   kind: TypeKind.BOOLEAN_LITERAL;
   value: boolean;
+  schemaProps?: SchemaProp[];
 }
 
 export interface StringType {
   kind: TypeKind.STRING;
+  schemaProps?: SchemaProp[];
 }
 
 export interface StringLiteralType {
   kind: TypeKind.STRING_LITERAL;
   value: string;
+  schemaProps?: SchemaProp[];
 }
 
 export interface FloatType {
   kind: TypeKind.FLOAT;
+  schemaProps?: SchemaProp[];
 }
 
 export interface DoubleType {
   kind: TypeKind.DOUBLE;
+  schemaProps?: SchemaProp[];
 }
 
 export interface FloatLiteralType {
   kind: TypeKind.FLOAT_LITERAL;
   value: number;
+  schemaProps?: SchemaProp[];
 }
 
 export interface Int32Type {
   kind: TypeKind.INT32;
+  schemaProps?: SchemaProp[];
 }
 
 export interface Int64Type {
   kind: TypeKind.INT64;
+  schemaProps?: SchemaProp[];
 }
 
 export interface IntLiteralType {
   kind: TypeKind.INT_LITERAL;
   value: number;
+  schemaProps?: SchemaProp[];
 }
 
 export interface DateType {
   kind: TypeKind.DATE;
+  schemaProps?: SchemaProp[];
 }
 
 export interface DateTimeType {
   kind: TypeKind.DATE_TIME;
+  schemaProps?: SchemaProp[];
 }
 
 export interface ObjectPropertiesType {
@@ -128,22 +145,26 @@ export interface ObjectPropertiesType {
 export interface ObjectType {
   kind: TypeKind.OBJECT;
   properties: Array<ObjectPropertiesType>;
+  schemaProps?: SchemaProp[];
 }
 
 export interface ArrayType {
   kind: TypeKind.ARRAY;
   elementType: Type;
+  schemaProps?: SchemaProp[];
 }
 
 export interface UnionType {
   kind: TypeKind.UNION;
   types: Type[];
   discriminator?: string;
+  schemaProps?: SchemaProp[];
 }
 
 export interface IntersectionType {
   kind: TypeKind.INTERSECTION;
   types: Type[];
+  schemaProps?: SchemaProp[];
 }
 
 export interface ReferenceType {
@@ -412,6 +433,12 @@ export function isReferenceType(type: Type): type is ReferenceType {
   return type.kind === TypeKind.REFERENCE;
 }
 
+export function isNotReferenceType<T extends Type>(
+  type: T
+): type is Exclude<T, ReferenceType> {
+  return !isReferenceType(type);
+}
+
 export function isPrimitiveType(type: Type): type is PrimitiveType {
   switch (type.kind) {
     case TypeKind.NULL:
@@ -452,6 +479,12 @@ export function isNotLiteralType<T extends Type>(
   type: T
 ): type is Exclude<T, LiteralType> {
   return !isLiteralType(type);
+}
+
+export function isSchemaPropAllowedType<T extends Type>(
+  type: T
+): type is Exclude<T, NullType | ReferenceType> {
+  return isNotNullType(type) && isNotReferenceType(type);
 }
 
 // Guard helpers

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/validator": "^13.1.3",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
-    "core-js": "^3.9.0",
+    "core-js": "^3.11.0",
     "css-loader": "^4.3.0",
     "eslint": "^7.25.0",
     "eslint-plugin-jest": "^24.3.5",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/inquirer": "^7.3.1",
     "@types/jest": "^26.0.22",
     "@types/js-yaml": "^4.0.0",
-    "@types/moxios": "^0.4.10",
+    "@types/moxios": "^0.4.11",
     "@types/qs": "^6.9.6",
     "@types/randomstring": "^1.1.6",
     "@types/react": "^17.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "html-webpack-plugin": "^4.5.2",
     "jest": "^26.6.3",
     "jest-junit": "^12.0.0",
-    "mini-css-extract-plugin": "^1.3.8",
+    "mini-css-extract-plugin": "^1.4.1",
     "mobx": "^6.0.4",
     "nock": "^13.0.7",
     "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "fs-extra": "^9.1.0",
     "inquirer": "^8.0.0",
     "js-yaml": "^4.0.0",
-    "qs": "^6.9.6",
+    "qs": "^6.10.1",
     "randomstring": "^1.1.5",
     "ts-morph": "^8.2.0",
     "typescript": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airtasker/spot",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "author": "Francois Wouts, Leslie Fung",
   "bin": {
     "spot": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/react-dom": "^17.0.3",
     "@types/supertest": "^2.0.11",
     "@types/validator": "^13.1.3",
-    "@typescript-eslint/eslint-plugin": "^4.15.1",
+    "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.21.0",
     "core-js": "^3.9.0",
     "css-loader": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jest-junit": "^12.0.0",
     "mini-css-extract-plugin": "^1.4.1",
     "mobx": "^6.0.4",
-    "nock": "^13.0.7",
+    "nock": "^13.0.11",
     "prettier": "^2.2.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@typescript-eslint/parser": "^4.21.0",
     "core-js": "^3.9.0",
     "css-loader": "^4.3.0",
-    "eslint": "^7.20.0",
+    "eslint": "^7.24.0",
     "eslint-plugin-jest": "^24.3.5",
     "html-webpack-plugin": "^4.5.2",
     "jest": "^26.6.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/moxios": "^0.4.11",
     "@types/qs": "^6.9.6",
     "@types/randomstring": "^1.1.6",
-    "@types/react": "^17.0.3",
+    "@types/react": "^17.0.4",
     "@types/react-dom": "^17.0.3",
     "@types/supertest": "^2.0.11",
     "@types/validator": "^13.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airtasker/spot",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": "Francois Wouts, Leslie Fung",
   "bin": {
     "spot": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "prettier": "^2.2.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
-    "redoc": "^2.0.0-rc.48",
+    "redoc": "^2.0.0-rc.51",
     "styled-components": "^4.4.1",
     "supertest": "^6.1.3",
     "ts-jest": "^26.5.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "core-js": "^3.9.0",
     "css-loader": "^4.3.0",
     "eslint": "^7.20.0",
-    "eslint-plugin-jest": "^24.1.5",
+    "eslint-plugin-jest": "^24.3.5",
     "html-webpack-plugin": "^4.5.2",
     "jest": "^26.6.3",
     "jest-junit": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/supertest": "^2.0.10",
     "@types/validator": "^13.1.3",
     "@typescript-eslint/eslint-plugin": "^4.15.1",
-    "@typescript-eslint/parser": "^4.15.1",
+    "@typescript-eslint/parser": "^4.21.0",
     "core-js": "^3.9.0",
     "css-loader": "^4.3.0",
     "eslint": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@stoplight/spectral": "^5.9.1",
     "@types/cors": "^2.8.10",
     "@types/express": "^4.17.11",
-    "@types/fs-extra": "^9.0.10",
+    "@types/fs-extra": "^9.0.11",
     "@types/inquirer": "^7.3.1",
     "@types/jest": "^26.0.22",
     "@types/js-yaml": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/moxios": "^0.4.10",
     "@types/qs": "^6.9.6",
     "@types/randomstring": "^1.1.6",
-    "@types/react": "^17.0.2",
+    "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.3",
     "@types/supertest": "^2.0.11",
     "@types/validator": "^13.1.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "qs": "^6.10.1",
     "randomstring": "^1.1.5",
     "ts-morph": "^8.2.0",
-    "typescript": "^4.1.5",
+    "typescript": "^4.2.4",
     "validator": "^13.6.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "html-webpack-plugin": "^4.5.2",
     "jest": "^26.6.3",
     "jest-junit": "^12.0.0",
-    "mini-css-extract-plugin": "^1.5.0",
+    "mini-css-extract-plugin": "^1.6.0",
     "mobx": "^6.3.0",
     "nock": "^13.0.11",
     "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/express": "^4.17.11",
     "@types/fs-extra": "^9.0.11",
     "@types/inquirer": "^7.3.1",
-    "@types/jest": "^26.0.22",
+    "@types/jest": "^26.0.23",
     "@types/js-yaml": "^4.0.1",
     "@types/moxios": "^0.4.11",
     "@types/qs": "^6.9.6",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "fs-extra": "^9.1.0",
-    "inquirer": "^7.3.3",
+    "inquirer": "^8.0.0",
     "js-yaml": "^4.0.0",
     "qs": "^6.9.6",
     "randomstring": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "core-js": "^3.11.0",
     "css-loader": "^4.3.0",
     "eslint": "^7.25.0",
-    "eslint-plugin-jest": "^24.3.5",
+    "eslint-plugin-jest": "^24.3.6",
     "html-webpack-plugin": "^4.5.2",
     "jest": "^26.6.3",
     "jest-junit": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "html-webpack-plugin": "^4.5.2",
     "jest": "^26.6.3",
     "jest-junit": "^12.0.0",
-    "mini-css-extract-plugin": "^1.4.1",
+    "mini-css-extract-plugin": "^1.5.0",
     "mobx": "^6.3.0",
     "nock": "^13.0.11",
     "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@typescript-eslint/parser": "^4.22.0",
     "core-js": "^3.9.0",
     "css-loader": "^4.3.0",
-    "eslint": "^7.24.0",
+    "eslint": "^7.25.0",
     "eslint-plugin-jest": "^24.3.5",
     "html-webpack-plugin": "^4.5.2",
     "jest": "^26.6.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/express": "^4.17.11",
     "@types/fs-extra": "^9.0.10",
     "@types/inquirer": "^7.3.1",
-    "@types/jest": "^26.0.20",
+    "@types/jest": "^26.0.22",
     "@types/js-yaml": "^4.0.0",
     "@types/moxios": "^0.4.10",
     "@types/qs": "^6.9.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.26.0",
-    "@stoplight/spectral": "^5.8.1",
+    "@stoplight/spectral": "^5.9.1",
     "@types/cors": "^2.8.10",
     "@types/express": "^4.17.11",
     "@types/fs-extra": "^9.0.7",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@stoplight/spectral": "^5.9.1",
     "@types/cors": "^2.8.10",
     "@types/express": "^4.17.11",
-    "@types/fs-extra": "^9.0.7",
+    "@types/fs-extra": "^9.0.10",
     "@types/inquirer": "^7.3.1",
     "@types/jest": "^26.0.20",
     "@types/js-yaml": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/fs-extra": "^9.0.10",
     "@types/inquirer": "^7.3.1",
     "@types/jest": "^26.0.22",
-    "@types/js-yaml": "^4.0.0",
+    "@types/js-yaml": "^4.0.1",
     "@types/moxios": "^0.4.11",
     "@types/qs": "^6.9.6",
     "@types/randomstring": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "prettier": "^2.2.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
-    "redoc": "^2.0.0-rc.51",
+    "redoc": "^2.0.0-rc.53",
     "styled-components": "^4.4.1",
     "supertest": "^6.1.3",
     "ts-jest": "^26.5.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/validator": "^13.1.3",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
-    "core-js": "^3.11.0",
+    "core-js": "^3.11.1",
     "css-loader": "^4.3.0",
     "eslint": "^7.25.0",
     "eslint-plugin-jest": "^24.3.6",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "styled-components": "^4.4.1",
     "supertest": "^6.1.3",
     "ts-jest": "^26.5.1",
-    "ts-loader": "^8.0.17",
+    "ts-loader": "^8.1.0",
     "webpack": "^4.44.2",
     "webpack-cli": "^4.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "express": "^4.17.1",
     "fs-extra": "^9.1.0",
     "inquirer": "^8.0.0",
-    "js-yaml": "^4.0.0",
+    "js-yaml": "^4.1.0",
     "qs": "^6.10.1",
     "randomstring": "^1.1.5",
     "ts-morph": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "redoc": "^2.0.0-rc.53",
     "styled-components": "^4.4.1",
     "supertest": "^6.1.3",
-    "ts-jest": "^26.5.1",
+    "ts-jest": "^26.5.5",
     "ts-loader": "^8.1.0",
     "webpack": "^4.44.2",
     "webpack-cli": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jest": "^26.6.3",
     "jest-junit": "^12.0.0",
     "mini-css-extract-plugin": "^1.4.1",
-    "mobx": "^6.0.4",
+    "mobx": "^6.3.0",
     "nock": "^13.0.11",
     "prettier": "^2.2.1",
     "react": "^16.14.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/jest": "^26.0.22",
     "@types/js-yaml": "^4.0.0",
     "@types/moxios": "^0.4.10",
-    "@types/qs": "^6.9.5",
+    "@types/qs": "^6.9.6",
     "@types/randomstring": "^1.1.6",
     "@types/react": "^17.0.2",
     "@types/react-dom": "^17.0.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "randomstring": "^1.1.5",
     "ts-morph": "^8.2.0",
     "typescript": "^4.1.5",
-    "validator": "^13.5.2"
+    "validator": "^13.6.0"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/randomstring": "^1.1.6",
     "@types/react": "^17.0.2",
     "@types/react-dom": "^17.0.3",
-    "@types/supertest": "^2.0.10",
+    "@types/supertest": "^2.0.11",
     "@types/validator": "^13.1.3",
     "@typescript-eslint/eslint-plugin": "^4.15.1",
     "@typescript-eslint/parser": "^4.21.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/qs": "^6.9.5",
     "@types/randomstring": "^1.1.6",
     "@types/react": "^17.0.2",
-    "@types/react-dom": "^17.0.1",
+    "@types/react-dom": "^17.0.3",
     "@types/supertest": "^2.0.10",
     "@types/validator": "^13.1.3",
     "@typescript-eslint/eslint-plugin": "^4.15.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airtasker/spot",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": "Francois Wouts, Leslie Fung",
   "bin": {
     "spot": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/supertest": "^2.0.11",
     "@types/validator": "^13.1.3",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
-    "@typescript-eslint/parser": "^4.21.0",
+    "@typescript-eslint/parser": "^4.22.0",
     "core-js": "^3.9.0",
     "css-loader": "^4.3.0",
     "eslint": "^7.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7509,9 +7509,9 @@ sshpk@^1.7.0:
     tweetnacl "~0.14.0"
 
 ssri@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
-  integrity sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5"
+  integrity sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==
   dependencies:
     figgy-pudding "^3.5.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -954,10 +954,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^26.0.22":
-  version "26.0.22"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.22.tgz#8308a1debdf1b807aa47be2838acdcd91e88fbe6"
-  integrity sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==
+"@types/jest@^26.0.23":
+  version "26.0.23"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.23.tgz#a1b7eab3c503b80451d019efb588ec63522ee4e7"
+  integrity sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -686,20 +686,21 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@stoplight/better-ajv-errors@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@stoplight/better-ajv-errors/-/better-ajv-errors-0.0.3.tgz#8d47a511aca89e0027cf748785910fbb25d7c54f"
-  integrity sha512-q3PoPiYZdzfJjQ+q6ifuLVFx3dBKRxW1OBGxnLAoDlamYb+GJUNiaSLB32L6OB4fi6h/TsY21lZB7y7aYFM7tQ==
+"@stoplight/better-ajv-errors@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@stoplight/better-ajv-errors/-/better-ajv-errors-0.0.4.tgz#2147e0e4e9918519e885e74b15aa458a89eb2337"
+  integrity sha512-HFXOerq/6/6YisiTJwCOScwfNaXyGmX7ROAEUoKOrckK9+hJ/QLFm5EofQYEgX4aXkvHokLEbWBs4NMwZ6hQUw==
   dependencies:
     jsonpointer "^4.0.1"
     leven "^3.1.0"
 
-"@stoplight/json-ref-readers@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-ref-readers/-/json-ref-readers-1.2.1.tgz#45061659cf46b60a7d9422858c4cd4c2a5d5e7c7"
-  integrity sha512-fbh8sXRrwfOCx4EA2e6FGUwvu5zxCQ9xHZg3vYDFSb1HLTlrCeRTdx3VCmYjCSGAhpcwgpB4zMc8kiudujo8Yg==
+"@stoplight/json-ref-readers@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-ref-readers/-/json-ref-readers-1.2.2.tgz#e5992bae597f228f988f362a4c0304c03a92008b"
+  integrity sha512-nty0tHUq2f1IKuFYsLM4CXLZGHdMn+X/IwEUIpeSOXt0QjMUbL0Em57iJUDzz+2MkWG83smIigNZ3fauGjqgdQ==
   dependencies:
     node-fetch "^2.6.0"
+    tslib "^1.14.1"
 
 "@stoplight/json-ref-resolver@3.1.1":
   version "3.1.1"
@@ -718,10 +719,10 @@
     tslib "^2.1.0"
     urijs "^1.19.5"
 
-"@stoplight/json@3.10.2", "@stoplight/json@^3.10.2":
-  version "3.10.2"
-  resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.10.2.tgz#a17463c7576602971edbf6f11d3eaed80db262bb"
-  integrity sha512-mUf4t2bOBZjVa8KdEI4+EqX/8zXJLfGKv/cj++giLbCkYNGjBgJnmPSDNOOBgJHpocdVml0hK8ZuLADqWVVB2Q==
+"@stoplight/json@3.11.2", "@stoplight/json@^3.10.2":
+  version "3.11.2"
+  resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.11.2.tgz#6bd5f60f81a59e79f5ab884ab50c1d1013f54b1c"
+  integrity sha512-6ePZkRBrcy/SVvnXH+Yi+sIBkKH4Nu4acG8dgaAi/pV8322lvnylyfZ21KLWEKYKON+Ll+NOZeIcaZNj5M0O9g==
   dependencies:
     "@stoplight/ordered-object-literal" "^1.0.1"
     "@stoplight/types" "^11.9.0"
@@ -746,18 +747,18 @@
   resolved "https://registry.yarnpkg.com/@stoplight/path/-/path-1.3.2.tgz#96e591496b72fde0f0cdae01a61d64f065bd9ede"
   integrity sha512-lyIc6JUlUA8Ve5ELywPC8I2Sdnh1zc1zmbYgVarhXIp9YeAB0ReeqmGEOWNtlHkbP2DAA1AL65Wfn2ncjK/jtQ==
 
-"@stoplight/spectral@^5.8.1":
-  version "5.8.1"
-  resolved "https://registry.yarnpkg.com/@stoplight/spectral/-/spectral-5.8.1.tgz#b7ac5cdb75ba54fbd65819490a3b638755a0714c"
-  integrity sha512-GhdKnnJ8LAYfvoiNRWmkgQMNRGHD03T9Hmtq8K7hYi98ToL3WfqYC5oAVLsYw/y9t+FpP32gWzyrTmz8lBI/kA==
+"@stoplight/spectral@^5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@stoplight/spectral/-/spectral-5.9.1.tgz#4fb029481763dc1abe8bca397da90cd14f6323cc"
+  integrity sha512-YgTtieZpYOva6vAwHRBQWom2muwtB6mzpbBG896C1vOiNq+ebAYA1PP9gzHyf+Uagt674CWTOfvsMrzVPosBqQ==
   dependencies:
-    "@stoplight/better-ajv-errors" "0.0.3"
-    "@stoplight/json" "3.10.2"
-    "@stoplight/json-ref-readers" "1.2.1"
+    "@stoplight/better-ajv-errors" "0.0.4"
+    "@stoplight/json" "3.11.2"
+    "@stoplight/json-ref-readers" "1.2.2"
     "@stoplight/json-ref-resolver" "3.1.1"
     "@stoplight/lifecycle" "2.3.2"
     "@stoplight/path" "1.3.2"
-    "@stoplight/types" "11.9.0"
+    "@stoplight/types" "11.10.0"
     "@stoplight/yaml" "4.2.1"
     abort-controller "3.0.0"
     ajv "6.12.5"
@@ -772,16 +773,16 @@
     nanoid "2.1.11"
     nimma "0.0.0"
     node-fetch "2.6.1"
-    proxy-agent "3.1.1"
+    proxy-agent "4.0.1"
     strip-ansi "6.0"
     text-table "0.2"
     tslib "1.13.0"
     yargs "15.4.1"
 
-"@stoplight/types@11.9.0", "@stoplight/types@^11.9.0":
-  version "11.9.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-11.9.0.tgz#ced7de2dd53439d2409a3cb390bf7d5b76382ac6"
-  integrity sha512-4bzPpWZobt0e+d0OtALCJyl1HGzKo6ur21qxnId9dTl8v3yeD+5HJKZ2h1mv7e94debH5QDtimMU80V6jbXM8Q==
+"@stoplight/types@11.10.0", "@stoplight/types@^11.9.0":
+  version "11.10.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-11.10.0.tgz#60bbee770526f4de9cd1c613c7ab84c4e4674126"
+  integrity sha512-ffHD9i4UHS8Gsg7Ar8pKjI9B4kq7MRekE7tCROFGcFDzQhfRx9T92AduoLAtP/010XNYq23yDKpLBRPIEk8+xg==
   dependencies:
     "@types/json-schema" "^7.0.4"
     utility-types "^3.10.0"
@@ -800,6 +801,11 @@
     "@stoplight/types" "^11.9.0"
     "@stoplight/yaml-ast-parser" "0.0.48"
     tslib "^1.12.0"
+
+"@tootallnate/once@1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
+  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
 "@ts-morph/common@~0.6.0":
   version "0.6.0"
@@ -1458,19 +1464,12 @@ acorn@^7.1.1, acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-agent-base@4, agent-base@^4.2.0, agent-base@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
-  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
+agent-base@6, agent-base@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
-    es6-promisify "^5.0.0"
-
-agent-base@~4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
-  integrity sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
-  dependencies:
-    es6-promisify "^5.0.0"
+    debug "4"
 
 ajv-errors@^1.0.0:
   version "1.0.1"
@@ -1693,10 +1692,10 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-ast-types@0.x.x:
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
-  integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==
+ast-types@^0.13.2:
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.4.tgz#ee0d77b343263965ecc3fb62da16e7222b2b6782"
+  integrity sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==
   dependencies:
     tslib "^2.0.1"
 
@@ -2748,10 +2747,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-uri-to-buffer@1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz#77163ea9c20d8641b4707e8f18abdf9a78f34835"
-  integrity sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==
+data-uri-to-buffer@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
+  integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
 
 data-urls@^2.0.0:
   version "2.0.0"
@@ -2762,17 +2761,10 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
-debug@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 
@@ -2782,13 +2774,6 @@ debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
   dependencies:
     ms "2.1.2"
-
-debug@^3.1.0:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
-  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
-  dependencies:
-    ms "^2.1.1"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -2849,14 +2834,14 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-degenerator@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/degenerator/-/degenerator-1.0.4.tgz#fcf490a37ece266464d9cc431ab98c5819ced095"
-  integrity sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=
+degenerator@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/degenerator/-/degenerator-2.2.0.tgz#49e98c11fa0293c5b26edfbb52f15729afcdb254"
+  integrity sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==
   dependencies:
-    ast-types "0.x.x"
-    escodegen "1.x.x"
-    esprima "3.x.x"
+    ast-types "^0.13.2"
+    escodegen "^1.8.1"
+    esprima "^4.0.0"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -3151,18 +3136,6 @@ es6-promise@^3.2.1:
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
   integrity sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=
 
-es6-promise@^4.0.3:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
-  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
-
-es6-promisify@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
-  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
-  dependencies:
-    es6-promise "^4.0.3"
-
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -3188,7 +3161,7 @@ escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
-escodegen@1.x.x, escodegen@^1.14.1:
+escodegen@^1.14.1, escodegen@^1.8.1:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
   integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
@@ -3291,11 +3264,6 @@ espree@^7.3.0, espree@^7.3.1:
     acorn "^7.4.0"
     acorn-jsx "^5.3.1"
     eslint-visitor-keys "^1.3.0"
-
-esprima@3.x.x:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
-  integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
 
 esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
   version "4.0.1"
@@ -3631,10 +3599,15 @@ file-entry-cache@^6.0.0:
   dependencies:
     flat-cache "^3.0.4"
 
-file-uri-to-path@1, file-uri-to-path@1.0.0:
+file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
+file-uri-to-path@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz#7b415aeba227d575851e0a5b0c640d7656403fba"
+  integrity sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -3800,7 +3773,7 @@ fs-extra@^6.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^8.1:
+fs-extra@^8.1, fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
@@ -3852,7 +3825,7 @@ fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
-ftp@~0.3.10:
+ftp@^0.3.10:
   version "0.3.10"
   resolved "https://registry.yarnpkg.com/ftp/-/ftp-0.3.10.tgz#9197d861ad8142f3e63d5a83bfe4c59f7330885d"
   integrity sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=
@@ -3918,17 +3891,17 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.0.tgz#3e0012cb6827319da2706e601a1583e8629a6718"
   integrity sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==
 
-get-uri@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/get-uri/-/get-uri-2.0.4.tgz#d4937ab819e218d4cb5ae18e4f5962bef169cc6a"
-  integrity sha512-v7LT/s8kVjs+Tx0ykk1I+H/rbpzkHvuIq87LmeXptcf5sNWm9uQiwjNAt94SJPA1zOlCntmnOlJvVWKmzsxG8Q==
+get-uri@3:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/get-uri/-/get-uri-3.0.2.tgz#f0ef1356faabc70e1f9404fa3b66b2ba9bfc725c"
+  integrity sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==
   dependencies:
-    data-uri-to-buffer "1"
-    debug "2"
-    extend "~3.0.2"
-    file-uri-to-path "1"
-    ftp "~0.3.10"
-    readable-stream "2"
+    "@tootallnate/once" "1"
+    data-uri-to-buffer "3"
+    debug "4"
+    file-uri-to-path "2"
+    fs-extra "^8.1.0"
+    ftp "^0.3.10"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -4231,13 +4204,14 @@ http-errors@1.7.3, http-errors@~1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
-http-proxy-agent@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
-  integrity sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==
+http-proxy-agent@^4.0.0, http-proxy-agent@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
+  integrity sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
   dependencies:
-    agent-base "4"
-    debug "3.1.0"
+    "@tootallnate/once" "1"
+    agent-base "6"
+    debug "4"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -4258,13 +4232,13 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-https-proxy-agent@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz#b8c286433e87602311b01c8ea34413d856a4af81"
-  integrity sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==
+https-proxy-agent@5, https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
   dependencies:
-    agent-base "^4.3.0"
-    debug "^3.1.0"
+    agent-base "6"
+    debug "4"
 
 human-signals@^1.1.1:
   version "1.1.1"
@@ -4408,7 +4382,7 @@ ip-regex@^2.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
-ip@1.1.5, ip@^1.1.5:
+ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
@@ -5773,7 +5747,7 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@2.1.2, ms@^2.1.1:
+ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -5841,10 +5815,10 @@ neo-async@^2.5.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-netmask@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
-  integrity sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=
+netmask@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
+  integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -6217,30 +6191,29 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-pac-proxy-agent@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-3.0.1.tgz#115b1e58f92576cac2eba718593ca7b0e37de2ad"
-  integrity sha512-44DUg21G/liUZ48dJpUSjZnFfZro/0K5JTyFYLBcmh9+T6Ooi4/i4efwUiEy0+4oQusCBqWdhv16XohIj1GqnQ==
+pac-proxy-agent@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-4.1.0.tgz#66883eeabadc915fc5e95457324cb0f0ac78defb"
+  integrity sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q==
   dependencies:
-    agent-base "^4.2.0"
-    debug "^4.1.1"
-    get-uri "^2.0.0"
-    http-proxy-agent "^2.1.0"
-    https-proxy-agent "^3.0.0"
-    pac-resolver "^3.0.0"
+    "@tootallnate/once" "1"
+    agent-base "6"
+    debug "4"
+    get-uri "3"
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "5"
+    pac-resolver "^4.1.0"
     raw-body "^2.2.0"
-    socks-proxy-agent "^4.0.1"
+    socks-proxy-agent "5"
 
-pac-resolver@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-3.0.0.tgz#6aea30787db0a891704deb7800a722a7615a6f26"
-  integrity sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==
+pac-resolver@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-4.2.0.tgz#b82bcb9992d48166920bc83c7542abb454bd9bdd"
+  integrity sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==
   dependencies:
-    co "^4.6.0"
-    degenerator "^1.0.4"
+    degenerator "^2.2.0"
     ip "^1.1.5"
-    netmask "^1.0.6"
-    thunkify "^2.1.2"
+    netmask "^2.0.1"
 
 pako@~1.0.5:
   version "1.0.11"
@@ -6597,19 +6570,19 @@ proxy-addr@~2.0.5:
     forwarded "~0.1.2"
     ipaddr.js "1.9.1"
 
-proxy-agent@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-3.1.1.tgz#7e04e06bf36afa624a1540be247b47c970bd3014"
-  integrity sha512-WudaR0eTsDx33O3EJE16PjBRZWcX8GqCEeERw1W3hZJgH/F2a46g7jty6UGty6NeJ4CKQy8ds2CJPMiyeqaTvw==
+proxy-agent@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-4.0.1.tgz#326c3250776c7044cd19655ccbfadf2e065a045c"
+  integrity sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA==
   dependencies:
-    agent-base "^4.2.0"
+    agent-base "^6.0.0"
     debug "4"
-    http-proxy-agent "^2.1.0"
-    https-proxy-agent "^3.0.0"
+    http-proxy-agent "^4.0.0"
+    https-proxy-agent "^5.0.0"
     lru-cache "^5.1.1"
-    pac-proxy-agent "^3.0.1"
+    pac-proxy-agent "^4.1.0"
     proxy-from-env "^1.0.0"
-    socks-proxy-agent "^4.0.1"
+    socks-proxy-agent "^5.0.0"
 
 proxy-from-env@^1.0.0:
   version "1.1.0"
@@ -6825,7 +6798,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-"readable-stream@1 || 2", readable-stream@2, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -7441,20 +7414,21 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-socks-proxy-agent@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz#3c8991f3145b2799e70e11bd5fbc8b1963116386"
-  integrity sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==
+socks-proxy-agent@5, socks-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-5.0.0.tgz#7c0f364e7b1cf4a7a437e71253bed72e9004be60"
+  integrity sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==
   dependencies:
-    agent-base "~4.2.1"
-    socks "~2.3.2"
+    agent-base "6"
+    debug "4"
+    socks "^2.3.3"
 
-socks@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.3.3.tgz#01129f0a5d534d2b897712ed8aceab7ee65d78e3"
-  integrity sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==
+socks@^2.3.3:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.0.tgz#6b984928461d39871b3666754b9000ecf39dfac2"
+  integrity sha512-mNmr9owlinMplev0Wd7UHFlqI4ofnBnNzFuzrm63PPaHgbkqCFe4T5LzwKmtQ/f2tX0NTpcdVLyD/FHxFBstYw==
   dependencies:
-    ip "1.1.5"
+    ip "^1.1.5"
     smart-buffer "^4.1.0"
 
 sort-keys@^4.0.0:
@@ -7943,11 +7917,6 @@ through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-thunkify@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
-  integrity sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=
-
 timers-browserify@^2.0.4:
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.12.tgz#44a45c11fbf407f34f97bccd1577c652361b00ee"
@@ -8092,7 +8061,7 @@ tslib@1.13.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@^1.10.0, tslib@^1.12.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.12.0, tslib@^1.14.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5628,10 +5628,10 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-mini-css-extract-plugin@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-1.5.0.tgz#69bee3b273d2d4ee8649a2eb409514b7df744a27"
-  integrity sha512-SIbuLMv6jsk1FnLIU5OUG/+VMGUprEjM1+o2trOAx8i5KOKMrhyezb1dJ4Ugsykb8Jgq8/w5NEopy6escV9G7g==
+mini-css-extract-plugin@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.0.tgz#b4db2525af2624899ed64a23b0016e0036411893"
+  integrity sha512-nPFKI7NSy6uONUo9yn2hIfb9vyYvkFu95qki0e21DQ9uaqNKDP15DGpK0KnV6wDroWxPHtExrdEwx/yDQ8nVRw==
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -900,10 +900,10 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/fs-extra@^9.0.10":
-  version "9.0.10"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.10.tgz#8023a72e3d06cf54929ea47ec7634e47f33f4046"
-  integrity sha512-O9T2LLkRDiTlalOBdjEkcnT0MRdT2+wglCl7pJUJ3mkWkR8hX4K+5bg2raQNJcLv4V8zGuTXe7Ud3wSqkTyuyQ==
+"@types/fs-extra@^9.0.11":
+  version "9.0.11"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.11.tgz#8cc99e103499eab9f347dbc6ca4e99fb8d2c2b87"
+  integrity sha512-mZsifGG4QeQ7hlkhO56u7zt/ycBgGxSVsFI/6lGTU34VtwkiqrrSDgw0+ygs8kFGWcXnFQWMrzF2h7TtDFNixA==
   dependencies:
     "@types/node" "*"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2546,10 +2546,10 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js@^3.11.0, core-js@^3.2.1:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.11.0.tgz#05dac6aa70c0a4ad842261f8957b961d36eb8926"
-  integrity sha512-bd79DPpx+1Ilh9+30aT5O1sgpQd4Ttg8oqkqi51ZzhedMM1omD2e6IOF48Z/DzDCZ2svp49tN/3vneTK6ZBkXw==
+core-js@^3.11.1, core-js@^3.2.1:
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.11.1.tgz#f920392bf8ed63a0ec8e4e729857bfa3d121c525"
+  integrity sha512-k93Isqg7e4txZWMGNYwevZL9MiogLk8pd1PtwrmFmi8IBq4GXqUaVW/a33Llt6amSI36uSjd0GWwc9pTT9ALlQ==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1015,10 +1015,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/qs@*", "@types/qs@^6.9.5":
-  version "6.9.5"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.5.tgz#434711bdd49eb5ee69d90c1d67c354a9a8ecb18b"
-  integrity sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==
+"@types/qs@*", "@types/qs@^6.9.6":
+  version "6.9.6"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.6.tgz#df9c3c8b31a247ec315e6996566be3171df4b3b1"
+  integrity sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==
 
 "@types/randomstring@^1.1.6":
   version "1.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,14 +1160,14 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^4.15.1":
-  version "4.15.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.15.1.tgz#4c91a0602733db63507e1dbf13187d6c71a153c4"
-  integrity sha512-V8eXYxNJ9QmXi5ETDguB7O9diAXlIyS+e3xzLoP/oVE4WCAjssxLIa0mqCLsCGXulYJUfT+GV70Jv1vHsdKwtA==
+"@typescript-eslint/parser@^4.21.0":
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.21.0.tgz#a227fc2af4001668c3e3f7415d4feee5093894c1"
+  integrity sha512-eyNf7QmE5O/l1smaQgN0Lj2M/1jOuNg2NrBm1dqqQN0sVngTLyw8tdCbih96ixlhbF1oINoN8fDCyEH9SjLeIA==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.15.1"
-    "@typescript-eslint/types" "4.15.1"
-    "@typescript-eslint/typescript-estree" "4.15.1"
+    "@typescript-eslint/scope-manager" "4.21.0"
+    "@typescript-eslint/types" "4.21.0"
+    "@typescript-eslint/typescript-estree" "4.21.0"
     debug "^4.1.1"
 
 "@typescript-eslint/scope-manager@4.15.1":
@@ -1178,10 +1178,23 @@
     "@typescript-eslint/types" "4.15.1"
     "@typescript-eslint/visitor-keys" "4.15.1"
 
+"@typescript-eslint/scope-manager@4.21.0":
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.21.0.tgz#c81b661c4b8af1ec0c010d847a8f9ab76ab95b4d"
+  integrity sha512-kfOjF0w1Ix7+a5T1knOw00f7uAP9Gx44+OEsNQi0PvvTPLYeXJlsCJ4tYnDj5PQEYfpcgOH5yBlw7K+UEI9Agw==
+  dependencies:
+    "@typescript-eslint/types" "4.21.0"
+    "@typescript-eslint/visitor-keys" "4.21.0"
+
 "@typescript-eslint/types@4.15.1":
   version "4.15.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.15.1.tgz#da702f544ef1afae4bc98da699eaecd49cf31c8c"
   integrity sha512-iGsaUyWFyLz0mHfXhX4zO6P7O3sExQpBJ2dgXB0G5g/8PRVfBBsmQIc3r83ranEQTALLR3Vko/fnCIVqmH+mPw==
+
+"@typescript-eslint/types@4.21.0":
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.21.0.tgz#abdc3463bda5d31156984fa5bc316789c960edef"
+  integrity sha512-+OQaupjGVVc8iXbt6M1oZMwyKQNehAfLYJJ3SdvnofK2qcjfor9pEM62rVjBknhowTkh+2HF+/KdRAc/wGBN2w==
 
 "@typescript-eslint/typescript-estree@4.15.1":
   version "4.15.1"
@@ -1196,12 +1209,33 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@typescript-eslint/typescript-estree@4.21.0":
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.21.0.tgz#3817bd91857beeaeff90f69f1f112ea58d350b0a"
+  integrity sha512-ZD3M7yLaVGVYLw4nkkoGKumb7Rog7QID9YOWobFDMQKNl+vPxqVIW/uDk+MDeGc+OHcoG2nJ2HphwiPNajKw3w==
+  dependencies:
+    "@typescript-eslint/types" "4.21.0"
+    "@typescript-eslint/visitor-keys" "4.21.0"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-glob "^4.0.1"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/visitor-keys@4.15.1":
   version "4.15.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.1.tgz#c76abbf2a3be8a70ed760f0e5756bf62de5865dd"
   integrity sha512-tYzaTP9plooRJY8eNlpAewTOqtWW/4ff/5wBjNVaJ0S0wC4Gpq/zDVRTJa5bq2v1pCNQ08xxMCndcvR+h7lMww==
   dependencies:
     "@typescript-eslint/types" "4.15.1"
+    eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@4.21.0":
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.21.0.tgz#990a9acdc124331f5863c2cf21c88ba65233cd8d"
+  integrity sha512-dH22dROWGi5Z6p+Igc8bLVLmwy7vEe8r+8c+raPQU0LxgogPUrRAtRGtvBWmlr9waTu3n+QLt/qrS/hWzk1x5w==
+  dependencies:
+    "@typescript-eslint/types" "4.21.0"
     eslint-visitor-keys "^2.0.0"
 
 "@webassemblyjs/ast@1.9.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -1037,13 +1037,19 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.2":
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.2.tgz#3de24c4efef902dd9795a49c75f760cbe4f7a5a8"
-  integrity sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==
+"@types/react@*", "@types/react@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
+  integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
   dependencies:
     "@types/prop-types" "*"
+    "@types/scheduler" "*"
     csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
 "@types/serve-static@*":
   version "1.13.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3144,10 +3144,10 @@ escodegen@^1.14.1, escodegen@^1.8.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-plugin-jest@^24.3.5:
-  version "24.3.5"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-24.3.5.tgz#71f0b580f87915695c286c3f0eb88cf23664d044"
-  integrity sha512-XG4rtxYDuJykuqhsOqokYIR84/C8pRihRtEpVskYLbIIKGwPNW2ySxdctuVzETZE+MbF/e7wmsnbNVpzM0rDug==
+eslint-plugin-jest@^24.3.6:
+  version "24.3.6"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-24.3.6.tgz#5f0ca019183c3188c5ad3af8e80b41de6c8e9173"
+  integrity sha512-WOVH4TIaBLIeCX576rLcOgjNXqP+jNlCiEmRgFTfQtJ52DpwnIQKAVGlGPAN7CZ33bW6eNfHD6s8ZbEUTQubJg==
   dependencies:
     "@typescript-eslint/experimental-utils" "^4.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -982,10 +982,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/moxios@^0.4.10":
-  version "0.4.10"
-  resolved "https://registry.yarnpkg.com/@types/moxios/-/moxios-0.4.10.tgz#0762de3157714f8078a3c79ba65dcec4da701bfe"
-  integrity sha512-OGXB0kvKJT4KAdy4OzdGkBhNJ3f1x3FsqUq6elUBLcaBsVMy09hErlyhq2+zwEwcNbv1DGmksASW06XRISnxUQ==
+"@types/moxios@^0.4.11":
+  version "0.4.11"
+  resolved "https://registry.yarnpkg.com/@types/moxios/-/moxios-0.4.11.tgz#f7f582311c0c4f51c29b0cc548a27eac6b7f600f"
+  integrity sha512-731cjysq/Z+8ImvUWrYS/FO6KOKnbqPbeBfe1HBCVTWBegJso62dyjLnnevz9VzSWx2tRAijyEorqv8/8+2n3A==
   dependencies:
     axios "^0.21.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3862,6 +3862,15 @@ get-intrinsic@^1.0.0:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
+get-intrinsic@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+
 get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
@@ -6056,6 +6065,11 @@ object-inspect@^1.8.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
 
+object-inspect@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
+  integrity sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
+
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -6680,10 +6694,12 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.9.4, qs@^6.9.6:
-  version "6.9.6"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
-  integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
+qs@^6.10.1, qs@^6.9.4:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
+  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+  dependencies:
+    side-channel "^1.0.4"
 
 qs@~6.5.2:
   version "6.5.2"
@@ -7354,6 +7370,15 @@ should@^13.2.1:
     should-type "^1.4.0"
     should-type-adaptors "^1.0.1"
     should-util "^1.0.0"
+
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8342,10 +8342,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-validator@^13.5.2:
-  version "13.5.2"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-13.5.2.tgz#c97ae63ed4224999fb6f42c91eaca9567fe69a46"
-  integrity sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ==
+validator@^13.6.0:
+  version "13.6.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.6.0.tgz#1e71899c14cdc7b2068463cb24c1cc16f6ec7059"
+  integrity sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -954,7 +954,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@26.x", "@types/jest@^26.0.22":
+"@types/jest@^26.0.22":
   version "26.0.22"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.22.tgz#8308a1debdf1b807aa47be2838acdcd91e88fbe6"
   integrity sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==
@@ -8027,12 +8027,11 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
-ts-jest@^26.5.1:
-  version "26.5.1"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.1.tgz#4d53ee4481552f57c1624f0bd3425c8b17996150"
-  integrity sha512-G7Rmo3OJMvlqE79amJX8VJKDiRcd7/r61wh9fnvvG8cAjhA9edklGw/dCxRSQmfZ/z8NDums5srSVgwZos1qfg==
+ts-jest@^26.5.5:
+  version "26.5.5"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.5.tgz#e40481b6ee4dd162626ba481a2be05fa57160ea5"
+  integrity sha512-7tP4m+silwt1NHqzNRAPjW1BswnAhopTdc2K3HEkRZjF0ZG2F/e/ypVH0xiZIMfItFtD3CX0XFbwPzp9fIEUVg==
   dependencies:
-    "@types/jest" "26.x"
     bs-logger "0.x"
     buffer-from "1.x"
     fast-json-stable-stringify "2.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1145,13 +1145,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^4.15.1":
-  version "4.15.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.1.tgz#835f64aa0a403e5e9e64c10ceaf8d05c3f015180"
-  integrity sha512-yW2epMYZSpNJXZy22Biu+fLdTG8Mn6b22kR3TqblVk50HGNV8Zya15WAXuQCr8tKw4Qf1BL4QtI6kv6PCkLoJw==
+"@typescript-eslint/eslint-plugin@^4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.0.tgz#3d5f29bb59e61a9dba1513d491b059e536e16dbc"
+  integrity sha512-U8SP9VOs275iDXaL08Ln1Fa/wLXfj5aTr/1c0t0j6CdbOnxh+TruXu1p4I0NAvdPBQgoPjHsgKn28mOi0FzfoA==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.15.1"
-    "@typescript-eslint/scope-manager" "4.15.1"
+    "@typescript-eslint/experimental-utils" "4.22.0"
+    "@typescript-eslint/scope-manager" "4.22.0"
     debug "^4.1.1"
     functional-red-black-tree "^1.0.1"
     lodash "^4.17.15"
@@ -1159,15 +1159,15 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@4.15.1", "@typescript-eslint/experimental-utils@^4.0.1":
-  version "4.15.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.1.tgz#d744d1ac40570a84b447f7aa1b526368afd17eec"
-  integrity sha512-9LQRmOzBRI1iOdJorr4jEnQhadxK4c9R2aEAsm7WE/7dq8wkKD1suaV0S/JucTL8QlYUPU1y2yjqg+aGC0IQBQ==
+"@typescript-eslint/experimental-utils@4.22.0", "@typescript-eslint/experimental-utils@^4.0.1":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.0.tgz#68765167cca531178e7b650a53456e6e0bef3b1f"
+  integrity sha512-xJXHHl6TuAxB5AWiVrGhvbGL8/hbiCQ8FiWwObO3r0fnvBdrbWEDy1hlvGQOAWc6qsCWuWMKdVWlLAEMpxnddg==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.15.1"
-    "@typescript-eslint/types" "4.15.1"
-    "@typescript-eslint/typescript-estree" "4.15.1"
+    "@typescript-eslint/scope-manager" "4.22.0"
+    "@typescript-eslint/types" "4.22.0"
+    "@typescript-eslint/typescript-estree" "4.22.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
@@ -1181,14 +1181,6 @@
     "@typescript-eslint/typescript-estree" "4.21.0"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.15.1":
-  version "4.15.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.15.1.tgz#f6511eb38def2a8a6be600c530c243bbb56ac135"
-  integrity sha512-ibQrTFcAm7yG4C1iwpIYK7vDnFg+fKaZVfvyOm3sNsGAerKfwPVFtYft5EbjzByDJ4dj1WD8/34REJfw/9wdVA==
-  dependencies:
-    "@typescript-eslint/types" "4.15.1"
-    "@typescript-eslint/visitor-keys" "4.15.1"
-
 "@typescript-eslint/scope-manager@4.21.0":
   version "4.21.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.21.0.tgz#c81b661c4b8af1ec0c010d847a8f9ab76ab95b4d"
@@ -1197,28 +1189,23 @@
     "@typescript-eslint/types" "4.21.0"
     "@typescript-eslint/visitor-keys" "4.21.0"
 
-"@typescript-eslint/types@4.15.1":
-  version "4.15.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.15.1.tgz#da702f544ef1afae4bc98da699eaecd49cf31c8c"
-  integrity sha512-iGsaUyWFyLz0mHfXhX4zO6P7O3sExQpBJ2dgXB0G5g/8PRVfBBsmQIc3r83ranEQTALLR3Vko/fnCIVqmH+mPw==
+"@typescript-eslint/scope-manager@4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz#ed411545e61161a8d702e703a4b7d96ec065b09a"
+  integrity sha512-OcCO7LTdk6ukawUM40wo61WdeoA7NM/zaoq1/2cs13M7GyiF+T4rxuA4xM+6LeHWjWbss7hkGXjFDRcKD4O04Q==
+  dependencies:
+    "@typescript-eslint/types" "4.22.0"
+    "@typescript-eslint/visitor-keys" "4.22.0"
 
 "@typescript-eslint/types@4.21.0":
   version "4.21.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.21.0.tgz#abdc3463bda5d31156984fa5bc316789c960edef"
   integrity sha512-+OQaupjGVVc8iXbt6M1oZMwyKQNehAfLYJJ3SdvnofK2qcjfor9pEM62rVjBknhowTkh+2HF+/KdRAc/wGBN2w==
 
-"@typescript-eslint/typescript-estree@4.15.1":
-  version "4.15.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.1.tgz#fa9a9ff88b4a04d901ddbe5b248bc0a00cd610be"
-  integrity sha512-z8MN3CicTEumrWAEB2e2CcoZa3KP9+SMYLIA2aM49XW3cWIaiVSOAGq30ffR5XHxRirqE90fgLw3e6WmNx5uNw==
-  dependencies:
-    "@typescript-eslint/types" "4.15.1"
-    "@typescript-eslint/visitor-keys" "4.15.1"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-glob "^4.0.1"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
+"@typescript-eslint/types@4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.22.0.tgz#0ca6fde5b68daf6dba133f30959cc0688c8dd0b6"
+  integrity sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==
 
 "@typescript-eslint/typescript-estree@4.21.0":
   version "4.21.0"
@@ -1233,13 +1220,18 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@4.15.1":
-  version "4.15.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.1.tgz#c76abbf2a3be8a70ed760f0e5756bf62de5865dd"
-  integrity sha512-tYzaTP9plooRJY8eNlpAewTOqtWW/4ff/5wBjNVaJ0S0wC4Gpq/zDVRTJa5bq2v1pCNQ08xxMCndcvR+h7lMww==
+"@typescript-eslint/typescript-estree@4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.0.tgz#b5d95d6d366ff3b72f5168c75775a3e46250d05c"
+  integrity sha512-TkIFeu5JEeSs5ze/4NID+PIcVjgoU3cUQUIZnH3Sb1cEn1lBo7StSV5bwPuJQuoxKXlzAObjYTilOEKRuhR5yg==
   dependencies:
-    "@typescript-eslint/types" "4.15.1"
-    eslint-visitor-keys "^2.0.0"
+    "@typescript-eslint/types" "4.22.0"
+    "@typescript-eslint/visitor-keys" "4.22.0"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-glob "^4.0.1"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
 
 "@typescript-eslint/visitor-keys@4.21.0":
   version "4.21.0"
@@ -1247,6 +1239,14 @@
   integrity sha512-dH22dROWGi5Z6p+Igc8bLVLmwy7vEe8r+8c+raPQU0LxgogPUrRAtRGtvBWmlr9waTu3n+QLt/qrS/hWzk1x5w==
   dependencies:
     "@typescript-eslint/types" "4.21.0"
+    eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.0.tgz#169dae26d3c122935da7528c839f42a8a42f6e47"
+  integrity sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==
+  dependencies:
+    "@typescript-eslint/types" "4.22.0"
     eslint-visitor-keys "^2.0.0"
 
 "@webassemblyjs/ast@1.9.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -4353,10 +4353,10 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-inquirer@^7.3.3:
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
-  integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
+inquirer@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.0.0.tgz#957a46db1abcf0fdd2ab82deb7470e90afc7d0ac"
+  integrity sha512-ON8pEJPPCdyjxj+cxsYRe6XfCJepTxANdNnTebsTuQgXpRyZRRT9t4dJwjRubgmvn20CLSEnozRUayXyM9VTXA==
   dependencies:
     ansi-escapes "^4.2.1"
     chalk "^4.1.0"
@@ -4364,10 +4364,10 @@ inquirer@^7.3.3:
     cli-width "^3.0.0"
     external-editor "^3.0.3"
     figures "^3.0.0"
-    lodash "^4.17.19"
+    lodash "^4.17.21"
     mute-stream "0.0.8"
     run-async "^2.4.0"
-    rxjs "^6.6.0"
+    rxjs "^6.6.6"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
     through "^2.3.6"
@@ -5425,10 +5425,15 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@4.17.20, lodash@4.x, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
+lodash@4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@4.x, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -7088,10 +7093,10 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^6.4.0, rxjs@^6.6.0:
-  version "6.6.3"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
-  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
+rxjs@^6.4.0, rxjs@^6.6.6:
+  version "6.6.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.6.tgz#14d8417aa5a07c5e633995b525e1e3c0dec03b70"
+  integrity sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==
   dependencies:
     tslib "^1.9.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,23 +1171,15 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^4.21.0":
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.21.0.tgz#a227fc2af4001668c3e3f7415d4feee5093894c1"
-  integrity sha512-eyNf7QmE5O/l1smaQgN0Lj2M/1jOuNg2NrBm1dqqQN0sVngTLyw8tdCbih96ixlhbF1oINoN8fDCyEH9SjLeIA==
+"@typescript-eslint/parser@^4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.22.0.tgz#e1637327fcf796c641fe55f73530e90b16ac8fe8"
+  integrity sha512-z/bGdBJJZJN76nvAY9DkJANYgK3nlRstRRi74WHm3jjgf2I8AglrSY+6l7ogxOmn55YJ6oKZCLLy+6PW70z15Q==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.21.0"
-    "@typescript-eslint/types" "4.21.0"
-    "@typescript-eslint/typescript-estree" "4.21.0"
+    "@typescript-eslint/scope-manager" "4.22.0"
+    "@typescript-eslint/types" "4.22.0"
+    "@typescript-eslint/typescript-estree" "4.22.0"
     debug "^4.1.1"
-
-"@typescript-eslint/scope-manager@4.21.0":
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.21.0.tgz#c81b661c4b8af1ec0c010d847a8f9ab76ab95b4d"
-  integrity sha512-kfOjF0w1Ix7+a5T1knOw00f7uAP9Gx44+OEsNQi0PvvTPLYeXJlsCJ4tYnDj5PQEYfpcgOH5yBlw7K+UEI9Agw==
-  dependencies:
-    "@typescript-eslint/types" "4.21.0"
-    "@typescript-eslint/visitor-keys" "4.21.0"
 
 "@typescript-eslint/scope-manager@4.22.0":
   version "4.22.0"
@@ -1197,28 +1189,10 @@
     "@typescript-eslint/types" "4.22.0"
     "@typescript-eslint/visitor-keys" "4.22.0"
 
-"@typescript-eslint/types@4.21.0":
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.21.0.tgz#abdc3463bda5d31156984fa5bc316789c960edef"
-  integrity sha512-+OQaupjGVVc8iXbt6M1oZMwyKQNehAfLYJJ3SdvnofK2qcjfor9pEM62rVjBknhowTkh+2HF+/KdRAc/wGBN2w==
-
 "@typescript-eslint/types@4.22.0":
   version "4.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.22.0.tgz#0ca6fde5b68daf6dba133f30959cc0688c8dd0b6"
   integrity sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==
-
-"@typescript-eslint/typescript-estree@4.21.0":
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.21.0.tgz#3817bd91857beeaeff90f69f1f112ea58d350b0a"
-  integrity sha512-ZD3M7yLaVGVYLw4nkkoGKumb7Rog7QID9YOWobFDMQKNl+vPxqVIW/uDk+MDeGc+OHcoG2nJ2HphwiPNajKw3w==
-  dependencies:
-    "@typescript-eslint/types" "4.21.0"
-    "@typescript-eslint/visitor-keys" "4.21.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-glob "^4.0.1"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@4.22.0":
   version "4.22.0"
@@ -1232,14 +1206,6 @@
     is-glob "^4.0.1"
     semver "^7.3.2"
     tsutils "^3.17.1"
-
-"@typescript-eslint/visitor-keys@4.21.0":
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.21.0.tgz#990a9acdc124331f5863c2cf21c88ba65233cd8d"
-  integrity sha512-dH22dROWGi5Z6p+Igc8bLVLmwy7vEe8r+8c+raPQU0LxgogPUrRAtRGtvBWmlr9waTu3n+QLt/qrS/hWzk1x5w==
-  dependencies:
-    "@typescript-eslint/types" "4.21.0"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.22.0":
   version "4.22.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1024,10 +1024,10 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/react-dom@^17.0.1":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.1.tgz#d92d77d020bfb083e07cc8e0ac9f933599a4d56a"
-  integrity sha512-yIVyopxQb8IDZ7SOHeTovurFq+fXiPICa+GV3gp0Xedsl+MwQlMLKmvrnEjFbQxjliH5YVAEWFh975eVNmKj7Q==
+"@types/react-dom@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.3.tgz#7fdf37b8af9d6d40127137865bb3fff8871d7ee1"
+  integrity sha512-4NnJbCeWE+8YBzupn/YrJxZ8VnjcJq5iR1laqQ1vkpQgBiA7bwk0Rp24fxsdNinzJY2U+HHS4dJJDPdoMjdJ7w==
   dependencies:
     "@types/react" "*"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -651,10 +651,10 @@
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-"@redocly/openapi-core@^1.0.0-beta.42":
-  version "1.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@redocly/openapi-core/-/openapi-core-1.0.0-beta.43.tgz#9744b689b12eb623b3cfe0ead1f61d994741a6be"
-  integrity sha512-R9Jcwqn4NimI4ZNlWCY0cvo4WvzmhxtCTFzHB15G6WwdQXsAPC4q7ZR6ocHlKYDuilpCLrtMjMBEwAZji5JU9w==
+"@redocly/openapi-core@^1.0.0-beta.44":
+  version "1.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@redocly/openapi-core/-/openapi-core-1.0.0-beta.44.tgz#e9a6c50ee2bb18e93b3439ed92c53e440de3aa7a"
+  integrity sha512-9HNnh1MzvMsLK1liuidFBqWiAsZ2Yg3RY58fcEsy0QruSMdDbn7SoeI1qnXe6O+BkBS+vAP4oVzZDMHCMKGsOQ==
   dependencies:
     "@redocly/ajv" "^6.12.3"
     "@types/node" "^14.11.8"
@@ -6893,12 +6893,12 @@ redeyed@~2.1.0:
   dependencies:
     esprima "~4.0.0"
 
-redoc@^2.0.0-rc.51:
-  version "2.0.0-rc.51"
-  resolved "https://registry.yarnpkg.com/redoc/-/redoc-2.0.0-rc.51.tgz#39a1c6eed071a062860fac87b48a43119283ab60"
-  integrity sha512-oy8RVrGXioizboAJaOpxnblvqLxfDknmFyjKvwFCpKzoAnrmgm4zXem73Ni/4NLGQg3dn73KzMmRHIiRQbtuqg==
+redoc@^2.0.0-rc.53:
+  version "2.0.0-rc.53"
+  resolved "https://registry.yarnpkg.com/redoc/-/redoc-2.0.0-rc.53.tgz#2841b78638894e724eb997a434c4ef31ac853983"
+  integrity sha512-nyHIEIVo+kxsMfAy7nkYSlU7qjXZAARcj0INaRwCoy/DG9BMMi3xLcpo0CmarL9XeI891+VN2tpyTJ8jhZUtPw==
   dependencies:
-    "@redocly/openapi-core" "^1.0.0-beta.42"
+    "@redocly/openapi-core" "^1.0.0-beta.44"
     "@redocly/react-dropdown-aria" "^2.0.11"
     "@types/node" "^13.11.1"
     classnames "^2.2.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -901,10 +901,10 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/fs-extra@^9.0.7":
-  version "9.0.7"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.7.tgz#a9ef2ffdab043def080c5bec94c03402f793577f"
-  integrity sha512-YGq2A6Yc3bldrLUlm17VNWOnUbnEzJ9CMgOeLFtQF3HOCN5lQBO8VyjG00a5acA5NNSM30kHVGp1trZgnVgi1Q==
+"@types/fs-extra@^9.0.10":
+  version "9.0.10"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.10.tgz#8023a72e3d06cf54929ea47ec7634e47f33f4046"
+  integrity sha512-O9T2LLkRDiTlalOBdjEkcnT0MRdT2+wglCl7pJUJ3mkWkR8hX4K+5bg2raQNJcLv4V8zGuTXe7Ud3wSqkTyuyQ==
   dependencies:
     "@types/node" "*"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -962,10 +962,10 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/js-yaml@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.0.tgz#d1a11688112091f2c711674df3a65ea2f47b5dfb"
-  integrity sha512-4vlpCM5KPCL5CfGmTbpjwVKbISRYhduEJvvUWsH5EB7QInhEj94XPZ3ts/9FPiLZFqYO0xoW4ZL8z2AabTGgJA==
+"@types/js-yaml@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.1.tgz#5544730b65a480b18ace6b6ce914e519cec2d43b"
+  integrity sha512-xdOvNmXmrZqqPy3kuCQ+fz6wA0xU5pji9cd1nDrflWaAWtYLLGk5ykW0H6yg5TVyehHP1pfmuuSaZkhP+kspVA==
 
 "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
   version "7.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8036,10 +8036,10 @@ ts-jest@^26.5.1:
     semver "7.x"
     yargs-parser "20.x"
 
-ts-loader@^8.0.17:
-  version "8.0.17"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.0.17.tgz#98f2ccff9130074f4079fd89b946b4c637b1f2fc"
-  integrity sha512-OeVfSshx6ot/TCxRwpBHQ/4lRzfgyTkvi7ghDVrLXOHzTbSK413ROgu/xNqM72i3AFeAIJgQy78FwSMKmOW68w==
+ts-loader@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.1.0.tgz#d6292487df279c7cc79b6d3b70bb9d31682b693e"
+  integrity sha512-YiQipGGAFj2zBfqLhp28yUvPP9jUGqHxRzrGYuc82Z2wM27YIHbElXiaZDc93c3x0mz4zvBmS6q/DgExpdj37A==
   dependencies:
     chalk "^4.1.0"
     enhanced-resolve "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5144,10 +5144,10 @@ js-yaml@^3.13.1, js-yaml@^3.14.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
-  integrity sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3184,10 +3184,10 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@^7.24.0:
-  version "7.24.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.24.0.tgz#2e44fa62d93892bfdb100521f17345ba54b8513a"
-  integrity sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==
+eslint@^7.25.0:
+  version "7.25.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.25.0.tgz#1309e4404d94e676e3e831b3a3ad2b050031eb67"
+  integrity sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==
   dependencies:
     "@babel/code-frame" "7.12.11"
     "@eslint/eslintrc" "^0.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -323,10 +323,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
-"@eslint/eslintrc@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.3.0.tgz#d736d6963d7003b6514e6324bec9c602ac340318"
-  integrity sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==
+"@eslint/eslintrc@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
+  integrity sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==
   dependencies:
     ajv "^6.12.4"
     debug "^4.1.1"
@@ -335,7 +335,6 @@
     ignore "^4.0.6"
     import-fresh "^3.2.1"
     js-yaml "^3.13.1"
-    lodash "^4.17.20"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
@@ -3219,13 +3218,13 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@^7.20.0:
-  version "7.20.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.20.0.tgz#db07c4ca4eda2e2316e7aa57ac7fc91ec550bdc7"
-  integrity sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==
+eslint@^7.24.0:
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.24.0.tgz#2e44fa62d93892bfdb100521f17345ba54b8513a"
+  integrity sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==
   dependencies:
     "@babel/code-frame" "7.12.11"
-    "@eslint/eslintrc" "^0.3.0"
+    "@eslint/eslintrc" "^0.4.0"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -3238,10 +3237,10 @@ eslint@^7.20.0:
     espree "^7.3.1"
     esquery "^1.4.0"
     esutils "^2.0.2"
-    file-entry-cache "^6.0.0"
+    file-entry-cache "^6.0.1"
     functional-red-black-tree "^1.0.1"
     glob-parent "^5.0.0"
-    globals "^12.1.0"
+    globals "^13.6.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
@@ -3249,7 +3248,7 @@ eslint@^7.20.0:
     js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
-    lodash "^4.17.20"
+    lodash "^4.17.21"
     minimatch "^3.0.4"
     natural-compare "^1.4.0"
     optionator "^0.9.1"
@@ -3598,10 +3597,10 @@ figures@^3.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-file-entry-cache@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.0.tgz#7921a89c391c6d93efec2169ac6bf300c527ea0a"
-  integrity sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==
+file-entry-cache@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
 
@@ -3975,6 +3974,13 @@ globals@^12.1.0:
   integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
   dependencies:
     type-fest "^0.8.1"
+
+globals@^13.6.0:
+  version "13.8.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.8.0.tgz#3e20f504810ce87a8d72e55aecf8435b50f4c1b3"
+  integrity sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==
+  dependencies:
+    type-fest "^0.20.2"
 
 globby@^10.0.1:
   version "10.0.2"
@@ -8154,6 +8160,11 @@ type-fest@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
+
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 type-fest@^0.6.0:
   version "0.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5712,10 +5712,10 @@ mobx-react@^7.0.5:
   dependencies:
     mobx-react-lite "^3.2.0"
 
-mobx@^6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.0.4.tgz#8fc3e3629a3346f8afddf5bd954411974744dad1"
-  integrity sha512-wT2QJT9tW19VSHo9x7RPKU3z/I2Ps6wUS8Kb1OO+kzmg7UY3n4AkcaYG6jq95Lp1R9ohjC/NGYuT2PtuvBjhFg==
+mobx@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.3.0.tgz#a8fb693c3047bdfcb1eaff9aa48e36a7eb084f96"
+  integrity sha512-Aa1+VXsg4WxqJMTQfWoYuJi5UD10VZhiobSmcs5kcmI3BIT0aVtn7DysvCeDADCzl7dnbX+0BTHUj/v7gLlZpQ==
 
 move-concurrently@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3136,10 +3136,10 @@ escodegen@1.x.x, escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-plugin-jest@^24.1.5:
-  version "24.1.5"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-24.1.5.tgz#1e866a9f0deac587d0a3d5d7cefe99815a580de2"
-  integrity sha512-FIP3lwC8EzEG+rOs1y96cOJmMVpdFNreoDJv29B5vIupVssRi8zrSY3QadogT0K3h1Y8TMxJ6ZSAzYUmFCp2hg==
+eslint-plugin-jest@^24.3.5:
+  version "24.3.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-24.3.5.tgz#71f0b580f87915695c286c3f0eb88cf23664d044"
+  integrity sha512-XG4rtxYDuJykuqhsOqokYIR84/C8pRihRtEpVskYLbIIKGwPNW2ySxdctuVzETZE+MbF/e7wmsnbNVpzM0rDug==
   dependencies:
     "@typescript-eslint/experimental-utils" "^4.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5628,10 +5628,10 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-mini-css-extract-plugin@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-1.4.1.tgz#975e27c1d0bd8e052972415f47c79cea5ed37548"
-  integrity sha512-COAGbpAsU0ioFzj+/RRfO5Qv177L1Z/XAx2EmCF33b8GDDqKygMffBTws2lit8iaPdrbKEY5P+zsseBUCREZWQ==
+mini-css-extract-plugin@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-1.5.0.tgz#69bee3b273d2d4ee8649a2eb409514b7df744a27"
+  integrity sha512-SIbuLMv6jsk1FnLIU5OUG/+VMGUprEjM1+o2trOAx8i5KOKMrhyezb1dJ4Ugsykb8Jgq8/w5NEopy6escV9G7g==
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8622,9 +8622,9 @@ xtend@^4.0.0, xtend@~4.0.1:
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
+  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
 
 y18n@^5.0.5:
   version "5.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1071,10 +1071,10 @@
     "@types/cookiejar" "*"
     "@types/node" "*"
 
-"@types/supertest@^2.0.10":
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/@types/supertest/-/supertest-2.0.10.tgz#630d79b4d82c73e043e43ff777a9ca98d457cab7"
-  integrity sha512-Xt8TbEyZTnD5Xulw95GLMOkmjGICrOQyJ2jqgkSjAUR3mm7pAIzSR0NFBaMcwlzVvlpCjNwbATcWWwjNiZiFrQ==
+"@types/supertest@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@types/supertest/-/supertest-2.0.11.tgz#2e70f69f220bc77b4f660d72c2e1a4231f44a77d"
+  integrity sha512-uci4Esokrw9qGb9bvhhSVEjd6rkny/dk5PK/Qz4yxKiyppEI+dOPlNrZBahE3i+PoKFYyDxChVXZ/ysS/nrm1Q==
   dependencies:
     "@types/superagent" "*"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,10 +955,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@26.x", "@types/jest@^26.0.20":
-  version "26.0.20"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.20.tgz#cd2f2702ecf69e86b586e1f5223a60e454056307"
-  integrity sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==
+"@types/jest@26.x", "@types/jest@^26.0.22":
+  version "26.0.22"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.22.tgz#8308a1debdf1b807aa47be2838acdcd91e88fbe6"
+  integrity sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8161,10 +8161,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
-  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
+typescript@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 typescript@~4.0.2:
   version "4.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2546,10 +2546,10 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js@^3.2.1, core-js@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.9.0.tgz#790b1bb11553a2272b36e2625c7179db345492f8"
-  integrity sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ==
+core-js@^3.11.0, core-js@^3.2.1:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.11.0.tgz#05dac6aa70c0a4ad842261f8957b961d36eb8926"
+  integrity sha512-bd79DPpx+1Ilh9+30aT5O1sgpQd4Ttg8oqkqi51ZzhedMM1omD2e6IOF48Z/DzDCZ2svp49tN/3vneTK6ZBkXw==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1036,10 +1036,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.3":
-  version "17.0.3"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
-  integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
+"@types/react@*", "@types/react@^17.0.4":
+  version "17.0.4"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.4.tgz#a67c6f7a460d2660e950d9ccc1c2f18525c28220"
+  integrity sha512-onz2BqScSFMoTRdJUZUDD/7xrusM8hBA2Fktk2qgaTYPCgPvWnDEgkrOs8hhPUf2jfcIXkJ5yK6VfYormJS3Jw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -642,6 +642,31 @@
   resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-1.0.4.tgz#b740f68609dfae8aa71c3a6cab15d816407ba493"
   integrity sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==
 
+"@redocly/ajv@^6.12.3":
+  version "6.12.4"
+  resolved "https://registry.yarnpkg.com/@redocly/ajv/-/ajv-6.12.4.tgz#b131c9c11d1bdaa5564f69bcaefe10a4c9a5aa65"
+  integrity sha512-RB6vWO78v6c+SW/3bZh+XZMr4nGdJKAiPGsBALuUZnLuCiQ7aXCT1AuFHqnfS2gyXbEUEj+kw8p4ux8KdAfs3A==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+"@redocly/openapi-core@^1.0.0-beta.42":
+  version "1.0.0-beta.43"
+  resolved "https://registry.yarnpkg.com/@redocly/openapi-core/-/openapi-core-1.0.0-beta.43.tgz#9744b689b12eb623b3cfe0ead1f61d994741a6be"
+  integrity sha512-R9Jcwqn4NimI4ZNlWCY0cvo4WvzmhxtCTFzHB15G6WwdQXsAPC4q7ZR6ocHlKYDuilpCLrtMjMBEwAZji5JU9w==
+  dependencies:
+    "@redocly/ajv" "^6.12.3"
+    "@types/node" "^14.11.8"
+    colorette "^1.2.0"
+    js-levenshtein "^1.1.6"
+    js-yaml "^3.14.0"
+    lodash.isequal "^4.5.0"
+    minimatch "^3.0.4"
+    node-fetch "^2.6.1"
+    yaml-ast-parser "0.0.43"
+
 "@redocly/react-dropdown-aria@^2.0.11":
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/@redocly/react-dropdown-aria/-/react-dropdown-aria-2.0.11.tgz#532b864b329237e646abe45d0f8edc923e77370a"
@@ -959,10 +984,10 @@
   dependencies:
     axios "^0.21.1"
 
-"@types/node@*":
-  version "14.14.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.9.tgz#04afc9a25c6ff93da14deabd65dc44485b53c8d6"
-  integrity sha512-JsoLXFppG62tWTklIoO4knA+oDTYsmqWxHRvd4lpmfQRNhX6osheUOWETP2jMoV/2bEHuMra8Pp3Dmo/stBFcw==
+"@types/node@*", "@types/node@^14.11.8":
+  version "14.14.37"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
+  integrity sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==
 
 "@types/node@^13.11.1":
   version "13.13.32"
@@ -2394,6 +2419,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+colorette@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
+  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
+
 colorette@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
@@ -3691,11 +3721,6 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
-
-format-util@^1.0.3:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.5.tgz#1ffb450c8a03e7bccffe40643180918cc297d271"
-  integrity sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==
 
 formidable@^1.2.2:
   version "1.2.2"
@@ -5072,12 +5097,17 @@ jest@^26.6.3:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.12.1, js-yaml@^3.13.1:
+js-yaml@^3.13.1, js-yaml@^3.14.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -5155,15 +5185,6 @@ json-pointer@^0.6.0:
   integrity sha512-3OvjqKdCBvH41DLpV4iSt6v2XhZXV1bPB4OROuknvUXI7ZQNofieCPkmE26stEJ9zdQuvIxDHCuYhfgxFAAs+Q==
   dependencies:
     foreach "^2.0.4"
-
-json-schema-ref-parser@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz#30af34aeab5bee0431da805dac0eb21b574bf63d"
-  integrity sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==
-  dependencies:
-    call-me-maybe "^1.0.1"
-    js-yaml "^3.12.1"
-    ono "^4.0.11"
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
@@ -5365,6 +5386,11 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -5824,7 +5850,7 @@ node-fetch-h2@^2.3.0:
   dependencies:
     http2-client "^1.2.5"
 
-node-fetch@2.6.1, node-fetch@^2.6.0:
+node-fetch@2.6.1, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -6079,13 +6105,6 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
-
-ono@^4.0.11:
-  version "4.0.11"
-  resolved "https://registry.yarnpkg.com/ono/-/ono-4.0.11.tgz#c7f4209b3e396e8a44ef43b9cedc7f5d791d221d"
-  integrity sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==
-  dependencies:
-    format-util "^1.0.3"
 
 openapi-sampler@^1.0.0-beta.18:
   version "1.0.0-beta.18"
@@ -6834,11 +6853,12 @@ redeyed@~2.1.0:
   dependencies:
     esprima "~4.0.0"
 
-redoc@^2.0.0-rc.48:
-  version "2.0.0-rc.48"
-  resolved "https://registry.yarnpkg.com/redoc/-/redoc-2.0.0-rc.48.tgz#5303cff67af5cba8a2b48dc1347a9854d45be835"
-  integrity sha512-shArJWhNG2gQ0XKxW8WcfG8peNOtxbZ86CqxgrR9P7MnE5ESAo559CH/PSlezePeVLpcC0C9tcimOfSN5MaAvA==
+redoc@^2.0.0-rc.51:
+  version "2.0.0-rc.51"
+  resolved "https://registry.yarnpkg.com/redoc/-/redoc-2.0.0-rc.51.tgz#39a1c6eed071a062860fac87b48a43119283ab60"
+  integrity sha512-oy8RVrGXioizboAJaOpxnblvqLxfDknmFyjKvwFCpKzoAnrmgm4zXem73Ni/4NLGQg3dn73KzMmRHIiRQbtuqg==
   dependencies:
+    "@redocly/openapi-core" "^1.0.0-beta.42"
     "@redocly/react-dropdown-aria" "^2.0.11"
     "@types/node" "^13.11.1"
     classnames "^2.2.6"
@@ -6846,7 +6866,6 @@ redoc@^2.0.0-rc.48:
     dompurify "^2.0.12"
     eventemitter3 "^4.0.4"
     json-pointer "^0.6.0"
-    json-schema-ref-parser "^6.1.0"
     lunr "2.3.8"
     mark.js "^8.11.1"
     marked "^0.7.0"
@@ -8618,6 +8637,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml-ast-parser@0.0.43:
+  version "0.0.43"
+  resolved "https://registry.yarnpkg.com/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz#e8a23e6fb4c38076ab92995c5dca33f3d3d7c9bb"
+  integrity sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==
 
 yaml@^1.10.0, yaml@^1.8.3:
   version "1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5841,10 +5841,10 @@ no-case@^3.0.3:
     lower-case "^2.0.1"
     tslib "^1.10.0"
 
-nock@^13.0.7:
-  version "13.0.7"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-13.0.7.tgz#9bc718c66bd0862dfa14601a9ba678a406127910"
-  integrity sha512-WBz73VYIjdbO6BwmXODRQLtn7B5tldA9pNpWJe5QTtTEscQlY5KXU4srnGzBOK2fWakkXj69gfTnXGzmrsaRWw==
+nock@^13.0.11:
+  version "13.0.11"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.0.11.tgz#ba733252e720897ca50033205c39db0c7470f331"
+  integrity sha512-sKZltNkkWblkqqPAsjYW0bm3s9DcHRPiMOyKO/PkfJ+ANHZ2+LA2PLe22r4lLrKgXaiSaDQwW3qGsJFtIpQIeQ==
   dependencies:
     debug "^4.1.0"
     json-stringify-safe "^5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5636,10 +5636,10 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-mini-css-extract-plugin@^1.3.8:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-1.3.8.tgz#639047b78c2ee728704285aa468d2a5a8d91d566"
-  integrity sha512-u+2kVov/Gcs74iz+x3phEBWMAGw2djjnKfYez+Pl/b5dyXL7aM4Lp5QQtIq16CDwRHT/woUJki49gBNMhfm1eA==
+mini-css-extract-plugin@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-1.4.1.tgz#975e27c1d0bd8e052972415f47c79cea5ed37548"
+  integrity sha512-COAGbpAsU0ioFzj+/RRfO5Qv177L1Z/XAx2EmCF33b8GDDqKygMffBTws2lit8iaPdrbKEY5P+zsseBUCREZWQ==
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"


### PR DESCRIPTION
## Description, Motivation and Context

When using `@oaSchemaProp example`, providing a numerical string like "123.3" for a String type fails.
When using `@oaSchemaProp example` for `Date`, `DateTime`, Object, Array, Union or Intersection type it fails.

Fix in this PR :
in `function extractJSDocSchemaProps(`
`const typeOf` is refactored and will use the `JSON.parse` real type instead of regexp filtering.

## Checklist:

- [X] I've added/updated tests to cover my changes
- [X] I've created an issue associated with this PR
