### PR TITLE
[ACQ-6253] Add GitHub Package Registry publishing to workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -93,14 +93,7 @@ jobs:
           EOF
 
       - name: Publish to NPM
-        id: npm-publish
         run: pnpm publish --access=public
-
-      - name: Verify NPM publish
-        run: |
-          echo "Waiting for NPM registry propagation..."
-          sleep 10
-          npm view @airtasker/spot@${{ github.event.release.tag_name }} version
 
       - name: Authenticate with GitHub Package Registry
         run: |
@@ -113,14 +106,6 @@ jobs:
         id: gpr-publish
         run: pnpm publish --registry=https://npm.pkg.github.com --access=public
         continue-on-error: true
-
-      - name: Verify GPR publish
-        if: steps.gpr-publish.outcome == 'success'
-        run: |
-          echo "Waiting for GitHub Package Registry propagation..."
-          sleep 10
-          npm view @airtasker/spot@${{ github.event.release.tag_name }} version \
-            --registry=https://npm.pkg.github.com
 
       - name: Report GPR failure
         if: steps.gpr-publish.outcome == 'failure'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,9 +10,6 @@ on:
   release:
     types: [published]
 
-env:
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
 jobs:
   test:
     name: test-node-${{ matrix.node-version }}
@@ -86,30 +83,35 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/prepare-repository
 
-      - name: Authenticate with NPM registry
+      - name: Authenticate with registries
         run: |
           cat > ~/.npmrc << 'EOF'
-          //registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}
-          EOF
-
-      - name: Publish to NPM
-        run: pnpm publish --access=public
-
-      - name: Authenticate with GitHub Package Registry
-        run: |
-          cat > ~/.npmrc << 'EOF'
+          //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
           //npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
           @airtasker:registry=https://npm.pkg.github.com
           EOF
 
+      - name: Publish to NPM
+        id: npm-publish
+        run: pnpm publish --access=public
+
       - name: Publish to GitHub Package Registry
         id: gpr-publish
+        if: steps.npm-publish.outcome == 'success'
         run: pnpm publish --registry=https://npm.pkg.github.com --access=public
         continue-on-error: true
 
-      - name: Report GPR failure
-        if: steps.gpr-publish.outcome == 'failure'
+      - name: Report publish status
+        if: always()
         run: |
-          echo "::warning::GitHub Package Registry publish failed, but NPM publish succeeded"
-          echo "::warning::Manual GPR publish may be required"
-          echo "::warning::Package is available on NPM: https://www.npmjs.com/package/@airtasker/spot"
+          if [ "${{ steps.npm-publish.outcome }}" != "success" ]; then
+            echo "::error::NPM publish failed"
+            exit 1
+          fi
+
+          if [ "${{ steps.gpr-publish.outcome }}" == "failure" ]; then
+            echo "::warning::GitHub Package Registry publish failed, but NPM publish succeeded"
+            echo "::warning::Manual GPR publish may be required"
+          fi
+
+          echo "✅ Package published to NPM: https://www.npmjs.com/package/@airtasker/spot"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,6 +17,8 @@ jobs:
   test:
     name: test-node-${{ matrix.node-version }}
     runs-on: runs-on,runner=4cpu-linux-x64
+    permissions:
+      contents: read
     strategy:
       fail-fast: true # if one job fails, stop the rest
       matrix:
@@ -52,6 +54,8 @@ jobs:
   test-summary-publish:
     runs-on: runs-on,runner=4cpu-linux-x64
     needs: [test]
+    permissions:
+      contents: read
     steps:
       - name: Test summary
         uses: test-summary/action@v2
@@ -60,6 +64,8 @@ jobs:
 
   lint-check:
     runs-on: runs-on,runner=4cpu-linux-x64
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/prepare-repository
@@ -81,15 +87,44 @@ jobs:
       - uses: ./.github/actions/prepare-repository
 
       - name: Authenticate with NPM registry
-        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+        run: |
+          cat > ~/.npmrc << 'EOF'
+          //registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}
+          EOF
 
       - name: Publish to NPM
-        run: pnpm publish --access=public --no-git-checks
+        id: npm-publish
+        run: pnpm publish --access=public
+
+      - name: Verify NPM publish
+        run: |
+          echo "Waiting for NPM registry propagation..."
+          sleep 10
+          npm view @airtasker/spot@${{ github.event.release.tag_name }} version
 
       - name: Authenticate with GitHub Package Registry
         run: |
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
-          echo "@airtasker:registry=https://npm.pkg.github.com" >> ~/.npmrc
+          cat > ~/.npmrc << 'EOF'
+          //npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
+          @airtasker:registry=https://npm.pkg.github.com
+          EOF
 
       - name: Publish to GitHub Package Registry
-        run: pnpm publish --registry=https://npm.pkg.github.com --access=public --no-git-checks
+        id: gpr-publish
+        run: pnpm publish --registry=https://npm.pkg.github.com --access=public
+        continue-on-error: true
+
+      - name: Verify GPR publish
+        if: steps.gpr-publish.outcome == 'success'
+        run: |
+          echo "Waiting for GitHub Package Registry propagation..."
+          sleep 10
+          npm view @airtasker/spot@${{ github.event.release.tag_name }} version \
+            --registry=https://npm.pkg.github.com
+
+      - name: Report GPR failure
+        if: steps.gpr-publish.outcome == 'failure'
+        run: |
+          echo "::warning::GitHub Package Registry publish failed, but NPM publish succeeded"
+          echo "::warning::Manual GPR publish may be required"
+          echo "::warning::Package is available on NPM: https://www.npmjs.com/package/@airtasker/spot"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -73,6 +73,9 @@ jobs:
     needs:
       - test
       - lint-check
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/prepare-repository
@@ -80,5 +83,13 @@ jobs:
       - name: Authenticate with NPM registry
         run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
 
-      - name: Publish
-        run: npm publish --access=public
+      - name: Publish to NPM
+        run: pnpm publish --access=public --no-git-checks
+
+      - name: Authenticate with GitHub Package Registry
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
+          echo "@airtasker:registry=https://npm.pkg.github.com" >> ~/.npmrc
+
+      - name: Publish to GitHub Package Registry
+        run: pnpm publish --registry=https://npm.pkg.github.com --access=public --no-git-checks


### PR DESCRIPTION
## Description, Motivation and Context

**Why is this change required?** 
Some repos expect @airtasker/spot to be available in the Github Registry, however this was never an issue as their lock files have conitnued to resolve using npmjs. With a clean install or migration to another package manager, they now throw a 404 when trying to find spot in Github.

The current workflow only publishes to npm registry. To make the package available on GitHub Package Registry as well, we need to add publishing steps for both registries.

**What does it do?**
  - Adds a separate publish step for GitHub Package Registry
  - Configures authentication for both npm and GitHub Package Registry
  - Adds required `packages: write` permission to the publish job
  - Uses `pnpm publish` with `--no-git-checks` flag for both registries
  - Maintains backward compatibility with existing npm publishing

## Changes Made

1. **Added permissions**: Added `packages: write` permission to the publish job to allow publishing to GitHub Package Registry
2. **NPM Publishing**: Updated to use `pnpm publish` instead of `npm publish` for consistency
3. **GitHub Registry Publishing**: Added authentication and publish steps for GitHub Package Registry using `GITHUB_TOKEN`
4. **Registry Configuration**: Properly configures the `.npmrc` file for each registry before publishing

## Checklist:

- [ ] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR