### PR TITLE
[NT] Optional proxy server for draft endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,9 @@ OPTIONS
   --proxyFallbackBaseUrl=proxyFallbackBaseUrl  Like proxyBaseUrl, except used when the requested API does not match
                                                defined SPOT contract. If unset, 404 will always be returned.
 
+  --proxyMockBaseUrl=proxyMockBaseUrl          Like proxyBaseUrl, except used to proxy draft endpoints instead of
+                                               returning mocked responses.
+
 EXAMPLE
   $ spot mock api.ts
 ```

--- a/cli/src/commands/mock.ts
+++ b/cli/src/commands/mock.ts
@@ -32,6 +32,10 @@ export default class Mock extends Command {
       description:
         "Like proxyBaseUrl, except used when the requested API does not match defined SPOT contract. If unset, 404 will always be returned."
     }),
+    proxyMockBaseUrl: flags.string({
+      description:
+        "Like proxyBaseUrl, except used to proxy draft endpoints instead of returning mocked responses."
+    }),
     port: flags.integer({
       char: "p",
       description: "Port on which to run the mock server",
@@ -46,16 +50,24 @@ export default class Mock extends Command {
   async run(): Promise<void> {
     const {
       args,
-      flags: { port, pathPrefix, proxyBaseUrl, proxyFallbackBaseUrl = "" }
+      flags: {
+        port,
+        pathPrefix,
+        proxyBaseUrl,
+        proxyMockBaseUrl,
+        proxyFallbackBaseUrl = ""
+      }
     } = this.parse(Mock);
     try {
       const proxyConfig = inferProxyConfig(proxyBaseUrl || "");
+      const proxyMockConfig = inferProxyConfig(proxyMockBaseUrl || "");
       const proxyFallbackConfig = inferProxyConfig(proxyFallbackBaseUrl || "");
       const contract = parse(args[ARG_API]);
       await runMockServer(contract, {
         port,
         pathPrefix: pathPrefix ?? "",
         proxyConfig,
+        proxyMockConfig,
         proxyFallbackConfig,
         logger: this
       }).defer();

--- a/lib/src/mock-server/server.ts
+++ b/lib/src/mock-server/server.ts
@@ -60,7 +60,7 @@ export function runMockServer(
           });
         }
 
-        // For draft endpoints, either either proxy or generate a mocked response.
+        // For draft endpoints, either proxy or generate a mocked response.
         if (proxyMockConfig) {
           return proxyRequest({
             incomingRequest: req,

--- a/lib/src/mock-server/server.ts
+++ b/lib/src/mock-server/server.ts
@@ -24,12 +24,14 @@ export function runMockServer(
     port,
     pathPrefix,
     proxyConfig,
+    proxyMockConfig,
     proxyFallbackConfig,
     logger
   }: {
     port: number;
     pathPrefix: string;
     proxyConfig?: ProxyConfig | null;
+    proxyMockConfig?: ProxyConfig | null;
     proxyFallbackConfig?: ProxyConfig | null;
     logger: Logger;
   }
@@ -49,6 +51,7 @@ export function runMockServer(
         // non-draft end points get real response
         const shouldProxy = !endpoint.draft;
 
+        // Proxy non-draft requests if we have a proxy config.
         if (shouldProxy && proxyConfig) {
           return proxyRequest({
             incomingRequest: req,
@@ -57,20 +60,29 @@ export function runMockServer(
           });
         }
 
-        logger.log(`Request hit for ${endpoint.name} registered.`);
-        const response = endpoint.responses[0] ?? endpoint.defaultResponse;
-        if (!response) {
-          logger.error(`No response defined for endpoint ${endpoint.name}`);
-          return;
-        }
-        resp.status("status" in response ? response.status : 200);
-        resp.header("content-type", "application/json");
-        if (response.body) {
-          resp.send(
-            JSON.stringify(
-              generateData(TypeTable.fromArray(api.types), response.body.type)
-            )
-          );
+        // For draft endpoints, either either proxy or generate a mocked response.
+        if (proxyMockConfig) {
+          return proxyRequest({
+            incomingRequest: req,
+            response: resp,
+            proxyConfig: proxyMockConfig
+          });
+        } else {
+          logger.log(`Request hit for ${endpoint.name} registered.`);
+          const response = endpoint.responses[0] ?? endpoint.defaultResponse;
+          if (!response) {
+            logger.error(`No response defined for endpoint ${endpoint.name}`);
+            return;
+          }
+          resp.status("status" in response ? response.status : 200);
+          resp.header("content-type", "application/json");
+          if (response.body) {
+            resp.send(
+              JSON.stringify(
+                generateData(TypeTable.fromArray(api.types), response.body.type)
+              )
+            );
+          }
         }
         return;
       }


### PR DESCRIPTION
## Description, Motivation and Context

This PR introduces a new option, `--proxyMockBaseUrl`, which can be used to proxy requests for draft contracts to a HTTP server instead of returning mocked response. With this, we now have the functionality to have a local implementation of a particular new draft contract while using existing live implementations for all other contracts and non-contract requests. For example, what I've been using this for locally is:

```
spot mock \
    --port 5601 \
    --proxyBaseUrl https://api.dev.company.com \
    --proxyFallbackBaseUrl https://api.dev.company.com \
    --proxyMockBaseUrl http://127.0.0.1:3000 \  # Hit a locally running server for draft requests
    ~/some/path/to/spots/api.ts
```

The diff of this PR is best viewed with whitespace ignored, as there's a large block of indentation changes: https://github.com/airtasker/spot/pull/2070/files?diff=split&w=1

## Checklist:

- [x] I've added/updated tests to cover my changes
- [x] I've created an issue associated with this PR
