### PR TITLE
Bug fixes for #2061

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
       - checkout
       - restore_cache:
           keys:
-            - v3-dependencies-{{ checksum "package.json" }}
+            - v3-dependencies-{{ checksum "yarn.lock" }}
             - v3-dependencies
       - run:
           name: Install dependencies
@@ -40,7 +40,7 @@ commands:
       - save_cache:
           paths:
             - node_modules
-          key: v3-dependencies-{{ checksum "package.json" }}
+          key: v3-dependencies-{{ checksum "yarn.lock" }}
 
   run-tests:
     description: Run the unit tests


### PR DESCRIPTION
## Description, Motivation and Context

After merging in #2061, `master` now fails to build, even though CI passed on that branch.
