### PR TITLE
fix(APE-1096): quote time values in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: weekly
     day: monday
-    time: 05:00
+    time: "05:00"
     timezone: Australia/Sydney
   open-pull-requests-limit: 99
   cooldown:
@@ -15,7 +15,7 @@ updates:
   schedule:
     interval: weekly
     day: monday
-    time: 05:00
+    time: "05:00"
     timezone: Australia/Sydney
   open-pull-requests-limit: 99
   cooldown:
@@ -24,20 +24,20 @@ updates:
   directory: /
   schedule:
     interval: daily
-    time: 09:00
+    time: "09:00"
     timezone: Australia/Sydney
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: /.github/actions/build-and-test
   schedule:
     interval: daily
-    time: 09:00
+    time: "09:00"
     timezone: Australia/Sydney
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: /.github/actions/prepare-repository
   schedule:
     interval: daily
-    time: 09:00
+    time: "09:00"
     timezone: Australia/Sydney
   open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

- Fixes unquoted time values in dependabot.yml configuration

## Why

Time values like `05:00` must be quoted in YAML to be interpreted as strings. Without quotes, YAML interprets them as sexagesimal (base 60) numbers, which can cause unexpected behavior.

This fixes an issue introduced in the previous APE-1096 PR where time values were inadvertently unquoted.

## What

- Quotes all `time:` values in dependabot.yml (e.g., `time: 05:00` → `time: "05:00"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)