### PR TITLE
[PSC-2029] Allow configuring the `lint` command via CLI arguments

### DIFF
--- a/cli/src/commands/lint.ts
+++ b/cli/src/commands/lint.ts
@@ -2,6 +2,7 @@ import { Command, flags } from "@oclif/command";
 import { lint } from "../../../lib/src/linting/linter";
 import { parse } from "../../../lib/src/parser";
 import { findLintViolations } from "../../../lib/src/linting/find-lint-violations";
+import { availableRules } from "../../../lib/src/linting/rules";
 
 const ARG_API = "spot_contract";
 
@@ -9,7 +10,6 @@ export interface LintConfig {
   rules: Record<string, string>;
 }
 
-// TODO: Make it possible to specify by reading a config file
 const lintConfig: LintConfig = {
   rules: {
     "no-omittable-fields-within-response-bodies": "warn"
@@ -22,7 +22,11 @@ const lintConfig: LintConfig = {
 export default class Lint extends Command {
   static description = "Lint a Spot contract";
 
-  static examples = ["$ spot lint api.ts"];
+  static examples = [
+    "$ spot lint api.ts",
+    "$ spot lint --has-descriminator=error",
+    "$ spot lint --no-nullable-arrays=off"
+  ];
 
   static args = [
     {
@@ -33,15 +37,36 @@ export default class Lint extends Command {
     }
   ];
 
-  static flags = {
-    help: flags.help({ char: "h" })
-  };
+  static flags = this.buildFlags();
+
+  static buildFlags() {
+    // Arguments depend on the list of available rules, it cannot be typed ahead of time.
+    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+    const finalFlags: flags.Input<any> = {
+      help: flags.help({ char: "h" })
+    };
+
+    Object.keys(availableRules).forEach((rule: string) => {
+      finalFlags[rule] = flags.enum({
+        description: `Setting for ${rule}`,
+        options: ["error", "warn", "off"]
+      });
+    });
+
+    return finalFlags;
+  }
 
   async run(): Promise<void> {
-    const { args } = this.parse(Lint);
+    const { args, flags } = this.parse(Lint);
     const contractPath = args[ARG_API];
     const contract = parse(contractPath);
     const groupedLintErrors = lint(contract);
+
+    Object.keys(availableRules).forEach((rule: string) => {
+      if (flags[rule] !== undefined) {
+        lintConfig.rules[rule] = flags[rule];
+      }
+    });
 
     const { errorCount, warningCount } = findLintViolations(
       groupedLintErrors,


### PR DESCRIPTION
## Description, Motivation and Context

The `lint` command can be configured with a `LintConfig`. However, this `LintConfig` is currently hardcoded in `lint.ts` and cannot be changed via command-line arguments.

This PR adds the ability to configure the `lint` command in the CLI.

This allows running things like:

```
$ spot lint api.ts --has-discriminator=error
$ spot lint api.ts --no-nullable-arrays=off
```

The `help` command now returns:

```
$ spot lint api.ts --help

Lint a Spot contract

USAGE
  $ spot lint SPOT_CONTRACT

ARGUMENTS
  SPOT_CONTRACT  path to Spot contract

OPTIONS
  -h, --help                                                     show CLI help
  --has-discriminator=(error|warn|off)                           Setting for has-discriminator
  --has-request-payload=(error|warn|off)                         Setting for has-request-payload
  --has-response=(error|warn|off)                                Setting for has-response
  --has-response-payload=(error|warn|off)                        Setting for has-response-payload
  --no-inline-objects-within-unions=(error|warn|off)             Setting for no-inline-objects-within-unions
  --no-nullable-arrays=(error|warn|off)                          Setting for no-nullable-arrays
  --no-nullable-fields-within-request-bodies=(error|warn|off)    Setting for no-nullable-fields-within-request-bodies
  --no-omittable-fields-within-response-bodies=(error|warn|off)  Setting for no-omittable-fields-within-response-bodies

EXAMPLE
  $ spot lint api.ts
  $ spot lint --has-descriminator=error
  $ spot lint --no-nullable-arrays=off
```

## Checklist:

- [ ] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
