### PR TITLE
[NT] Correct the hostname for proxy configurations with port numbers

### DIFF
--- a/cli/src/common/infer-proxy-config.spec.ts
+++ b/cli/src/common/infer-proxy-config.spec.ts
@@ -1,0 +1,69 @@
+import inferProxyConfig from "./infer-proxy-config";
+
+describe("inferProxyConfig", () => {
+  it("returns null when no inputs are provided", () => {
+    expect(inferProxyConfig("")).toBe(null);
+  });
+
+  it("throws an error when non-HTTP or HTTPS protocols are provided", () => {
+    expect(() => {
+      inferProxyConfig("chicken");
+    }).toThrowError(/Invalid URL/);
+
+    expect(() => {
+      inferProxyConfig("ftp://127.0.0.1/foo/bar/baz");
+    }).toThrowError(/Could not infer protocol/);
+  });
+
+  it("returns the expected value for proxy servers on the default port", () => {
+    expect(inferProxyConfig("http://example.com/foo")).toEqual({
+      isHttps: false,
+      host: "example.com",
+      port: null,
+      path: "/foo"
+    });
+    expect(inferProxyConfig("http://example.com")).toEqual({
+      isHttps: false,
+      host: "example.com",
+      port: null,
+      path: "/"
+    });
+    expect(inferProxyConfig("https://api.dev.mycompany.com/api/v1")).toEqual({
+      isHttps: true,
+      host: "api.dev.mycompany.com",
+      port: null,
+      path: "/api/v1"
+    });
+  });
+
+  it("returns the expected value for proxy servers on an explicit port", () => {
+    expect(inferProxyConfig("http://example.com:80/foo")).toEqual({
+      isHttps: false,
+      host: "example.com",
+      port: null,
+      path: "/foo"
+    });
+    expect(
+      inferProxyConfig("https://api.dev.mycompany.com:443/api/v1")
+    ).toEqual({
+      isHttps: true,
+      host: "api.dev.mycompany.com",
+      port: null,
+      path: "/api/v1"
+    });
+    expect(inferProxyConfig("http://localhost:3000/api/v1")).toEqual({
+      isHttps: false,
+      host: "localhost",
+      port: 3000,
+      path: "/api/v1"
+    });
+    expect(
+      inferProxyConfig("https://api.dev.mycompany.com:8443/api/v1")
+    ).toEqual({
+      isHttps: true,
+      host: "api.dev.mycompany.com",
+      port: 8443,
+      path: "/api/v1"
+    });
+  });
+});

--- a/cli/src/common/infer-proxy-config.ts
+++ b/cli/src/common/infer-proxy-config.ts
@@ -16,7 +16,7 @@ export default function inferProxyConfig(
 
   return {
     isHttps: url.protocol === "https:",
-    host: url.host,
+    host: url.hostname,
     port: url.port ? parseInt(url.port, 10) : null,
     path: url.pathname
   };


### PR DESCRIPTION
## Description, Motivation and Context

This PR fixes a bug in the proxy hostname parsing, where we currently accidentally use the wrong field from the parsed `URL` object to refer to the hostname of the proxy. https://developer.mozilla.org/en-US/docs/Web/API/URL — the `host` attribute is of the form `<host>:<port>` if present, whereas `hostname` is just `<host>`. How we use the parsed attribute expects just a hostname without a port number.

This PR fixes this bug by using the `hostname` attribute of the parsed URL instead of the `host` attribute. While I was here, I also added tests for this proxy URL parsing function given there were none before.

## Checklist:

- [x] I've added/updated tests to cover my changes
- [x] I've created an issue associated with this PR
