### PR TITLE
chore(APE-993): update CODEOWNERS to technology-based teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @airtasker/platform-services-core
+* @airtasker/web-eng
 
 # Explicitly no codeowners for dependencies files.
 package.json


### PR DESCRIPTION
## Why

Updating CODEOWNERS to align with the new technology-based team structure as outlined in [APE-993 Solution Proposal](https://airtasker.atlassian.net/wiki/spaces/ENG/pages/4029251661/2025-07-29+Solution+Proposal+-+Fit+for+purpose+CODEOWNERS).

## What

- Updated team assignments in CODEOWNERS file to reflect new engineering team structure
- Replaced product-focused teams with technology-focused teams (kotlin-eng, web-eng, mobile-eng, etc.)
- Maintained SRE, data, and SEO team ownership where appropriate