### PR TITLE
[NT] Run CI across multiple NodeJS versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
   node: circleci/node@1.1.6
 
 executors:
-  node-executor:
+  node14:
     docker:
       - image: cimg/node:14.17
     working_directory: ~/repo
@@ -26,13 +26,9 @@ commands:
             - node_modules
           key: v3-dependencies-{{ checksum "package.json" }}
 
-jobs:
-  test:
-    executor: node-executor
-    resource_class: xlarge
-    parallelism: 8
+  run-tests:
+    description: Run the unit tests
     steps:
-      - prepare-repository
       - node/with-splitting:
           glob-path: lib/**/*.spec.ts
           timings-type: classname
@@ -44,11 +40,20 @@ jobs:
                   JEST_JUNIT_OUTPUT_DIR: ./test-reports/jest
                   JEST_JUNIT_OUTPUT_NAME: results.xml
                   JEST_JUNIT_CLASSNAME: "{filepath}"
+
+jobs:
+  test-node14:
+    executor: node14
+    resource_class: xlarge
+    parallelism: 8
+    steps:
+      - prepare-repository
+      - run-tests
       - store_test_results:
           path: ./test-reports
 
   lint-check:
-    executor: node-executor
+    executor: node14
     steps:
       - prepare-repository
       - run:
@@ -56,7 +61,7 @@ jobs:
           command: yarn lint:check
 
   publish:
-    executor: node-executor
+    executor: node14
     steps:
       - prepare-repository
       - run:
@@ -69,7 +74,7 @@ jobs:
 workflows:
   build-and-test:
     jobs:
-      - test:
+      - test-node14:
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
@@ -79,7 +84,7 @@ workflows:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - publish:
           requires:
-            - test
+            - test-node14
             - lint-check
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ commands:
   run-tests:
     description: Run the unit tests
     steps:
+      - prepare-repository
       - run:
           name: Run the tests in parallel.
           environment:
@@ -53,18 +54,35 @@ commands:
             JEST_JUNIT_CLASSNAME: "{filepath}"
           command: |
             set -uex
-            TESTFILES=$(circleci tests glob lib/**/*.spec.ts | circleci tests split --split-by=name)
+            TESTFILES=$(circleci tests glob lib/**/*.spec.ts | circleci tests split --split-by=timings)
             yarn ci:test $TESTFILES
+      - store_test_results:
+          path: ./test-reports
 
 jobs:
   test-node14:
     executor: node14
     parallelism: 8
     steps:
-      - prepare-repository
       - run-tests
-      - store_test_results:
-          path: ./test-reports
+
+  test-node16:
+    executor: node16
+    parallelism: 8
+    steps:
+      - run-tests
+
+  test-node18:
+    executor: node18
+    parallelism: 8
+    steps:
+      - run-tests
+
+  test-node20:
+    executor: node20
+    parallelism: 8
+    steps:
+      - run-tests
 
   lint-check:
     executor: node14
@@ -92,6 +110,18 @@ workflows:
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      - test-node16:
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      - test-node18:
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      - test-node20:
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - lint-check:
           filters:
             tags:
@@ -99,6 +129,9 @@ workflows:
       - publish:
           requires:
             - test-node14
+            - test-node16
+            - test-node18
+            - test-node20
             - lint-check
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,10 @@ commands:
     steps:
       - prepare-repository
       - run:
-          name: Run the tests in parallel.
+          name: Compile the repository on this version of Node.
+          command: yarn build
+      - run:
+          name: Run the tests on this version of Node.
           environment:
             JEST_JUNIT_OUTPUT_DIR: ./test-reports/jest
             JEST_JUNIT_OUTPUT_NAME: results.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,28 @@
 version: 2.1
 
-orbs:
-  node: circleci/node@1.1.6
-
 executors:
   node14:
     docker:
       - image: cimg/node:14.17
+    resource_class: medium
+    working_directory: ~/repo
+
+  node16:
+    docker:
+      - image: cimg/node:16.20.1
+    resource_class: medium
+    working_directory: ~/repo
+
+  node18:
+    docker:
+      - image: cimg/node:18.18.1
+    resource_class: medium
+    working_directory: ~/repo
+
+  node20:
+    docker:
+      - image: cimg/node:20.4.0
+    resource_class: medium
     working_directory: ~/repo
 
 commands:
@@ -29,22 +45,20 @@ commands:
   run-tests:
     description: Run the unit tests
     steps:
-      - node/with-splitting:
-          glob-path: lib/**/*.spec.ts
-          timings-type: classname
-          steps:
-            - run:
-                name: Run tests
-                command: yarn ci:test $TESTFILES
-                environment:
-                  JEST_JUNIT_OUTPUT_DIR: ./test-reports/jest
-                  JEST_JUNIT_OUTPUT_NAME: results.xml
-                  JEST_JUNIT_CLASSNAME: "{filepath}"
+      - run:
+          name: Run the tests in parallel.
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./test-reports/jest
+            JEST_JUNIT_OUTPUT_NAME: results.xml
+            JEST_JUNIT_CLASSNAME: "{filepath}"
+          command: |
+            set -uex
+            TESTFILES=$(circleci tests glob lib/**/*.spec.ts | circleci tests split --split-by=name)
+            yarn ci:test $TESTFILES
 
 jobs:
   test-node14:
     executor: node14
-    resource_class: xlarge
     parallelism: 8
     steps:
       - prepare-repository


### PR DESCRIPTION
## Description, Motivation and Context

Run CI across multiple NodeJS versions to help ensure we make forwards and backwards compatible changes.
