### PR TITLE
airtasker#1417 @oaSchemaProp example fails with numerical strings, Date, DateTime, Object, Array, Union or Intersection

### DIFF
--- a/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
@@ -934,6 +934,9 @@ exports[`OpenAPI 2 generator schemaprops contract with schemaprops parses correc
                     ],
                     \\"minProperties\\": 1,
                     \\"maxProperties\\": 100,
+                    \\"example\\": {
+                      \\"price\\": 3.14
+                    },
                     \\"description\\": \\"property-schemaprop description for object\\"
                   },
                   \\"currencies\\": {
@@ -955,6 +958,7 @@ exports[`OpenAPI 2 generator schemaprops contract with schemaprops parses correc
                       \\"APPROVED\\"
                     ],
                     \\"title\\": \\"process-code\\",
+                    \\"example\\": \\"WAITING\\",
                     \\"description\\": \\"property-schemaprop description for union\\"
                   },
                   \\"inheritance\\": {
@@ -992,6 +996,10 @@ exports[`OpenAPI 2 generator schemaprops contract with schemaprops parses correc
                       }
                     ],
                     \\"title\\": \\"process-code\\",
+                    \\"example\\": {
+                      \\"inheritId\\": 3.14,
+                      \\"inheritName\\": 42
+                    },
                     \\"description\\": \\"property-schemaprop description for intersection\\"
                   }
                 },

--- a/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
+++ b/lib/src/generators/openapi2/__snapshots__/openapi2.spec.ts.snap
@@ -884,6 +884,15 @@ exports[`OpenAPI 2 generator schemaprops contract with schemaprops parses correc
             \\"pattern\\": \\"^[0-9a-z_]+$\\"
           },
           {
+            \\"name\\": \\"start-time\\",
+            \\"in\\": \\"header\\",
+            \\"description\\": \\"property-schemaprop description for date-time\\",
+            \\"required\\": false,
+            \\"type\\": \\"string\\",
+            \\"format\\": \\"date-time\\",
+            \\"default\\": \\"1990-12-31T15:59:60-08:00\\"
+          },
+          {
             \\"name\\": \\"size\\",
             \\"in\\": \\"header\\",
             \\"description\\": \\"property-schemaprop description for integer\\",

--- a/lib/src/generators/openapi2/__spec-examples__/contract-with-schemaprops.ts
+++ b/lib/src/generators/openapi2/__spec-examples__/contract-with-schemaprops.ts
@@ -59,6 +59,8 @@ class EndpointWithSchemaPropsOnHeaders {
        * 1
        * @oaSchemaProp maxProperties
        * 100
+       * @oaSchemaProp example
+       * {"price":3.14}
        *  */
       element: {
         /** property-schemaprop description for float inner object
@@ -83,11 +85,15 @@ class EndpointWithSchemaPropsOnHeaders {
       /** property-schemaprop description for union
        * @oaSchemaProp title
        * "process-code"
+       * @oaSchemaProp example
+       * "WAITING"
        *  */
       code?: "VALID" | "NOT_VALID" | "WAITING" | "APPROVED";
       /** property-schemaprop description for intersection
        * @oaSchemaProp title
        * "process-code"
+       * @oaSchemaProp example
+       * {"inheritId":3.14, "inheritName":42}
        *  */
       inheritance?: {
         /** property-schemaprop description for double inner intersection

--- a/lib/src/generators/openapi2/__spec-examples__/contract-with-schemaprops.ts
+++ b/lib/src/generators/openapi2/__spec-examples__/contract-with-schemaprops.ts
@@ -6,6 +6,7 @@ import {
   request,
   response,
   String,
+  DateTime,
   Integer,
   Float,
   Int64,
@@ -33,6 +34,11 @@ class EndpointWithSchemaPropsOnHeaders {
        * "^[0-9a-z_]+$"
        *  */
       status: String;
+      /** property-schemaprop description for date-time
+       * @default
+       * "1990-12-31T15:59:60-08:00"
+       *  */
+      "start-time"?: DateTime;
       /** property-schemaprop description for integer
        * @oaSchemaProp minimum
        * 1

--- a/lib/src/generators/openapi2/openapi2.spec.ts
+++ b/lib/src/generators/openapi2/openapi2.spec.ts
@@ -303,6 +303,15 @@ describe("OpenAPI 2 generator", () => {
           pattern: "^[0-9a-z_]+$"
         },
         {
+          description: "property-schemaprop description for date-time",
+          name: "start-time",
+          in: "header",
+          required: false,
+          type: "string",
+          format: "date-time",
+          default: "1990-12-31T15:59:60-08:00"
+        },
+        {
           description: "property-schemaprop description for integer",
           name: "size",
           in: "header",

--- a/lib/src/generators/openapi2/openapi2.spec.ts
+++ b/lib/src/generators/openapi2/openapi2.spec.ts
@@ -332,6 +332,7 @@ describe("OpenAPI 2 generator", () => {
                   description: "property-schemaprop description for object",
                   maxProperties: 100,
                   minProperties: 1,
+                  example: { price: 3.14 },
                   properties: {
                     price: {
                       description:
@@ -366,6 +367,7 @@ describe("OpenAPI 2 generator", () => {
                   description: "property-schemaprop description for union",
                   enum: ["VALID", "NOT_VALID", "WAITING", "APPROVED"],
                   title: "process-code",
+                  example: "WAITING",
                   type: "string"
                 },
                 inheritance: {
@@ -400,6 +402,10 @@ describe("OpenAPI 2 generator", () => {
                       type: "object"
                     }
                   ],
+                  example: {
+                    inheritId: 3.14,
+                    inheritName: 42
+                  },
                   description:
                     "property-schemaprop description for intersection",
                   title: "process-code"

--- a/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
@@ -1086,6 +1086,18 @@ exports[`OpenAPI 3 generator schemaprops contract with schemaprops parses correc
             }
           },
           {
+            \\"name\\": \\"start-time\\",
+            \\"in\\": \\"header\\",
+            \\"description\\": \\"property-schemaprop description for date-time\\",
+            \\"required\\": false,
+            \\"schema\\": {
+              \\"type\\": \\"string\\",
+              \\"format\\": \\"date-time\\",
+              \\"title\\": \\"date-time-title\\",
+              \\"default\\": \\"1990-12-31T15:59:60-08:00\\"
+            }
+          },
+          {
             \\"name\\": \\"size\\",
             \\"in\\": \\"header\\",
             \\"description\\": \\"property-schemaprop description for integer\\",

--- a/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
@@ -1169,6 +1169,7 @@ exports[`OpenAPI 3 generator schemaprops contract with schemaprops parses correc
                         ],
                         \\"title\\": \\"process-code\\",
                         \\"deprecated\\": false,
+                        \\"example\\": \\"WAITING\\",
                         \\"description\\": \\"property-schemaprop description for union\\"
                       },
                       \\"inheritance\\": {
@@ -1210,6 +1211,10 @@ exports[`OpenAPI 3 generator schemaprops contract with schemaprops parses correc
                         ],
                         \\"title\\": \\"process-code\\",
                         \\"deprecated\\": true,
+                        \\"example\\": {
+                          \\"inheritId\\": 3.14,
+                          \\"inheritName\\": 42
+                        },
                         \\"description\\": \\"property-schemaprop description for intersection\\"
                       }
                     },

--- a/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
@@ -1147,6 +1147,9 @@ exports[`OpenAPI 3 generator schemaprops contract with schemaprops parses correc
                         \\"minProperties\\": 1,
                         \\"maxProperties\\": 100,
                         \\"additionalProperties\\": true,
+                        \\"example\\": {
+                          \\"price\\": 3.14
+                        },
                         \\"description\\": \\"property-schemaprop description for object\\"
                       },
                       \\"currencies\\": {

--- a/lib/src/generators/openapi3/__spec-examples__/contract-with-schemaprops.ts
+++ b/lib/src/generators/openapi3/__spec-examples__/contract-with-schemaprops.ts
@@ -69,6 +69,8 @@ class EndpointWithSchemaPropsOnHeaders {
        * 100
        * @oaSchemaProp additionalProperties
        * true
+       * @oaSchemaProp example
+       * {"price":3.14}
        *  */
       element: {
         /** property-schemaprop description for float inner object

--- a/lib/src/generators/openapi3/__spec-examples__/contract-with-schemaprops.ts
+++ b/lib/src/generators/openapi3/__spec-examples__/contract-with-schemaprops.ts
@@ -97,6 +97,8 @@ class EndpointWithSchemaPropsOnHeaders {
        * "process-code"
        * @oaSchemaProp deprecated
        * false
+       * @oaSchemaProp example
+       * "WAITING"
        *  */
       code?: "VALID" | "NOT_VALID" | "WAITING" | "APPROVED";
       /** property-schemaprop description for intersection
@@ -104,6 +106,8 @@ class EndpointWithSchemaPropsOnHeaders {
        * "process-code"
        * @oaSchemaProp deprecated
        * true
+       * @oaSchemaProp example
+       * {"inheritId":3.14, "inheritName":42}
        *  */
       inheritance?: {
         /** property-schemaprop description for double inner intersection

--- a/lib/src/generators/openapi3/__spec-examples__/contract-with-schemaprops.ts
+++ b/lib/src/generators/openapi3/__spec-examples__/contract-with-schemaprops.ts
@@ -6,6 +6,7 @@ import {
   request,
   response,
   String,
+  DateTime,
   Integer,
   Float,
   Int64,
@@ -35,6 +36,13 @@ class EndpointWithSchemaPropsOnHeaders {
        * "^[0-9a-z_]+$"
        *  */
       status: String;
+      /** property-schemaprop description for date-time
+       * @oaSchemaProp title
+       * "date-time-title"
+       * @default
+       * "1990-12-31T15:59:60-08:00"
+       *  */
+      "start-time"?: DateTime;
       /** property-schemaprop description for integer
        * @oaSchemaProp minimum
        * 1

--- a/lib/src/generators/openapi3/openapi3.spec.ts
+++ b/lib/src/generators/openapi3/openapi3.spec.ts
@@ -462,6 +462,7 @@ describe("OpenAPI 3 generator", () => {
                       description: "property-schemaprop description for union",
                       enum: ["VALID", "NOT_VALID", "WAITING", "APPROVED"],
                       title: "process-code",
+                      example: "WAITING",
                       deprecated: false,
                       type: "string"
                     },
@@ -501,6 +502,10 @@ describe("OpenAPI 3 generator", () => {
                         }
                       ],
                       deprecated: true,
+                      example: {
+                        inheritId: 3.14,
+                        inheritName: 42
+                      },
                       description:
                         "property-schemaprop description for intersection",
                       title: "process-code"

--- a/lib/src/generators/openapi3/openapi3.spec.ts
+++ b/lib/src/generators/openapi3/openapi3.spec.ts
@@ -388,6 +388,18 @@ describe("OpenAPI 3 generator", () => {
           }
         },
         {
+          description: "property-schemaprop description for date-time",
+          in: "header",
+          name: "start-time",
+          required: false,
+          schema: {
+            title: "date-time-title",
+            type: "string",
+            format: "date-time",
+            default: "1990-12-31T15:59:60-08:00"
+          }
+        },
+        {
           description: "property-schemaprop description for integer",
           name: "size",
           in: "header",

--- a/lib/src/generators/openapi3/openapi3.spec.ts
+++ b/lib/src/generators/openapi3/openapi3.spec.ts
@@ -427,6 +427,7 @@ describe("OpenAPI 3 generator", () => {
                       maxProperties: 100,
                       minProperties: 1,
                       additionalProperties: true,
+                      example: { price: 3.14 },
                       properties: {
                         price: {
                           description:

--- a/lib/src/parsers/__spec-examples__/schemaprops.ts
+++ b/lib/src/parsers/__spec-examples__/schemaprops.ts
@@ -1,4 +1,4 @@
-import { Date, Integer } from "../../syntax";
+import { Date, Integer, String } from "../../syntax";
 
 type SchemaPropTests = {
   /** property-schemaprop description
@@ -6,6 +6,11 @@ type SchemaPropTests = {
    * "property-schemaprop-value"
    *  */
   "property-with-schemaprop": string;
+   /**
+   * @oaSchemaProp example
+   * "123.3"
+   */
+  "property-with-string": String;
   /** property-two-schemaprops description
    * @oaSchemaProp minimum
    * 123

--- a/lib/src/parsers/__spec-examples__/schemaprops.ts
+++ b/lib/src/parsers/__spec-examples__/schemaprops.ts
@@ -22,6 +22,11 @@ type SchemaPropTests = {
    * "1990-12-31"
    *  */
   "property-with-date": Date;
+  /** property-schemaprop array of integer
+   * @oaSchemaProp example
+   * [1990,12,31]
+   *  */
+  "property-with-array": Integer[];
   /**
    * @oaSchemaProp example
    * This_is_not_an_integer

--- a/lib/src/parsers/__spec-examples__/schemaprops.ts
+++ b/lib/src/parsers/__spec-examples__/schemaprops.ts
@@ -1,4 +1,4 @@
-import { Integer } from "../../syntax";
+import { Date, Integer } from "../../syntax";
 
 type SchemaPropTests = {
   /** property-schemaprop description
@@ -17,6 +17,11 @@ type SchemaPropTests = {
    * false
    *  */
   "property-with-boolean": boolean;
+  /** property-schemaprop date
+   * @oaSchemaProp example
+   * "1990-12-31"
+   *  */
+  "property-with-date": Date;
   /**
    * @oaSchemaProp example
    * This_is_not_an_integer

--- a/lib/src/parsers/__spec-examples__/schemaprops.ts
+++ b/lib/src/parsers/__spec-examples__/schemaprops.ts
@@ -6,7 +6,7 @@ type SchemaPropTests = {
    * "property-schemaprop-value"
    *  */
   "property-with-schemaprop": string;
-   /**
+  /**
    * @oaSchemaProp example
    * "123.3"
    */

--- a/lib/src/parsers/schemaprop-parser.spec.ts
+++ b/lib/src/parsers/schemaprop-parser.spec.ts
@@ -49,6 +49,24 @@ describe("schemaprop-parser", () => {
       ]);
     });
 
+    test("successfully parses string example schemaprops on properties on type ParsedSchemaProps", () => {
+      const stringSchemaPropNode = getJsDocsFromPropertySignatures(
+        properties,
+        '"property-with-string"'
+      );
+      const retrieveStringSchemaProp = extractJSDocSchemaProps(
+        stringSchemaPropNode,
+        {
+          kind: TypeKind.STRING
+        }
+      );
+      expect(retrieveStringSchemaProp).toBeDefined();
+      expect(retrieveStringSchemaProp!.isOk).toBeTruthy();
+      expect(retrieveStringSchemaProp!.unwrapOrThrow()).toStrictEqual([
+        { name: "example", value: "123.3" }
+      ]);
+    });
+
     test("successfully parses integer schemaprops on properties on type ParsedSchemaProps", () => {
       const integerSchemaPropNode = getJsDocsFromPropertySignatures(
         properties,

--- a/lib/src/parsers/schemaprop-parser.spec.ts
+++ b/lib/src/parsers/schemaprop-parser.spec.ts
@@ -86,6 +86,25 @@ describe("schemaprop-parser", () => {
       ]);
     });
 
+    test("successfully parses array schemaprops on properties on type ParsedSchemaProps", () => {
+      const booleanSchemaPropNode = getJsDocsFromPropertySignatures(
+        properties,
+        '"property-with-array"'
+      );
+      const retrieveBooleanSchemaProp = extractJSDocSchemaProps(
+        booleanSchemaPropNode,
+        {
+          kind: TypeKind.ARRAY,
+          elementType: { kind: TypeKind.INT32 }
+        }
+      );
+      expect(retrieveBooleanSchemaProp).toBeDefined();
+      expect(retrieveBooleanSchemaProp!.isOk).toBeTruthy();
+      expect(retrieveBooleanSchemaProp!.unwrapOrThrow()).toStrictEqual([
+        { name: "example", value: [1990, 12, 31] }
+      ]);
+    });
+
     test("successfully parses date schemaprops on properties on type ParsedSchemaProps", () => {
       const booleanSchemaPropNode = getJsDocsFromPropertySignatures(
         properties,

--- a/lib/src/parsers/schemaprop-parser.spec.ts
+++ b/lib/src/parsers/schemaprop-parser.spec.ts
@@ -86,6 +86,24 @@ describe("schemaprop-parser", () => {
       ]);
     });
 
+    test("successfully parses date schemaprops on properties on type ParsedSchemaProps", () => {
+      const booleanSchemaPropNode = getJsDocsFromPropertySignatures(
+        properties,
+        '"property-with-date"'
+      );
+      const retrieveBooleanSchemaProp = extractJSDocSchemaProps(
+        booleanSchemaPropNode,
+        {
+          kind: TypeKind.DATE
+        }
+      );
+      expect(retrieveBooleanSchemaProp).toBeDefined();
+      expect(retrieveBooleanSchemaProp!.isOk).toBeTruthy();
+      expect(retrieveBooleanSchemaProp!.unwrapOrThrow()).toStrictEqual([
+        { name: "example", value: "1990-12-31" }
+      ]);
+    });
+
     test("errors schemaprops on properties on type MismatchedSchemaPropAndIntegerType", () => {
       const integerSchemaPropNode = getJsDocsFromPropertySignatures(
         properties,

--- a/lib/src/parsers/schemaprop-parser.ts
+++ b/lib/src/parsers/schemaprop-parser.ts
@@ -52,6 +52,19 @@ export function extractJSDocSchemaProps(
     const typeSpecified: TypeKind | "number" =
       spotTypesToJSTypesMap.get(type.kind) || type.kind;
 
+    let subTypeSpecified = typeSpecified;
+    if (type.kind === TypeKind.UNION || type.kind === TypeKind.INTERSECTION) {
+      const referenceType: TypeKind = type.types[0].kind;
+      if (
+        type.types.every(subType => {
+          return subType.kind === referenceType;
+        })
+      ) {
+        subTypeSpecified =
+          spotTypesToJSTypesMap.get(referenceType) || referenceType;
+      }
+    }
+
     rawSchemaProps.every(schemaProp => {
       const schemaPropName = schemaProp?.split("\n")[0]?.trim();
       const schemaPropValue = schemaProp?.split("\n")[1]?.trim();
@@ -148,7 +161,7 @@ export function extractJSDocSchemaProps(
       schemaProps.some(
         schemaProp =>
           (propTypeMap.get(schemaProp.name)?.type === "any" &&
-            typeOf(schemaProp.value) !== typeSpecified) ||
+            typeOf(schemaProp.value) !== subTypeSpecified) ||
           (propTypeMap.get(schemaProp.name)?.type !== "any" &&
             propTypeMap.get(schemaProp.name)?.type !== typeOf(schemaProp.value))
       )


### PR DESCRIPTION
## Description, Motivation and Context

Please see #1417
When using `@oaSchemaProp example`, providing a numerical string like "123.3" for a String type fails.
When using `@oaSchemaProp example` for `Date`, `DateTime`, Object, Array, Union or Intersection type it fails.

Fix in this PR :
in `function extractJSDocSchemaProps(`
`const typeOf` is refactored and will use the `JSON.parse` real type instead of regexp filtering.

## Checklist:

- [X] I've added/updated tests to cover my changes
- [X] I've created an issue associated with this PR
