### PR TITLE
[NT] Unset PSC as codeowners from any package management files.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 * @airtasker/platform-services-core
 
 # Explicitly no codeowners for dependencies files.
-/package.json
-/yarn.lock
+package.json
+yarn.lock


### PR DESCRIPTION
## Description, Motivation and Context

PSC was already set as not the codeowners for the top-level package management files. This PR extends this to cover the `/docs` folder.
