### PR TITLE
[PSC-2029] Add lint rule to prevent trailing forward slashes

### DIFF
--- a/cli/src/commands/lint.ts
+++ b/cli/src/commands/lint.ts
@@ -12,7 +12,8 @@ export interface LintConfig {
 
 const lintConfig: LintConfig = {
   rules: {
-    "no-omittable-fields-within-response-bodies": "warn"
+    "no-omittable-fields-within-response-bodies": "warn",
+    "no-trailing-forward-slash": "warn"
   }
 };
 

--- a/lib/src/linting/rules.ts
+++ b/lib/src/linting/rules.ts
@@ -7,6 +7,7 @@ import { noInlineObjectsWithinUnions } from "./rules/no-inline-objects-within-un
 import { noNullableArrays } from "./rules/no-nullable-arrays";
 import { noNullableFieldsWithinRequestBodies } from "./rules/no-nullable-fields-within-request-bodies";
 import { noOmittableFieldsWithinResponseBodies } from "./rules/no-omittable-fields-within-response-bodies";
+import { noTrailingForwardSlash } from "./rules/no-trailing-forward-slash";
 
 export const availableRules: LintingRules = {
   "has-discriminator": hasDiscriminator,
@@ -18,7 +19,8 @@ export const availableRules: LintingRules = {
   "no-nullable-fields-within-request-bodies":
     noNullableFieldsWithinRequestBodies,
   "no-omittable-fields-within-response-bodies":
-    noOmittableFieldsWithinResponseBodies
+    noOmittableFieldsWithinResponseBodies,
+  "no-trailing-forward-slash": noTrailingForwardSlash
 };
 
 interface LintingRules {

--- a/lib/src/linting/rules/__spec-examples__/no-trailing-forward-slash/no-trailing-forward-slash.ts
+++ b/lib/src/linting/rules/__spec-examples__/no-trailing-forward-slash/no-trailing-forward-slash.ts
@@ -1,0 +1,17 @@
+import { api, body, endpoint, response, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users"
+})
+class Endpoint {
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  body: String;
+}

--- a/lib/src/linting/rules/__spec-examples__/no-trailing-forward-slash/trailing-forward-slash.ts
+++ b/lib/src/linting/rules/__spec-examples__/no-trailing-forward-slash/trailing-forward-slash.ts
@@ -1,0 +1,17 @@
+import { api, body, endpoint, response, String } from "@airtasker/spot";
+
+@api({ name: "contract" })
+class Contract {}
+
+@endpoint({
+  method: "GET",
+  path: "/users/"
+})
+class Endpoint {
+  @response({ status: 200 })
+  successResponse(@body body: Body) {}
+}
+
+interface Body {
+  body: String;
+}

--- a/lib/src/linting/rules/no-trailing-forward-slash.spec.ts
+++ b/lib/src/linting/rules/no-trailing-forward-slash.spec.ts
@@ -1,0 +1,25 @@
+import { parseContract } from "../../parsers/contract-parser";
+import { createProjectFromExistingSourceFile } from "../../spec-helpers/helper";
+import { noTrailingForwardSlash } from "./no-trailing-forward-slash";
+
+describe("no-trailing-forward-slash linter rule", () => {
+  test("returns no violations for contract not containing a trailing forward slash", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/no-trailing-forward-slash/no-trailing-forward-slash.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    expect(noTrailingForwardSlash(contract)).toHaveLength(0);
+  });
+
+  test("returns a violation for contract containing a trailing forward slash", () => {
+    const file = createProjectFromExistingSourceFile(
+      `${__dirname}/__spec-examples__/no-trailing-forward-slash/trailing-forward-slash.ts`
+    ).file;
+
+    const { contract } = parseContract(file).unwrapOrThrow();
+
+    expect(noTrailingForwardSlash(contract)).toHaveLength(1);
+  });
+});

--- a/lib/src/linting/rules/no-trailing-forward-slash.ts
+++ b/lib/src/linting/rules/no-trailing-forward-slash.ts
@@ -1,0 +1,25 @@
+import { Contract } from "../../definitions";
+import { LintingRuleViolation } from "../rule";
+
+/**
+ * Request types should always be object types
+ *
+ * @param contract a contract
+ */
+export function noTrailingForwardSlash(
+  contract: Contract
+): LintingRuleViolation[] {
+  const violations: LintingRuleViolation[] = [];
+
+  contract.endpoints.forEach(endpoint => {
+    const { path } = endpoint;
+
+    if (path.match(/\/$/)) {
+      violations.push({
+        message: `Endpoint (${endpoint.name} ${path}) contains a trailing forward slash`
+      });
+    }
+  });
+
+  return violations;
+}

--- a/lib/src/linting/rules/no-trailing-forward-slash.ts
+++ b/lib/src/linting/rules/no-trailing-forward-slash.ts
@@ -2,7 +2,8 @@ import { Contract } from "../../definitions";
 import { LintingRuleViolation } from "../rule";
 
 /**
- * Request types should always be object types
+ * Checks that no endpoint is defined with a path that contains a trailing
+ * forward slash.
  *
  * @param contract a contract
  */


### PR DESCRIPTION
## Description, Motivation and Context

In an attempt to increase consistency across endpoints, Airtasker wants to avoid having endpoints whose path ends with a trailing forward slash. This PR adds a lint rule that rejects contracts containing endpoints with a trailing forward slash.

To maintain backwards compatibility, the default `LintConfig` has been updated to only `warn` on such issues.

The rule can be enforced by running
`spot lint <api.rs> --no-trailing-forward-slash=error`

The rule can be fully disabled by running
`spot lint <api.ts> --no-trailing-forward-slash=off`.

Example output:
```
$ spot lint api.ts
 ›   Warning: Endpoint (AAA /aaa/) contains a trailing forward slash
 ›   Warning: Endpoint (AAB /aab/) contains a trailing forward slash
 ›   Warning: Endpoint (ABC /abc/) contains a trailing forward slash
 ›   Warning: Endpoint (XXX /xxx/) contains a trailing forward slash
 ›   Warning: Endpoint (XYZ /xyz/) contains a trailing forward slash
Found 0 errors and 5 warnings


$ spot lint api.ts --no-trailing-forward-slash=error
 ›   Error: Endpoint (AAA /aaa/) contains a trailing forward slash
 ›   Error: Endpoint (AAB /aab/) contains a trailing forward slash
 ›   Error: Endpoint (ABC /abc/) contains a trailing forward slash
 ›   Error: Endpoint (XXX /xxx/) contains a trailing forward slash
 ›   Error: Endpoint (XYZ /xyz/) contains a trailing forward slash
Found 0 errors and 5 warnings


$ spot lint api.ts --no-trailing-forward-slash=off
Found 0 errors and 0 warnings
```

## Checklist:

- [x] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
