### PR TITLE
[NT] Normalise paths before proxying.

### DIFF
--- a/lib/src/mock-server/matcher.spec.ts
+++ b/lib/src/mock-server/matcher.spec.ts
@@ -1,4 +1,4 @@
-import { isRequestForEndpoint } from "./matcher";
+import { isRequestForEndpoint, normalisePath } from "./matcher";
 
 const BASE_ENDPOINT = {
   name: "my-endpoint",
@@ -158,6 +158,25 @@ describe("Matcher", () => {
           }
         )
       ).toBeFalsy();
+    });
+  });
+
+  describe("normalisePath", () => {
+    it("Performs a no-op with no slashes", () => {
+      expect(normalisePath("")).toBe("");
+      expect(normalisePath("chicken little")).toBe("chicken little");
+    });
+
+    it("Normalises more than one slash at various positions within the string", () => {
+      expect(normalisePath("//foo/bar")).toBe("/foo/bar");
+      expect(normalisePath("////foo/bar")).toBe("/foo/bar");
+      expect(normalisePath("/foo/////bar")).toBe("/foo/bar");
+      expect(normalisePath("/foo/bar//")).toBe("/foo/bar/");
+    });
+
+    it("Normalises more than one slash at multiple positions within the string", () => {
+      expect(normalisePath("//foo//bar")).toBe("/foo/bar");
+      expect(normalisePath("////foo////bar")).toBe("/foo/bar");
     });
   });
 });

--- a/lib/src/mock-server/matcher.ts
+++ b/lib/src/mock-server/matcher.ts
@@ -15,7 +15,8 @@ export function isRequestForEndpoint(
   pathPrefix: string,
   endpoint: Endpoint
 ): boolean {
-  if (req.path.substr(0, pathPrefix.length) !== pathPrefix) {
+  const requestPath = normalisePath(req.path);
+  if (requestPath.substr(0, pathPrefix.length) !== pathPrefix) {
     return false;
   }
   if (req.method.toUpperCase() !== endpoint.method) {
@@ -24,5 +25,14 @@ export function isRequestForEndpoint(
   const regexp = new RegExp(
     "^" + endpoint.path.replace(/:\w+/g, "[^/]+") + "$"
   );
-  return regexp.test(req.path.substr(pathPrefix.length));
+  return regexp.test(requestPath.substr(pathPrefix.length));
+}
+
+/**
+ * Normalises a given HTTP request path, by replacing all instances of two or more "/" in a row with a singular "/".
+ *
+ * @param path The path to normalise
+ */
+export function normalisePath(path: string): string {
+  return path.replace(/[/]{2,}/g, "/");
 }

--- a/lib/src/mock-server/proxy.ts
+++ b/lib/src/mock-server/proxy.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import http from "http";
 import https from "https";
 import { ProxyConfig } from "./server";
+import { normalisePath } from "./matcher";
 
 export function proxyRequest({
   incomingRequest,
@@ -23,7 +24,7 @@ export function proxyRequest({
           ? 443
           : 80
         : proxyConfig.port,
-    path: proxyConfig.path + incomingRequest.path,
+    path: normalisePath(proxyConfig.path + incomingRequest.path),
     headers: {
       ...incomingRequest.headers,
       host: proxyConfig.host


### PR DESCRIPTION
## Description, Motivation and Context

Due to various layers of proxying, sometimes a proxied request ends up with multiple leading slashes. Some web servers do not not normalise request paths, leading to 404's.

This PR normalises the received request path on the mock server before matching against contract paths, and normalises the received request paths when proxying the request.

## Checklist:

- [x] I've added/updated tests to cover my changes
- [x] I've created an issue associated with this PR
