### PR TITLE
[ACQ-6267] Fix pnpm publish failing on release tags

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -93,12 +93,12 @@ jobs:
 
       - name: Publish to NPM
         id: npm-publish
-        run: pnpm publish --access=public
+        run: pnpm publish --access=public --no-git-checks
 
       - name: Publish to GitHub Package Registry
         id: gpr-publish
         if: steps.npm-publish.outcome == 'success'
-        run: pnpm publish --registry=https://npm.pkg.github.com --access=public
+        run: pnpm publish --registry=https://npm.pkg.github.com --access=public --no-git-checks
         continue-on-error: true
 
       - name: Report publish status


### PR DESCRIPTION
## Summary

- Add `--no-git-checks` flag to both `pnpm publish` steps (NPM and GitHub Package Registry) in the release workflow

## Context

`pnpm publish` runs git safety checks by default — it verifies the working tree is clean and the current branch matches the publish branch. When GitHub Actions triggers on a `release` event, `actions/checkout` checks out the **tag ref in detached HEAD state**, not a branch. This causes pnpm's git checks to fail with an error like:

```
ERR_PNPM_GIT_NOT_CORRECT_BRANCH  Your current branch "HEAD" is not the publish branch "master".
```

Adding `--no-git-checks` is the [documented fix](https://pnpm.io/cli/publish#--no-git-checks) for CI environments where detached HEAD is expected.

## Safety

This does not reduce publish safety because:
- The publish job only runs on `release` events (line 75)
- It requires both `test` and `lint-check` jobs to pass first
- The release event itself acts as the human gate for publishing

## Test plan

- [ ] Create a GitHub release and verify the publish workflow completes without git check errors
- [ ] Verify the package is published to both NPM and GitHub Package Registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)