### PR TITLE
Add Claude Code Integration workflow

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,40 @@
+name: Claude Code Integration
+
+on:
+  issue_comment:
+    types: [ created ]
+  pull_request_review_comment:
+    types: [ created ]
+  issues:
+    types: [ opened, assigned ]
+  pull_request_review:
+    types: [ submitted ]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - uses: airtasker/claude-code-agent-action@v1.0
+        with:
+          claude_aws_role: ${{ vars.CLAUDE_AWS_ROLE }}
+          claude_aws_region: ${{ vars.CLAUDE_AWS_REGION }}
+          claude_app_id: ${{ secrets.CLAUDE_APP_ID }}
+          claude_app_private_key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          claude_code_enable_telemetry: ${{ vars.CLAUDE_CODE_ENABLE_TELEMETRY }}
+          claude_otel_logs_exporter: ${{ vars.CLAUDE_OTEL_LOGS_EXPORTER }}
+          claude_otel_metrics_exporter: ${{ vars.CLAUDE_OTEL_METRICS_EXPORTER }}
+          claude_otel_exporter_otlp_protocol: ${{ vars.CLAUDE_OTEL_EXPORTER_OTLP_PROTOCOL }}
+          claude_otel_exporter_otlp_endpoint: ${{ vars.CLAUDE_OTEL_EXPORTER_OTLP_ENDPOINT }}
+          claude_otel_exporter_otlp_headers: ${{ secrets.CLAUDE_OTEL_EXPORTER_OTLP_HEADERS }}
+          claude_aws_model: ${{ vars.CLAUDE_AWS_MODEL }}


### PR DESCRIPTION
## Summary
- Added Claude Code Integration workflow to enable @claude mentions in issues, PRs, and comments
- Uses the standard Airtasker template from the .github repository

## Test plan
- [ ] Verify workflow file is properly formatted and follows GitHub Actions syntax
- [ ] Test @claude integration once merged

🤖 Generated with [Claude Code](https://claude.ai/code)