### PR TITLE
[PSC-1988] Enable `spot mock` to have a 404 fallback proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,12 +283,15 @@ ARGUMENTS
   SPOT_CONTRACT  path to Spot contract
 
 OPTIONS
-  -h, --help                   show CLI help
-  -p, --port=port              (required) [default: 3010] Port on which to run the mock server
-  --pathPrefix=pathPrefix      Prefix to prepend to each endpoint path
+  -h, --help                                   show CLI help
+  -p, --port=port                              (required) [default: 3010] Port on which to run the mock server
+  --pathPrefix=pathPrefix                      Prefix to prepend to each endpoint path
 
-  --proxyBaseUrl=proxyBaseUrl  If set, the server will act as a proxy and fetch data from the given remote server
-                               instead of mocking it
+  --proxyBaseUrl=proxyBaseUrl                  If set, the server will act as a proxy and fetch data from the given
+                                               remote server instead of mocking it
+
+  --proxyFallbackBaseUrl=proxyFallbackBaseUrl  Like proxyBaseUrl, except used when the requested API does not match
+                                               defined SPOT contract. If unset, 404 will always be returned.
 
 EXAMPLE
   $ spot mock api.ts

--- a/cli/src/commands/mock.ts
+++ b/cli/src/commands/mock.ts
@@ -28,6 +28,10 @@ export default class Mock extends Command {
       description:
         "If set, the server will act as a proxy and fetch data from the given remote server instead of mocking it"
     }),
+    proxyFallbackBaseUrl: flags.string({
+      description:
+        "Like proxyBaseUrl, except used when the requested API does not match defined SPOT contract. If unset, 404 will always be returned."
+    }),
     port: flags.integer({
       char: "p",
       description: "Port on which to run the mock server",
@@ -42,15 +46,17 @@ export default class Mock extends Command {
   async run(): Promise<void> {
     const {
       args,
-      flags: { port, pathPrefix, proxyBaseUrl = "" }
+      flags: { port, pathPrefix, proxyBaseUrl, proxyFallbackBaseUrl = "" }
     } = this.parse(Mock);
     try {
-      const proxyConfig = inferProxyConfig(proxyBaseUrl);
+      const proxyConfig = inferProxyConfig(proxyBaseUrl || "");
+      const proxyFallbackConfig = inferProxyConfig(proxyFallbackBaseUrl || "");
       const contract = parse(args[ARG_API]);
       await runMockServer(contract, {
         port,
         pathPrefix: pathPrefix ?? "",
         proxyConfig,
+        proxyFallbackConfig,
         logger: this
       }).defer();
       this.log(`Mock server is running on port ${port}.`);

--- a/lib/src/mock-server/server.spec.ts
+++ b/lib/src/mock-server/server.spec.ts
@@ -26,8 +26,8 @@ describe("Server", () => {
 
   const fallbackProxyConfig: ProxyConfig = {
     isHttps: false,
-    host: "localhost",
-    port: 9944,
+    host: "example.com",
+    port: 80,
     path: ""
   };
   const proxyFallbackBaseUrl = buildProxyBaseUrl(fallbackProxyConfig);
@@ -101,9 +101,6 @@ describe("Server", () => {
 
   // Set up mock proxy server
   nock(proxyBaseUrl).get("/api/companies").reply(200, data, {
-    "Content-Type": "application/json"
-  });
-  nock(proxyFallbackBaseUrl).get("/api/not-a-contract").reply(200, data, {
     "Content-Type": "application/json"
   });
 
@@ -183,15 +180,14 @@ describe("Server", () => {
       const { app } = runMockServer(contract, {
         logger: mockLogger,
         pathPrefix: "/api",
-        port: 8085,
-        proxyConfig
+        port: 8085
       });
 
       await request(app)
-        .get("/api/not-a-contract")
+        .get("/")
         .then(response => {
           expect(response.statusCode).toBe(404);
-        })
+        });
     });
 
     it("Requests that do not match a contract to proxy the request with a fallback proxy", async () => {
@@ -199,16 +195,14 @@ describe("Server", () => {
         logger: mockLogger,
         pathPrefix: "/api",
         port: 8085,
-        proxyConfig,
-        proxyFallbackConfig: fallbackProxyConfig,
+        proxyFallbackConfig: fallbackProxyConfig
       });
 
       await request(app)
-        .get("/api/not-a-contract")
+        .get("/")
         .then(response => {
           expect(response.statusCode).toBe(200);
-          expect(response.body.name).toBe("This is the real response");
-        })
+        });
     });
   });
 });

--- a/lib/src/mock-server/server.ts
+++ b/lib/src/mock-server/server.ts
@@ -24,11 +24,13 @@ export function runMockServer(
     port,
     pathPrefix,
     proxyConfig,
+    proxyFallbackConfig,
     logger
   }: {
     port: number;
     pathPrefix: string;
     proxyConfig?: ProxyConfig | null;
+    proxyFallbackConfig?: ProxyConfig | null;
     logger: Logger;
   }
 ) {
@@ -74,9 +76,17 @@ export function runMockServer(
       }
     }
 
-    logger.error(`No match for request ${req.method} at ${req.path}.`);
-    resp.status(404);
-    resp.send();
+    logger.log(`No match for request ${req.method} at ${req.path}.`);
+    if (proxyFallbackConfig) {
+      return proxyRequest({
+        incomingRequest: req,
+        response: resp,
+        proxyConfig: proxyFallbackConfig
+      });
+    } else {
+      resp.status(404);
+      resp.send();
+    }
   });
   return {
     app,


### PR DESCRIPTION
## Description, Motivation and Context

In order to make the mock server more useful in the case where you have multiple different upstream servers on the same hostname, this PR adds a new optional fallback proxy to `spot mock`, which is used instead of instantly 404'ing the received request if the request does not match any of the given contracts. If provided, instead of 404'ing, it will send the request through to the fallback proxy.