### PR TITLE
[ACQ-6298] Fix pnpm-workspace.yaml configuration structure

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,12 +1,7 @@
 packages:
   - 'docs'
 
-settings:
-  # Automatically install peer dependencies
-  autoInstallPeers: true
-
-  # Don't fail on unmet peer dependencies (migration compatibility)
-  strictPeerDependencies: false
-
-  # Security: 7-day delay before using newly published packages (10,080 minutes)
-  minimumReleaseAge: 10080
+# Security: 7-day delay before using newly published packages (10,080 minutes)
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - '@airtasker/*'


### PR DESCRIPTION
## Summary
- Fixed invalid `settings:` nesting in pnpm-workspace.yaml
- Removed unnecessary configuration options (`autoInstallPeers`, `strictPeerDependencies`)
- Moved `minimumReleaseAge` to root level as per pnpm specification
- Added `minimumReleaseAgeExclude` for `@airtasker/*` packages

## Related Tickets
- ACQ-6298

## Technical Details
The pnpm-workspace.yaml file had an invalid `settings:` wrapper that is not supported by pnpm's workspace configuration. Configuration options like `minimumReleaseAge` should be at the root level of the file, not nested under `settings:`.

Removed options:
- `autoInstallPeers: true` - default behavior, not needed
- `strictPeerDependencies: false` - default behavior, not needed