### PR TITLE
[PSC-1988] Fix `--proxyBaseUrl` argument to `spot mock`

### DIFF
--- a/cli/src/commands/mock.ts
+++ b/cli/src/commands/mock.ts
@@ -50,7 +50,7 @@ export default class Mock extends Command {
       await runMockServer(contract, {
         port,
         pathPrefix: pathPrefix ?? "",
-        ...proxyConfig,
+        proxyConfig,
         logger: this
       }).defer();
       this.log(`Mock server is running on port ${port}.`);

--- a/cli/src/common/infer-proxy-config.ts
+++ b/cli/src/common/infer-proxy-config.ts
@@ -7,7 +7,7 @@ export default function inferProxyConfig(
     return null;
   }
 
-  const url = new URL(proxyBaseUrl)
+  const url = new URL(proxyBaseUrl);
   if (url.protocol !== "http:" && url.protocol !== "https:") {
     throw new Error(
       'Could not infer protocol from proxy base url, should be either "http" or "https".'
@@ -17,6 +17,6 @@ export default function inferProxyConfig(
   return {
     isHttps: url.protocol === "https:",
     host: url.host,
-    path: url.pathname,
+    path: url.pathname
   };
 }

--- a/cli/src/common/infer-proxy-config.ts
+++ b/cli/src/common/infer-proxy-config.ts
@@ -7,16 +7,16 @@ export default function inferProxyConfig(
     return null;
   }
 
-  const [protocol] = proxyBaseUrl.split("://");
-
-  if (protocol !== "http" && protocol !== "https") {
+  const url = new URL(proxyBaseUrl)
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
     throw new Error(
       'Could not infer protocol from proxy base url, should be either "http" or "https".'
     );
   }
 
   return {
-    protocol,
-    proxyBaseUrl
+    isHttps: url.protocol === "https:",
+    host: url.host,
+    path: url.pathname,
   };
 }

--- a/cli/src/common/infer-proxy-config.ts
+++ b/cli/src/common/infer-proxy-config.ts
@@ -17,6 +17,7 @@ export default function inferProxyConfig(
   return {
     isHttps: url.protocol === "https:",
     host: url.host,
+    port: url.port ? parseInt(url.port, 10) : null,
     path: url.pathname
   };
 }

--- a/lib/src/mock-server/proxy.ts
+++ b/lib/src/mock-server/proxy.ts
@@ -12,11 +12,18 @@ export function proxyRequest({
   response: Response;
   proxyConfig: ProxyConfig;
 }): void {
+  console.log(proxyConfig);
   const requestHandler = proxyConfig.isHttps ? https : http;
 
   const options = {
     method: incomingRequest.method,
     host: proxyConfig.host,
+    port:
+      proxyConfig.port === null
+        ? proxyConfig.isHttps
+          ? 443
+          : 80
+        : proxyConfig.port,
     path: proxyConfig.path + incomingRequest.path,
     headers: {
       ...incomingRequest.headers,

--- a/lib/src/mock-server/proxy.ts
+++ b/lib/src/mock-server/proxy.ts
@@ -10,7 +10,7 @@ export function proxyRequest({
 }: {
   incomingRequest: Request;
   response: Response;
-  proxyConfig: ProxyConfig
+  proxyConfig: ProxyConfig;
 }): void {
   const requestHandler = proxyConfig.isHttps ? https : http;
 
@@ -20,8 +20,8 @@ export function proxyRequest({
     path: proxyConfig.path + incomingRequest.path,
     headers: {
       ...incomingRequest.headers,
-      host: proxyConfig.host,
-    },
+      host: proxyConfig.host
+    }
   };
   console.log(options);
 

--- a/lib/src/mock-server/proxy.ts
+++ b/lib/src/mock-server/proxy.ts
@@ -12,7 +12,6 @@ export function proxyRequest({
   response: Response;
   proxyConfig: ProxyConfig;
 }): void {
-  console.log(proxyConfig);
   const requestHandler = proxyConfig.isHttps ? https : http;
 
   const options = {
@@ -30,7 +29,6 @@ export function proxyRequest({
       host: proxyConfig.host
     }
   };
-  console.log(options);
 
   const proxyRequest = requestHandler.request(options, res => {
     // Forward headers

--- a/lib/src/mock-server/proxy.ts
+++ b/lib/src/mock-server/proxy.ts
@@ -1,27 +1,31 @@
 import { Request, Response } from "express";
 import http from "http";
 import https from "https";
+import { ProxyConfig } from "./server";
 
 export function proxyRequest({
   incomingRequest,
   response,
-  protocol,
-  proxyBaseUrl
+  proxyConfig
 }: {
   incomingRequest: Request;
   response: Response;
-  protocol: "http" | "https";
-  proxyBaseUrl: string;
+  proxyConfig: ProxyConfig
 }): void {
-  const requestHandler = protocol === "http" ? http : https;
+  const requestHandler = proxyConfig.isHttps ? https : http;
 
   const options = {
-    headers: incomingRequest.headers,
     method: incomingRequest.method,
-    path: incomingRequest.path
+    host: proxyConfig.host,
+    path: proxyConfig.path + incomingRequest.path,
+    headers: {
+      ...incomingRequest.headers,
+      host: proxyConfig.host,
+    },
   };
+  console.log(options);
 
-  const proxyRequest = requestHandler.request(proxyBaseUrl, options, res => {
+  const proxyRequest = requestHandler.request(options, res => {
     // Forward headers
     response.writeHead(res.statusCode ?? response.statusCode, res.headers);
     res.pipe(response);

--- a/lib/src/mock-server/server.spec.ts
+++ b/lib/src/mock-server/server.spec.ts
@@ -3,11 +3,17 @@ import request from "supertest";
 import { Contract } from "../definitions";
 import { defaultConfig } from "../parsers/config-parser";
 import { TypeKind } from "../types";
-import { runMockServer } from "./server";
+import { ProxyConfig, runMockServer } from "./server";
 
 describe("Server", () => {
-  const proxyBaseUrl = "http://localhost:9988";
-  const protocol = "http";
+  const proxyConfig: ProxyConfig = {
+    isHttps: false,
+    host: "localhost:9988",
+    path: ""
+  };
+  const proxyBaseUrl = `http${proxyConfig.isHttps ? "s" : ""}://${
+    proxyConfig.host
+  }${proxyConfig.path}`;
 
   afterEach(() => {
     nock.cleanAll();
@@ -92,10 +98,7 @@ describe("Server", () => {
         logger: mockLogger,
         pathPrefix: "/api",
         port: 8085,
-        proxyConfig: {
-          protocol,
-          proxyBaseUrl
-        }
+        proxyConfig
       });
 
       await request(app)
@@ -111,10 +114,7 @@ describe("Server", () => {
         logger: mockLogger,
         pathPrefix: "/api",
         port: 8085,
-        proxyConfig: {
-          protocol,
-          proxyBaseUrl
-        }
+        proxyConfig
       });
 
       await request(app)
@@ -147,10 +147,7 @@ describe("Server", () => {
         logger: mockLogger,
         pathPrefix: "/api",
         port: 8085,
-        proxyConfig: {
-          protocol,
-          proxyBaseUrl
-        }
+        proxyConfig
       });
 
       await request(app)

--- a/lib/src/mock-server/server.spec.ts
+++ b/lib/src/mock-server/server.spec.ts
@@ -5,15 +5,24 @@ import { defaultConfig } from "../parsers/config-parser";
 import { TypeKind } from "../types";
 import { ProxyConfig, runMockServer } from "./server";
 
+function buildProxyBaseUrl(proxyConfig: ProxyConfig): string {
+  let url = `http${proxyConfig.isHttps ? "s" : ""}://`;
+  url += proxyConfig.host;
+  if (proxyConfig.port !== null) {
+    url += `:${proxyConfig.port}`;
+  }
+  url += proxyConfig.path;
+  return url;
+}
+
 describe("Server", () => {
   const proxyConfig: ProxyConfig = {
     isHttps: false,
-    host: "localhost:9988",
+    host: "localhost",
+    port: 9988,
     path: ""
   };
-  const proxyBaseUrl = `http${proxyConfig.isHttps ? "s" : ""}://${
-    proxyConfig.host
-  }${proxyConfig.path}`;
+  const proxyBaseUrl = buildProxyBaseUrl(proxyConfig);
 
   afterEach(() => {
     nock.cleanAll();

--- a/lib/src/mock-server/server.ts
+++ b/lib/src/mock-server/server.ts
@@ -8,8 +8,9 @@ import { isRequestForEndpoint } from "./matcher";
 import { proxyRequest } from "./proxy";
 
 export interface ProxyConfig {
-  protocol: "http" | "https";
-  proxyBaseUrl: string;
+  isHttps: boolean;
+  host: string,
+  path: string;
 }
 
 /**
@@ -26,7 +27,7 @@ export function runMockServer(
   }: {
     port: number;
     pathPrefix: string;
-    proxyConfig?: ProxyConfig;
+    proxyConfig?: ProxyConfig | null;
     logger: Logger;
   }
 ) {
@@ -48,7 +49,7 @@ export function runMockServer(
           return proxyRequest({
             incomingRequest: req,
             response: resp,
-            ...proxyConfig
+            proxyConfig
           });
         }
 

--- a/lib/src/mock-server/server.ts
+++ b/lib/src/mock-server/server.ts
@@ -10,6 +10,7 @@ import { proxyRequest } from "./proxy";
 export interface ProxyConfig {
   isHttps: boolean;
   host: string;
+  port: number | null;
   path: string;
 }
 

--- a/lib/src/mock-server/server.ts
+++ b/lib/src/mock-server/server.ts
@@ -9,7 +9,7 @@ import { proxyRequest } from "./proxy";
 
 export interface ProxyConfig {
   isHttps: boolean;
-  host: string,
+  host: string;
   path: string;
 }
 


### PR DESCRIPTION
## Description, Motivation and Context

There exists functionality in `spot` to be able to run a mock server with an optional proxy. When the proxy isn't supplied, all endpoints that are defined in the given contact will have a stubbed response returned, with random, structurally valid data being returned. When the optional proxy argument is supplied, any non-draft SPOT contracts will be proxied through to the upstream instead of having mocked data returned.

The intent of this proxy argument is to allow you to perform local development against a stubbed new endpoint that doesn't yet have an implementation upstream.

When attempting to use this though, I found that the proxy was never being used, even though the code looked like it was meant to be doing the right thing. Upon further digging, I found that the proxy argument was never setup to be used correctly due to a bug in the code that TypeScript did not pick up on, due to the use of a generic object of options being passed to an object.

This PR:
1. Fixes the aforementioned bug, and now actually passes the proxy configuration through from the CLI parser to the mock server function call.
2. Updates the proxying logic to set the `host` header correctly when invoking HTTPs endpoints.

## Checklist:

- [x] I've added/updated tests to cover my changes
- [x] I've created an issue associated with this PR
