### PR TITLE
#1461 HEAD support first try

### DIFF
--- a/lib/src/definitions.ts
+++ b/lib/src/definitions.ts
@@ -108,7 +108,7 @@ export interface Oa3ServerVariable {
 export type QueryParamArrayStrategy = "ampersand" | "comma";
 
 /** Supported HTTP methods */
-export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD";
 
 /** Type guards */
 export function isSpecificResponse(

--- a/lib/src/generators/openapi2/openapi2.ts
+++ b/lib/src/generators/openapi2/openapi2.ts
@@ -252,6 +252,8 @@ function httpMethodToPathItemMethod(
       return "delete";
     case "PATCH":
       return "patch";
+    case "HEAD":
+      return "head";
     default:
       assertNever(method);
   }

--- a/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
+++ b/lib/src/generators/openapi3/__snapshots__/openapi3.spec.ts.snap
@@ -76,6 +76,42 @@ exports[`OpenAPI 3 generator HTTP verbs GET endpoint 1`] = `
 }"
 `;
 
+exports[`OpenAPI 3 generator HTTP verbs HEAD endpoint 1`] = `
+"{
+  \\"openapi\\": \\"3.0.2\\",
+  \\"info\\": {
+    \\"title\\": \\"contract\\",
+    \\"version\\": \\"0.0.0\\"
+  },
+  \\"paths\\": {
+    \\"/users\\": {
+      \\"head\\": {
+        \\"operationId\\": \\"HeadEndpoint\\",
+        \\"responses\\": {
+          \\"204\\": {
+            \\"description\\": \\"204 response\\",
+            \\"headers\\": {
+              \\"Location\\": {
+                \\"required\\": true,
+                \\"schema\\": {
+                  \\"type\\": \\"string\\"
+                }
+              },
+              \\"Link\\": {
+                \\"required\\": false,
+                \\"schema\\": {
+                  \\"type\\": \\"string\\"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`OpenAPI 3 generator HTTP verbs PATCH endpoint 1`] = `
 "{
   \\"openapi\\": \\"3.0.2\\",

--- a/lib/src/generators/openapi3/__spec-examples__/contract-with-head-endpoint.ts
+++ b/lib/src/generators/openapi3/__spec-examples__/contract-with-head-endpoint.ts
@@ -1,0 +1,19 @@
+import { api, headers, endpoint, response, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "HEAD",
+  path: "/users"
+})
+class HeadEndpoint {
+  @response({ status: 204 })
+  successResponse(
+    @headers
+    headers: {
+      Location: String;
+      Link?: String;
+    }
+  ) {}
+}

--- a/lib/src/generators/openapi3/openapi3.spec.ts
+++ b/lib/src/generators/openapi3/openapi3.spec.ts
@@ -128,6 +128,18 @@ describe("OpenAPI 3 generator", () => {
       const spectralResult = await spectral.run(result);
       expect(spectralResult).toHaveLength(0);
     });
+
+    test("HEAD endpoint", async () => {
+      const contract = generateContract("contract-with-head-endpoint.ts");
+      const result = generateOpenAPI3(contract);
+
+      expect(result.paths["/users"]).toMatchObject({
+        head: expect.anything()
+      });
+      expect(JSON.stringify(result, null, 2)).toMatchSnapshot();
+      const spectralResult = await spectral.run(result);
+      expect(spectralResult).toHaveLength(0);
+    });
   });
 
   describe("path params", () => {

--- a/lib/src/generators/openapi3/openapi3.ts
+++ b/lib/src/generators/openapi3/openapi3.ts
@@ -343,6 +343,8 @@ function httpMethodToPathItemMethod(
       return "delete";
     case "PATCH":
       return "patch";
+    case "HEAD":
+      return "head";
     default:
       assertNever(method);
   }

--- a/lib/src/linting/rules/__spec-examples__/has-request-payload/head-endpoint-with-request-body.ts
+++ b/lib/src/linting/rules/__spec-examples__/has-request-payload/head-endpoint-with-request-body.ts
@@ -1,0 +1,30 @@
+import {
+  api,
+  body,
+  endpoint,
+  request,
+  response,
+  String
+} from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "HEAD",
+  path: "/users"
+})
+class HeadEndpoint {
+  @request
+  request(
+    @body
+    body: Body
+  ) {}
+
+  @response({ status: 204 })
+  successResponse() {}
+}
+
+interface Body {
+  body: String;
+}

--- a/lib/src/linting/rules/__spec-examples__/has-request-payload/head-endpoint-without-request-body.ts
+++ b/lib/src/linting/rules/__spec-examples__/has-request-payload/head-endpoint-without-request-body.ts
@@ -1,0 +1,23 @@
+import {
+  api,
+  body,
+  endpoint,
+  request,
+  response,
+  String
+} from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "HEAD",
+  path: "/users"
+})
+class HeadEndpoint {
+  @request
+  request() {}
+
+  @response({ status: 204 })
+  successResponse() {}
+}

--- a/lib/src/linting/rules/has-query-parameters.ts
+++ b/lib/src/linting/rules/has-query-parameters.ts
@@ -15,6 +15,7 @@ export function hasQueryParameters(contract: Contract): LintingRuleViolation[] {
     switch (endpoint.method) {
       case "DELETE":
       case "GET":
+      case "HEAD":
         break;
       case "PATCH":
       case "POST":

--- a/lib/src/linting/rules/has-request-payload.spec.ts
+++ b/lib/src/linting/rules/has-request-payload.spec.ts
@@ -29,6 +29,32 @@ describe("has-request-payload linter rule", () => {
     });
   });
 
+  describe("HTTP HEAD", () => {
+    test("returns violations for endpoint with a request body", () => {
+      const file = createProjectFromExistingSourceFile(
+        `${__dirname}/__spec-examples__/has-request-payload/head-endpoint-with-request-body.ts`
+      ).file;
+
+      const { contract } = parseContract(file).unwrapOrThrow();
+
+      const result = hasRequestPayload(contract);
+      expect(result).toHaveLength(1);
+      const message = result[0].message;
+      expect(message).toEqual(
+        "Endpoint (HeadEndpoint) with HTTP method HEAD must not contain a request body"
+      );
+    });
+    test("returns no violations for endpoint with no request body", () => {
+      const file = createProjectFromExistingSourceFile(
+        `${__dirname}/__spec-examples__/has-request-payload/head-endpoint-without-request-body.ts`
+      ).file;
+
+      const { contract } = parseContract(file).unwrapOrThrow();
+
+      expect(hasRequestPayload(contract)).toHaveLength(0);
+    });
+  });
+
   describe("HTTP POST", () => {
     test("returns no violations for endpoint with a request body", () => {
       const file = createProjectFromExistingSourceFile(

--- a/lib/src/linting/rules/has-request-payload.ts
+++ b/lib/src/linting/rules/has-request-payload.ts
@@ -16,6 +16,7 @@ export function hasRequestPayload(contract: Contract): LintingRuleViolation[] {
   contract.endpoints.forEach(endpoint => {
     switch (endpoint.method) {
       case "GET":
+      case "HEAD":
         if (endpoint.request?.body) {
           violations.push({
             message: `Endpoint (${endpoint.name}) with HTTP method ${endpoint.method} must not contain a request body`

--- a/lib/src/parsers/parser-helpers.ts
+++ b/lib/src/parsers/parser-helpers.ts
@@ -359,6 +359,7 @@ export function isHttpMethod(method: string): method is HttpMethod {
     case "PUT":
     case "PATCH":
     case "DELETE":
+    case "HEAD":
       return true;
     default:
       return false;


### PR DESCRIPTION
## Description, Motivation and Context

- Currently Spot lacks the ability to design APIs using HEAD method which is very usefull when requesting collection metadata for example.
- Adds support for HEAD method to be used in Spot design and to generate OAS contracts.

## Checklist:

- [x ] I've added/updated tests to cover my changes
- [ x] I've created an issue associated with this PR
