### PR TITLE
chore(APE-1096): add 7-day cooldown to npm Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,40 +1,43 @@
 version: 2
-
 updates:
-  - package-ecosystem: npm
-    directory: "/"
-    schedule:
-      interval: weekly
-      day: monday
-      time: "05:00"
-      timezone: Australia/Sydney
-    open-pull-requests-limit: 99
-  - package-ecosystem: npm
-    directory: "/docs"
-    schedule:
-      interval: weekly
-      day: monday
-      time: "05:00"
-      timezone: Australia/Sydney
-    open-pull-requests-limit: 99
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: daily
-      time: "09:00"
-      timezone: Australia/Sydney
-    open-pull-requests-limit: 10
-  - package-ecosystem: github-actions
-    directory: "/.github/actions/build-and-test"
-    schedule:
-      interval: daily
-      time: "09:00"
-      timezone: Australia/Sydney
-    open-pull-requests-limit: 10
-  - package-ecosystem: github-actions
-    directory: "/.github/actions/prepare-repository"
-    schedule:
-      interval: daily
-      time: "09:00"
-      timezone: Australia/Sydney
-    open-pull-requests-limit: 10
+- package-ecosystem: npm
+  directory: /
+  schedule:
+    interval: weekly
+    day: monday
+    time: 05:00
+    timezone: Australia/Sydney
+  open-pull-requests-limit: 99
+  cooldown:
+    default-days: 7
+- package-ecosystem: npm
+  directory: /docs
+  schedule:
+    interval: weekly
+    day: monday
+    time: 05:00
+    timezone: Australia/Sydney
+  open-pull-requests-limit: 99
+  cooldown:
+    default-days: 7
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+    time: 09:00
+    timezone: Australia/Sydney
+  open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: /.github/actions/build-and-test
+  schedule:
+    interval: daily
+    time: 09:00
+    timezone: Australia/Sydney
+  open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: /.github/actions/prepare-repository
+  schedule:
+    interval: daily
+    time: 09:00
+    timezone: Australia/Sydney
+  open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

- Adds a 7-day cooldown period for npm dependency updates

## Why

This cooldown helps protect against supply chain attacks by allowing time for the community to identify and report malicious packages before they are automatically updated to our codebase.

**Important:** This cooldown does not affect security updates, which will still be created immediately when vulnerabilities are detected.

## References

- Ticket: [APE-1096](https://airtasker.atlassian.net/browse/APE-1096)
- [Dependabot cooldown documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APE-1096]: https://airtasker.atlassian.net/browse/APE-1096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ